### PR TITLE
ci: add SBOM generation and artifact attestations to releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repo
@@ -61,10 +63,29 @@ jobs:
         run: |
           tar czvf "zaparoo_app-web-${VERSION}.tar.gz" -C ./dist .
           tar czvf "zaparoo_app-web-core-${VERSION}.tar.gz" -C ./dist-core .
+      - name: Generate SBOM
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: 'zaparoo_app-web-*.tar.gz'
+      - name: Attest SBOM
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: 'zaparoo_app-web-*.tar.gz'
+          sbom-path: sbom.spdx.json
       - name: Create release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: zaparoo_app-web-*.tar.gz
+          files: |
+            zaparoo_app-web-*.tar.gz
+            sbom.spdx.json
           fail_on_unmatched_files: true
           make_latest: false


### PR DESCRIPTION
## Summary

- Add Sigstore-signed build provenance attestations to release artifacts
- Generate SPDX SBOM and attach as both an attestation and a release asset
- Release artifacts verifiable with `gh attestation verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release artifacts now include Software Bill of Materials (SBOM) and build attestations, providing enhanced supply chain transparency and verification for downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->