### PR TITLE
fix: null-safe localeCompare sort comparator (Rollbar #95/#96)

### DIFF
--- a/src/__tests__/unit/components/SystemSelector.test.tsx
+++ b/src/__tests__/unit/components/SystemSelector.test.tsx
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, waitFor, act } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
+import { useQuery } from "@tanstack/react-query";
 import { useStatusStore } from "@/lib/store";
 import {
   SystemSelector,
@@ -209,6 +210,35 @@ describe("SystemSelector", () => {
       expect(
         screen.queryByRole("radio", { name: "Sega Genesis" }),
       ).not.toBeInTheDocument();
+    });
+
+    it("should sort multiple non-priority categories alphabetically after priority ones", () => {
+      // Arrange - override query to include two extra non-priority categories
+      vi.mocked(useQuery).mockReturnValueOnce({
+        data: {
+          systems: [
+            ...mockSystems,
+            { id: "dos", name: "DOS Games", category: "PC" },
+            { id: "arcade", name: "Street Fighter II", category: "Arcade" },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      } as ReturnType<typeof useQuery>);
+
+      // Act
+      render(<SystemSelector {...defaultProps} />);
+
+      // Assert - "Arcade" and "PC" (non-priority) should appear in alphabetical order
+      const tabs = screen.getAllByRole("tab");
+      const tabNames = tabs.map((tab) => tab.textContent ?? "");
+      const arcadeIndex = tabNames.findIndex((n) => n.includes("Arcade"));
+      const pcIndex = tabNames.findIndex((n) => n.includes("PC"));
+
+      expect(arcadeIndex).toBeGreaterThan(0);
+      expect(pcIndex).toBeGreaterThan(0);
+      expect(arcadeIndex).toBeLessThan(pcIndex); // "Arcade" < "PC" alphabetically
     });
 
     it("should prioritize Nintendo, Sony, Sega, Atari categories", () => {

--- a/src/__tests__/unit/components/SystemSelector.test.tsx
+++ b/src/__tests__/unit/components/SystemSelector.test.tsx
@@ -225,7 +225,7 @@ describe("SystemSelector", () => {
         isLoading: false,
         isError: false,
         refetch: vi.fn(),
-      } as ReturnType<typeof useQuery>);
+      } as unknown as ReturnType<typeof useQuery>);
 
       // Act
       render(<SystemSelector {...defaultProps} />);

--- a/src/__tests__/unit/components/TagSelector.test.tsx
+++ b/src/__tests__/unit/components/TagSelector.test.tsx
@@ -172,6 +172,39 @@ describe("TagSelector", () => {
       });
     });
 
+    it("should sort multiple non-priority types alphabetically after priority ones", async () => {
+      // Arrange - two non-priority types ("zone" > "arcade" alphabetically)
+      vi.mocked(CoreAPI.mediaTags).mockResolvedValue({
+        tags: [
+          { tag: "Action", type: "genre" },
+          { tag: "1990", type: "year" },
+          { tag: "Zebra Tag", type: "zone" },
+          { tag: "Alpha Tag", type: "arcade" },
+        ],
+      });
+
+      // Act
+      render(<TagSelector {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /tagSelector\.type\.genre/i }),
+        ).toBeInTheDocument();
+      });
+
+      // Assert - "arcade" should appear before "zone" (alphabetical among non-priority types)
+      const triggers = screen.getAllByRole("button", {
+        name: /tagSelector\.type\./i,
+      });
+      const typeNames = triggers.map((t) => t.textContent ?? "");
+      const arcadeIndex = typeNames.findIndex((n) => n.includes("arcade"));
+      const zoneIndex = typeNames.findIndex((n) => n.includes("zone"));
+
+      expect(arcadeIndex).toBeGreaterThan(-1);
+      expect(zoneIndex).toBeGreaterThan(-1);
+      expect(arcadeIndex).toBeLessThan(zoneIndex); // "arcade" < "zone" alphabetically
+    });
+
     it("should sort types with priority (genre, year, series, publisher first)", async () => {
       // Arrange
       vi.mocked(CoreAPI.mediaTags).mockResolvedValue({

--- a/src/__tests__/unit/lib/utils.test.ts
+++ b/src/__tests__/unit/lib/utils.test.ts
@@ -1,10 +1,58 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  compareStrings,
   parseDuration,
   formatDuration,
   formatDurationDisplay,
   formatDurationAccessible,
 } from "@/lib/utils";
+
+describe("compareStrings", () => {
+  it("should sort defined strings correctly", () => {
+    expect(compareStrings("a", "b")).toBeLessThan(0);
+    expect(compareStrings("b", "a")).toBeGreaterThan(0);
+    expect(compareStrings("a", "a")).toBe(0);
+  });
+
+  it("should treat undefined first argument as empty string", () => {
+    expect(compareStrings(undefined, "a")).toBeLessThan(0);
+  });
+
+  it("should treat undefined second argument as empty string", () => {
+    expect(compareStrings("a", undefined)).toBeGreaterThan(0);
+  });
+
+  it("should treat null as empty string", () => {
+    expect(compareStrings(null, "a")).toBeLessThan(0);
+    expect(compareStrings("a", null)).toBeGreaterThan(0);
+  });
+
+  it("should return 0 when both are undefined", () => {
+    expect(compareStrings(undefined, undefined)).toBe(0);
+  });
+
+  it("should return 0 when both are null", () => {
+    expect(compareStrings(null, null)).toBe(0);
+  });
+
+  it("should return 0 for mixed null and undefined", () => {
+    expect(compareStrings(null, undefined)).toBe(0);
+    expect(compareStrings(undefined, null)).toBe(0);
+  });
+
+  it("should return 0 for empty string vs undefined", () => {
+    expect(compareStrings("", undefined)).toBe(0);
+    expect(compareStrings(undefined, "")).toBe(0);
+  });
+
+  it("should not throw for any combination of null, undefined, string", () => {
+    expect(() => compareStrings(undefined, undefined)).not.toThrow();
+    expect(() => compareStrings(null, null)).not.toThrow();
+    expect(() => compareStrings(undefined, null)).not.toThrow();
+    expect(() => compareStrings(undefined, "x")).not.toThrow();
+    expect(() => compareStrings("x", undefined)).not.toThrow();
+  });
+});
 
 describe("parseDuration", () => {
   it("returns zero for empty or zero input", () => {

--- a/src/components/SimpleSystemSelect.tsx
+++ b/src/components/SimpleSystemSelect.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { CoreAPI } from "@/lib/coreApi";
+import { compareStrings } from "@/lib/utils";
 import { useStatusStore } from "@/lib/store";
 
 interface SimpleSystemSelectProps {
@@ -48,10 +49,10 @@ export function SimpleSystemSelect({
 
   // Sort categories alphabetically and systems within each category
   const sortedCategories = Object.entries(groupedSystems)
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => compareStrings(a, b))
     .map(([category, systems]) => ({
       category,
-      systems: systems.sort((a, b) => a.name.localeCompare(b.name)),
+      systems: systems.sort((a, b) => compareStrings(a.name, b.name)),
     }));
 
   const handleChange = (e: { target: { value: string } }) => {

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -6,6 +6,7 @@ import { Search, Check, X } from "lucide-react";
 import { useDebounce } from "use-debounce";
 import classNames from "classnames";
 import { CoreAPI } from "@/lib/coreApi";
+import { compareStrings } from "@/lib/utils";
 import { useStatusStore } from "@/lib/store";
 import { useSmartTabs } from "@/hooks/useSmartTabs";
 import { useAnnouncer } from "./A11yAnnouncer";
@@ -114,7 +115,7 @@ export function SystemSelector({
       }
       if (aPriority !== -1) return -1;
       if (bPriority !== -1) return 1;
-      return a.localeCompare(b);
+      return compareStrings(a, b);
     });
 
     // Filter systems based on search and category
@@ -137,7 +138,7 @@ export function SystemSelector({
     }
 
     // Sort filtered systems by name
-    filtered.sort((a, b) => a.name.localeCompare(b.name));
+    filtered.sort((a, b) => compareStrings(a.name, b.name));
 
     return { filteredSystems: filtered, categories };
   }, [systemsData, debouncedSearchQuery, selectedCategory]);

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -6,6 +6,7 @@ import { Search, Check, X, ChevronUp, ChevronDown } from "lucide-react";
 import { useDebounce } from "use-debounce";
 import classNames from "classnames";
 import { CoreAPI } from "@/lib/coreApi";
+import { compareStrings } from "@/lib/utils";
 import { useStatusStore } from "@/lib/store";
 import { TagInfo } from "@/lib/models";
 import { useAnnouncer } from "./A11yAnnouncer";
@@ -99,12 +100,12 @@ export function TagSelector({
       }
       if (aPriority !== -1) return -1;
       if (bPriority !== -1) return 1;
-      return a.localeCompare(b);
+      return compareStrings(a, b);
     });
 
     // Sort tags within each group
     Object.keys(grouped).forEach((type) => {
-      grouped[type]!.sort((a, b) => a.tag.localeCompare(b.tag));
+      grouped[type]!.sort((a, b) => compareStrings(a.tag, b.tag));
     });
 
     // Apply search filter if needed

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -104,6 +104,14 @@ export function formatDurationDisplay(
   return parts.length > 0 ? parts.join(" ") : "0m";
 }
 
+/** Null-safe string comparator for Array.sort — treats undefined/null as "" */
+export function compareStrings(
+  a: string | undefined | null,
+  b: string | undefined | null,
+): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
 /** Translation function type for formatDurationAccessible */
 type TranslateFn = (key: string, options?: { count: number }) => string;
 


### PR DESCRIPTION
- Adds `compareStrings(a, b)` to `src/lib/utils.ts` — coerces `undefined`/`null` to `""` before calling `localeCompare`, preventing `TypeError` when Core API returns items with missing `name`, `tag`, or `type` fields.
- Applies the helper at all six unsafe `.sort(... localeCompare ...)` sites in `SystemSelector`, `TagSelector`, and `SimpleSystemSelect`.
- Adds 9 unit tests covering every null/undefined combination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified string comparison across system, category, and tag selectors to provide consistent, null-safe alphabetical ordering.

* **Tests**
  * Added unit tests verifying ordering behavior, including handling of null/undefined inputs and correct alphabetical ordering among priority and non-priority groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->