### PR TITLE
fix: eliminate RevenueCat auth-state race conditions (Rollbar error 11/22)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { usePassiveNfcListener } from "./hooks/usePassiveNfcListener";
 import { useLiveUpdate } from "./hooks/useLiveUpdate";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
+import { purchasesReady } from "./lib/purchasesSetup";
 import {
   A11yAnnouncerProvider,
   useAnnouncer,
@@ -249,6 +250,7 @@ export default function App() {
 
       // Sync RevenueCat identity with Firebase user (skip on web)
       if (Capacitor.getPlatform() !== "web") {
+        await purchasesReady;
         try {
           if (change.user) {
             // Link RevenueCat to Firebase user - transfers anonymous purchases
@@ -284,8 +286,11 @@ export default function App() {
               });
             }
           } else {
-            // Revert to anonymous RevenueCat customer
-            await Purchases.logOut();
+            // Revert to anonymous RevenueCat customer — only if not already anonymous
+            const { isAnonymous } = await Purchases.isAnonymous();
+            if (!isAnonymous) {
+              await Purchases.logOut();
+            }
             const { customerInfo } = await Purchases.getCustomerInfo();
             const hasAccess =
               !!customerInfo.entitlements.active?.tapto_launcher;

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -80,7 +80,13 @@ vi.mock("@revenuecat/purchases-capacitor", () => ({
     logIn: (...args: unknown[]) => mockPurchasesLogIn(...args),
     logOut: () => mockPurchasesLogOut(),
     getCustomerInfo: () => mockPurchasesGetCustomerInfo(),
+    isAnonymous: vi.fn().mockResolvedValue({ isAnonymous: false }),
   },
+}));
+
+// purchasesReady resolves immediately in tests
+vi.mock("@/lib/purchasesSetup", () => ({
+  purchasesReady: Promise.resolve(),
 }));
 
 vi.mock("@/lib/onlineApi", () => ({
@@ -598,6 +604,45 @@ describe("Firebase Auth Integration", () => {
       });
 
       expect(mockPurchasesLogOut).toHaveBeenCalled();
+      expect(mockPurchasesGetCustomerInfo).toHaveBeenCalled();
+    });
+
+    it("should not call Purchases.logOut when RC user is already anonymous on sign out", async () => {
+      mockPlatform = "ios";
+
+      const { Purchases } = await import("@revenuecat/purchases-capacitor");
+      vi.mocked(Purchases.isAnonymous).mockResolvedValueOnce({
+        isAnonymous: true,
+      });
+
+      mockPurchasesGetCustomerInfo.mockResolvedValue({
+        customerInfo: { entitlements: { active: {} } },
+      });
+
+      let authCallback: ((change: { user: unknown }) => Promise<void>) | null =
+        null;
+      mockAddListener.mockImplementation(
+        (
+          _event: string,
+          callback: (change: { user: unknown }) => Promise<void>,
+        ) => {
+          authCallback = callback;
+          return Promise.resolve({ remove: mockRemove });
+        },
+      );
+
+      const App = (await import("@/App")).default;
+      render(<App />);
+
+      await waitFor(() => {
+        expect(authCallback).not.toBeNull();
+      });
+
+      await act(async () => {
+        await authCallback!({ user: null });
+      });
+
+      expect(mockPurchasesLogOut).not.toHaveBeenCalled();
       expect(mockPurchasesGetCustomerInfo).toHaveBeenCalled();
     });
 

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -197,6 +197,7 @@ vi.mock("@/hooks/useWriteQueueProcessor", () => ({
 }));
 vi.mock("@/hooks/useShakeDetection", () => ({ useShakeDetection: vi.fn() }));
 vi.mock("@/lib/logger", () => ({ initDeviceInfo: vi.fn() }));
+vi.mock("@/lib/purchasesSetup", () => ({ purchasesReady: Promise.resolve() }));
 
 describe("App Integration", () => {
   beforeEach(() => {

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@capacitor-firebase/authentication", () => ({
 vi.mock("@revenuecat/purchases-capacitor", () => ({
   Purchases: {
     logOut: vi.fn().mockResolvedValue(undefined),
+    isAnonymous: vi.fn().mockResolvedValue({ isAnonymous: false }),
   },
 }));
 
@@ -284,6 +285,40 @@ describe("RequirementsModal", () => {
     await waitFor(() => {
       expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
     });
+  });
+
+  it("should not call Purchases.logOut when RC user is already anonymous", async () => {
+    const { Purchases } = await import("@revenuecat/purchases-capacitor");
+    vi.mocked(Purchases.isAnonymous).mockResolvedValueOnce({
+      isAnonymous: true,
+    });
+
+    const requirements: PendingRequirement[] = [
+      {
+        type: "terms_acceptance",
+        description: "Accept terms",
+        endpoint: "/account/requirements",
+      },
+    ];
+
+    useRequirementsStore.setState({
+      isOpen: true,
+      pendingRequirements: requirements,
+    });
+
+    render(<RequirementsModal />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /requirements\.logout/i }),
+    );
+
+    const { FirebaseAuthentication } =
+      await import("@capacitor-firebase/authentication");
+    await waitFor(() => {
+      expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
+    });
+
+    expect(Purchases.logOut).not.toHaveBeenCalled();
   });
 
   it("should send verification email when button clicked", async () => {

--- a/src/__tests__/unit/hooks/useProAccessCheck.test.ts
+++ b/src/__tests__/unit/hooks/useProAccessCheck.test.ts
@@ -35,6 +35,11 @@ vi.mock("@revenuecat/purchases-capacitor", () => ({
   },
 }));
 
+// purchasesReady resolves immediately in tests
+vi.mock("@/lib/purchasesSetup", () => ({
+  purchasesReady: Promise.resolve(),
+}));
+
 // Mock logger
 vi.mock("../../../lib/logger", () => ({
   logger: mockLogger,
@@ -258,6 +263,62 @@ describe("useProAccessCheck", () => {
       });
 
       expect(mockSetProAccessHydrated).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("purchasesReady gating", () => {
+    afterEach(() => {
+      vi.resetModules();
+    });
+
+    it("should not call getCustomerInfo before purchasesReady resolves", async () => {
+      vi.resetModules();
+
+      let resolveReady!: () => void;
+      const deferredReady = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+      });
+
+      const mockGetCustomerInfoDeferred = vi.fn().mockResolvedValue({
+        customerInfo: { entitlements: { active: {} } },
+      });
+      const mockSetLauncherAccessDeferred = vi.fn();
+      const mockSetProAccessHydratedDeferred = vi.fn();
+
+      vi.doMock("@/lib/purchasesSetup", () => ({
+        purchasesReady: deferredReady,
+      }));
+      vi.doMock("@capacitor/core", () => ({
+        Capacitor: { getPlatform: vi.fn().mockReturnValue("ios") },
+      }));
+      vi.doMock("@revenuecat/purchases-capacitor", () => ({
+        Purchases: { getCustomerInfo: mockGetCustomerInfoDeferred },
+      }));
+      vi.doMock("@/lib/preferencesStore", () => ({
+        usePreferencesStore: vi.fn((selector: (s: unknown) => unknown) =>
+          selector({
+            setLauncherAccess: mockSetLauncherAccessDeferred,
+            setProAccessHydrated: mockSetProAccessHydratedDeferred,
+          }),
+        ),
+      }));
+      vi.doMock("@/lib/logger", () => ({
+        logger: { log: vi.fn(), error: vi.fn() },
+      }));
+
+      const { useProAccessCheck: hookFresh } =
+        await import("@/hooks/useProAccessCheck");
+      const { renderHook, waitFor } = await import("@testing-library/react");
+
+      renderHook(() => hookFresh());
+
+      expect(mockGetCustomerInfoDeferred).not.toHaveBeenCalled();
+
+      resolveReady();
+
+      await waitFor(() => {
+        expect(mockGetCustomerInfoDeferred).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@capacitor-firebase/authentication", () => ({
 vi.mock("@revenuecat/purchases-capacitor", () => ({
   Purchases: {
     logOut: () => mockPurchasesLogOut(),
+    isAnonymous: vi.fn().mockResolvedValue({ isAnonymous: false }),
   },
 }));
 
@@ -358,6 +359,30 @@ describe("Settings Online Route", () => {
         expect(mockPurchasesLogOut).toHaveBeenCalled();
         expect(mockFirebaseAuth.signOut).toHaveBeenCalled();
       });
+
+      expect(mockPurchasesLogOut.mock.invocationCallOrder[0]!).toBeLessThan(
+        mockFirebaseAuth.signOut.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it("should not call Purchases.logOut when RC user is already anonymous on native platform", async () => {
+      const user = userEvent.setup();
+      mockState.platform = "ios";
+
+      const { Purchases } = await import("@revenuecat/purchases-capacitor");
+      vi.mocked(Purchases.isAnonymous).mockResolvedValueOnce({
+        isAnonymous: true,
+      });
+
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "online.logout" }));
+
+      await waitFor(() => {
+        expect(mockFirebaseAuth.signOut).toHaveBeenCalled();
+      });
+
+      expect(mockPurchasesLogOut).not.toHaveBeenCalled();
     });
 
     it("should skip RevenueCat logout on web platform", async () => {

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -112,7 +112,10 @@ export function RequirementsModal() {
     // Revert RevenueCat to anonymous before Firebase signOut (skip on web)
     if (Capacitor.getPlatform() !== "web") {
       try {
-        await Purchases.logOut();
+        const { isAnonymous } = await Purchases.isAnonymous();
+        if (!isAnonymous) {
+          await Purchases.logOut();
+        }
       } catch (e) {
         logger.error("RevenueCat logout failed:", e, {
           category: "purchase",

--- a/src/hooks/useProAccessCheck.ts
+++ b/src/hooks/useProAccessCheck.ts
@@ -3,6 +3,7 @@ import { Capacitor } from "@capacitor/core";
 import { Purchases } from "@revenuecat/purchases-capacitor";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { logger } from "@/lib/logger";
+import { purchasesReady } from "@/lib/purchasesSetup";
 
 /**
  * Hook to check Pro access status from RevenueCat on app startup.
@@ -25,8 +26,9 @@ export function useProAccessCheck() {
       return;
     }
 
-    // Check customer info from RevenueCat
-    Purchases.getCustomerInfo()
+    // Wait for Purchases.configure() to complete before querying customer info
+    purchasesReady
+      .then(() => Purchases.getCustomerInfo())
       .then((info) => {
         // Use optional chaining for safe access to nested entitlements
         const hasProAccess =

--- a/src/lib/purchasesSetup.ts
+++ b/src/lib/purchasesSetup.ts
@@ -1,0 +1,10 @@
+// Promise executor runs synchronously, so _resolve is always assigned before use
+let _resolve!: () => void;
+
+export const purchasesReady: Promise<void> = new Promise<void>((resolve) => {
+  _resolve = resolve;
+});
+
+export function resolvePurchasesReady(): void {
+  _resolve();
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import App from "./App";
 import { ThemeProvider } from "./components/theme-provider";
 import { ErrorComponent } from "./components/ErrorComponent";
 import { logger } from "./lib/logger";
+import { resolvePurchasesReady } from "./lib/purchasesSetup";
 
 // Firebase config is optional - auth features will be disabled without it
 const firebaseConfigs = import.meta.glob<Record<string, string>>(
@@ -51,14 +52,32 @@ const onDeviceReady = async () => {
     });
   }
 
-  if (Capacitor.getPlatform() === "ios") {
-    await Purchases.configure({ apiKey: import.meta.env.VITE_APPLE_STORE_API });
-  } else if (Capacitor.getPlatform() === "android") {
-    await Purchases.configure({
-      apiKey: import.meta.env.VITE_GOOGLE_STORE_API,
+  try {
+    if (Capacitor.getPlatform() === "ios") {
+      await Purchases.configure({
+        apiKey: import.meta.env.VITE_APPLE_STORE_API,
+      });
+    } else if (Capacitor.getPlatform() === "android") {
+      await Purchases.configure({
+        apiKey: import.meta.env.VITE_GOOGLE_STORE_API,
+      });
+    }
+  } catch (e) {
+    logger.error("Purchases configure failed:", e, {
+      category: "purchase",
+      action: "configure",
+      severity: "error",
     });
+  } finally {
+    resolvePurchasesReady();
   }
 };
+
+// Web platform skips RC entirely — resolve immediately so awaits don't hang
+if (!Capacitor.isNativePlatform()) {
+  resolvePurchasesReady();
+}
+
 document.addEventListener("deviceready", onDeviceReady, false);
 
 // App content wrapped in theme and query providers

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -346,7 +346,10 @@ function OnlinePage() {
     // Revert RevenueCat to anonymous before Firebase signOut (skip on web)
     if (Capacitor.getPlatform() !== "web") {
       try {
-        await Purchases.logOut();
+        const { isAnonymous } = await Purchases.isAnonymous();
+        if (!isAnonymous) {
+          await Purchases.logOut();
+        }
       } catch (e) {
         logger.error("RevenueCat logout failed:", e, {
           category: "purchase",

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -125,16 +125,6 @@ export const mockCapacitorCore = (platform = "ios") => ({
   },
 });
 
-// RevenueCat Purchases mock
-export const mockRevenueCatPurchases = () => ({
-  Purchases: {
-    restorePurchases: vi.fn(),
-    getCustomerInfo: vi.fn(),
-    getOfferings: vi.fn(),
-    purchasePackage: vi.fn(),
-  },
-});
-
 // React Hot Toast mock
 export const mockReactHotToast = () => ({
   default: {


### PR DESCRIPTION
- Adds `src/lib/purchasesSetup.ts` exposing a `purchasesReady` promise that resolves after `Purchases.configure()` completes (or immediately on web), so RC identity calls can never race against SDK initialisation (Race B — INVALID_CREDENTIALS_ERROR code 11, ~409 Rollbar warnings/day).
- Gates `Purchases.logIn()` and `getCustomerInfo()` behind `await purchasesReady` in the `authStateChange` listener and `useProAccessCheck`, serialising them behind `deviceready`.
- Checks `Purchases.isAnonymous()` before calling `Purchases.logOut()` at all three call sites (`App.tsx`, `RequirementsModal`, `settings.online`) to skip the call when RC is already in anonymous state (Race A — LOG_OUT_ANONYMOUS_USER_ERROR code 22, ~44 Rollbar warnings/day).
- Adds tests covering the `isAnonymous: true` skip-path, a deferred `purchasesReady` gating test, and a defensive mock in `App.integration.test.tsx`.
- Removes unused `mockRevenueCatPurchases` factory from `test-utils/mocks.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of account synchronization with payment service by ensuring proper initialization order
  * Enhanced logout behavior to properly handle anonymous accounts
  * Added error handling and logging for payment configuration failures

* **Chores**
  * Expanded test coverage for authentication initialization patterns
  * Removed deprecated test utility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->