### PR TITLE
fix: gate onlineApi requests on auth state (Rollbar #91)

### DIFF
--- a/src/__tests__/unit/lib/onlineApi.test.ts
+++ b/src/__tests__/unit/lib/onlineApi.test.ts
@@ -11,13 +11,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useStatusStore } from "../../../lib/store";
 
 // Mock axios before importing the module
 const mockGet = vi.fn();
 const mockPost = vi.fn();
 const mockDelete = vi.fn();
 
-// Capture interceptor callbacks for testing
+// Capture response interceptor callbacks for testing
 let responseInterceptorSuccess: ((response: unknown) => unknown) | null = null;
 let responseInterceptorError: ((error: unknown) => Promise<never>) | null =
   null;
@@ -54,7 +55,18 @@ vi.mock("axios", () => ({
 // Mock Firebase Authentication
 vi.mock("@capacitor-firebase/authentication", () => ({
   FirebaseAuthentication: {
+    getCurrentUser: vi.fn().mockResolvedValue({ user: { uid: "test-uid" } }),
     getIdToken: vi.fn().mockResolvedValue({ token: "mock-token" }),
+  },
+}));
+
+// Mock store
+vi.mock("../../../lib/store", () => ({
+  useStatusStore: {
+    getState: vi.fn().mockReturnValue({
+      loggedInUser: { uid: "test-uid" },
+      setLoggedInUser: vi.fn(),
+    }),
   },
 }));
 
@@ -457,6 +469,77 @@ describe("onlineApi", () => {
       );
 
       expect(mockTrigger).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authRequestInterceptor", () => {
+    let authRequestInterceptor: (typeof import("../../../lib/onlineApi"))["authRequestInterceptor"];
+    let NotSignedInError: (typeof import("../../../lib/onlineApi"))["NotSignedInError"];
+    let FirebaseAuthentication: (typeof import("@capacitor-firebase/authentication"))["FirebaseAuthentication"];
+
+    beforeEach(async () => {
+      ({ authRequestInterceptor, NotSignedInError } =
+        await import("../../../lib/onlineApi"));
+      ({ FirebaseAuthentication } =
+        await import("@capacitor-firebase/authentication"));
+      vi.mocked(useStatusStore.getState).mockReturnValue({
+        loggedInUser: { uid: "test-uid" },
+        setLoggedInUser: vi.fn(),
+      } as any);
+    });
+
+    it("should set Authorization header when user is signed in", async () => {
+      vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
+        user: { uid: "test-uid" } as any,
+      });
+      vi.mocked(FirebaseAuthentication.getIdToken).mockResolvedValueOnce({
+        token: "test-token",
+      });
+
+      const config = { headers: {} } as any;
+      await authRequestInterceptor(config);
+
+      expect(config.headers["Authorization"]).toBe("Bearer test-token");
+    });
+
+    it("should throw NotSignedInError when no user is signed in", async () => {
+      vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
+        user: null,
+      });
+
+      await expect(
+        authRequestInterceptor({ headers: {} } as any),
+      ).rejects.toBeInstanceOf(NotSignedInError);
+    });
+
+    it("should sync store to null when no user is signed in", async () => {
+      vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
+        user: null,
+      });
+
+      const mockSetLoggedInUser = vi.fn();
+      vi.mocked(useStatusStore.getState).mockReturnValueOnce({
+        loggedInUser: { uid: "test-uid" },
+        setLoggedInUser: mockSetLoggedInUser,
+      } as any);
+
+      await expect(
+        authRequestInterceptor({ headers: {} } as any),
+      ).rejects.toThrow();
+
+      expect(mockSetLoggedInUser).toHaveBeenCalledWith(null);
+    });
+
+    it("should not call getIdToken when no user is signed in", async () => {
+      vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
+        user: null,
+      });
+
+      await expect(
+        authRequestInterceptor({ headers: {} } as any),
+      ).rejects.toThrow();
+
+      expect(FirebaseAuthentication.getIdToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/unit/lib/onlineApi.test.ts
+++ b/src/__tests__/unit/lib/onlineApi.test.ts
@@ -11,7 +11,18 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { type InternalAxiosRequestConfig } from "axios";
+import {
+  type GetCurrentUserResult,
+  type GetIdTokenResult,
+  type User,
+} from "@capacitor-firebase/authentication";
 import { useStatusStore } from "../../../lib/store";
+
+type PartialStoreState = Pick<
+  ReturnType<typeof useStatusStore.getState>,
+  "loggedInUser" | "setLoggedInUser"
+>;
 
 // Mock axios before importing the module
 const mockGet = vi.fn();
@@ -483,20 +494,22 @@ describe("onlineApi", () => {
       ({ FirebaseAuthentication } =
         await import("@capacitor-firebase/authentication"));
       vi.mocked(useStatusStore.getState).mockReturnValue({
-        loggedInUser: { uid: "test-uid" },
+        loggedInUser: { uid: "test-uid" } as User,
         setLoggedInUser: vi.fn(),
-      } as any);
+      } satisfies PartialStoreState as unknown as ReturnType<
+        typeof useStatusStore.getState
+      >);
     });
 
     it("should set Authorization header when user is signed in", async () => {
       vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
-        user: { uid: "test-uid" } as any,
-      });
+        user: { uid: "test-uid" } as User,
+      } satisfies GetCurrentUserResult);
       vi.mocked(FirebaseAuthentication.getIdToken).mockResolvedValueOnce({
         token: "test-token",
-      });
+      } satisfies GetIdTokenResult);
 
-      const config = { headers: {} } as any;
+      const config = { headers: {} } as InternalAxiosRequestConfig;
       await authRequestInterceptor(config);
 
       expect(config.headers["Authorization"]).toBe("Bearer test-token");
@@ -505,38 +518,60 @@ describe("onlineApi", () => {
     it("should throw NotSignedInError when no user is signed in", async () => {
       vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
         user: null,
-      });
+      } satisfies GetCurrentUserResult);
 
       await expect(
-        authRequestInterceptor({ headers: {} } as any),
+        authRequestInterceptor({} as InternalAxiosRequestConfig),
       ).rejects.toBeInstanceOf(NotSignedInError);
     });
 
     it("should sync store to null when no user is signed in", async () => {
       vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
         user: null,
-      });
+      } satisfies GetCurrentUserResult);
 
       const mockSetLoggedInUser = vi.fn();
       vi.mocked(useStatusStore.getState).mockReturnValueOnce({
-        loggedInUser: { uid: "test-uid" },
+        loggedInUser: { uid: "test-uid" } as User,
         setLoggedInUser: mockSetLoggedInUser,
-      } as any);
+      } satisfies PartialStoreState as unknown as ReturnType<
+        typeof useStatusStore.getState
+      >);
 
       await expect(
-        authRequestInterceptor({ headers: {} } as any),
+        authRequestInterceptor({} as InternalAxiosRequestConfig),
       ).rejects.toThrow();
 
       expect(mockSetLoggedInUser).toHaveBeenCalledWith(null);
     });
 
+    it("should not sync store when loggedInUser is already null", async () => {
+      vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
+        user: null,
+      } satisfies GetCurrentUserResult);
+
+      const mockSetLoggedInUser = vi.fn();
+      vi.mocked(useStatusStore.getState).mockReturnValueOnce({
+        loggedInUser: null,
+        setLoggedInUser: mockSetLoggedInUser,
+      } satisfies PartialStoreState as unknown as ReturnType<
+        typeof useStatusStore.getState
+      >);
+
+      await expect(
+        authRequestInterceptor({} as InternalAxiosRequestConfig),
+      ).rejects.toThrow();
+
+      expect(mockSetLoggedInUser).not.toHaveBeenCalled();
+    });
+
     it("should not call getIdToken when no user is signed in", async () => {
       vi.mocked(FirebaseAuthentication.getCurrentUser).mockResolvedValueOnce({
         user: null,
-      });
+      } satisfies GetCurrentUserResult);
 
       await expect(
-        authRequestInterceptor({ headers: {} } as any),
+        authRequestInterceptor({} as InternalAxiosRequestConfig),
       ).rejects.toThrow();
 
       expect(FirebaseAuthentication.getIdToken).not.toHaveBeenCalled();

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import toast from "react-hot-toast";
+import { NotSignedInError } from "@/lib/onlineApi";
 
 // Use vi.hoisted for all variables that need to be accessed in mock factories
 const {
@@ -84,12 +85,16 @@ vi.mock("@capacitor/browser", () => ({
   },
 }));
 
-// Mock onlineApi
-vi.mock("@/lib/onlineApi", () => ({
-  updateRequirements: (...args: unknown[]) => mockUpdateRequirements(...args),
-  deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args),
-  cancelAccountDeletion: () => mockCancelAccountDeletion(),
-}));
+// Mock onlineApi — spread actual module so non-function exports (e.g. NotSignedInError) are real
+vi.mock("@/lib/onlineApi", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    updateRequirements: (...args: unknown[]) => mockUpdateRequirements(...args),
+    deleteAccount: (...args: unknown[]) => mockDeleteAccount(...args),
+    cancelAccountDeletion: () => mockCancelAccountDeletion(),
+  };
+});
 
 // Mock store
 vi.mock("@/lib/store", async (importOriginal) => {
@@ -1042,6 +1047,35 @@ describe("Settings Online Route", () => {
         );
       });
     });
+
+    it("should close modal and show not-signed-in toast when auth is stale during delete", async () => {
+      const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
+      mockDeleteAccount.mockRejectedValueOnce(new NotSignedInError());
+
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", { name: "online.deleteAccount" }),
+      );
+
+      const confirmInput = screen.getByPlaceholderText("DELETE MY ACCOUNT");
+      await user.type(confirmInput, "DELETE MY ACCOUNT");
+
+      const deleteButtons = screen.getAllByRole("button", {
+        name: /online.deleteAccount/,
+      });
+      await user.click(deleteButtons[deleteButtons.length - 1]!);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("online.notSignedInError");
+      });
+
+      expect(
+        screen.queryByText("online.deleteAccountConfirmTitle"),
+      ).not.toBeInTheDocument();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe("scheduled deletion cancellation", () => {
@@ -1081,6 +1115,44 @@ describe("Settings Online Route", () => {
           "online.deleteAccountScheduled",
         );
       });
+    });
+
+    it("should show not-signed-in toast without logging error when auth is stale during cancel", async () => {
+      const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
+
+      mockDeleteAccount.mockResolvedValueOnce({
+        scheduled_deletion_at: "2024-02-15T00:00:00Z",
+      });
+      mockCancelAccountDeletion.mockRejectedValueOnce(new NotSignedInError());
+
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", { name: "online.deleteAccount" }),
+      );
+      const confirmInput = screen.getByPlaceholderText("DELETE MY ACCOUNT");
+      await user.type(confirmInput, "DELETE MY ACCOUNT");
+      const deleteButtons = screen.getAllByRole("button", {
+        name: /online.deleteAccount/,
+      });
+      await user.click(deleteButtons[deleteButtons.length - 1]!);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "online.cancelDeletion" }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "online.cancelDeletion" }),
+      );
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("online.notSignedInError");
+      });
+
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("should handle cancel deletion failure", async () => {

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -1071,10 +1071,15 @@ describe("Settings Online Route", () => {
         expect(toast.error).toHaveBeenCalledWith("online.notSignedInError");
       });
 
-      expect(
-        screen.queryByText("online.deleteAccountConfirmTitle"),
-      ).not.toBeInTheDocument();
-      expect(logger.error).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(
+          screen.queryByText("online.deleteAccountConfirmTitle"),
+        ).not.toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(logger.error).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/lib/onlineApi.ts
+++ b/src/lib/onlineApi.ts
@@ -1,6 +1,7 @@
-import axios from "axios";
+import axios, { type InternalAxiosRequestConfig } from "axios";
 import { FirebaseAuthentication } from "@capacitor-firebase/authentication";
 import { useRequirementsStore } from "@/hooks/useRequirementsModal";
+import { useStatusStore } from "@/lib/store";
 import type {
   RequirementsResponse,
   UpdateRequirementsRequest,
@@ -8,15 +9,34 @@ import type {
   DeleteAccountResponse,
 } from "@/lib/models";
 
+export class NotSignedInError extends Error {
+  constructor() {
+    super("User is not signed in");
+    this.name = "NotSignedInError";
+  }
+}
+
 const client = axios.create({
   baseURL: "https://api.zaparoo.com/v1",
 });
 
-client.interceptors.request.use(async function (config) {
+export async function authRequestInterceptor(
+  config: InternalAxiosRequestConfig,
+) {
+  const { user } = await FirebaseAuthentication.getCurrentUser();
+  if (!user) {
+    const state = useStatusStore.getState();
+    if (state.loggedInUser !== null) {
+      state.setLoggedInUser(null);
+    }
+    throw new NotSignedInError();
+  }
   const token = await FirebaseAuthentication.getIdToken();
   config.headers.Authorization = `Bearer ${token.token}`;
   return config;
-});
+}
+
+client.interceptors.request.use(authRequestInterceptor);
 
 // Response interceptor to catch requirements_not_met errors
 client.interceptors.response.use(

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -28,6 +28,7 @@ import {
   updateRequirements,
   deleteAccount,
   cancelAccountDeletion,
+  NotSignedInError,
 } from "@/lib/onlineApi";
 import {
   Dialog,
@@ -389,6 +390,12 @@ function OnlinePage() {
       setConfirmText("");
       toast.success(t("online.deleteAccountScheduled"));
     } catch (e) {
+      if (e instanceof NotSignedInError) {
+        setDeleteModalOpen(false);
+        setConfirmText("");
+        toast.error(t("online.notSignedInError"));
+        return;
+      }
       const error = e as AxiosError<{ error?: { code?: string } }>;
       const code = error.response?.data?.error?.code;
 
@@ -418,6 +425,10 @@ function OnlinePage() {
       setScheduledDeletion(null);
       toast.success(t("online.deletionCancelled"));
     } catch (e) {
+      if (e instanceof NotSignedInError) {
+        toast.error(t("online.notSignedInError"));
+        return;
+      }
       logger.error("Cancel deletion failed:", e, {
         category: "api",
         action: "cancelAccountDeletion",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -313,6 +313,7 @@
       "deletionAlreadyScheduled": "Account deletion is already scheduled",
       "deleteAccountScheduled": "Account deletion scheduled",
       "deleteAccountFailed": "Failed to delete account",
+      "notSignedInError": "You're no longer signed in. Please sign in again.",
       "deletionScheduledTitle": "Account deletion scheduled",
       "deletionScheduledMessage": "Your account will be deleted on {{date}}",
       "cancelDeletion": "Cancel deletion",


### PR DESCRIPTION
- Adds `authRequestInterceptor` (exported named function) to `onlineApi.ts` that calls `FirebaseAuthentication.getCurrentUser()` before every request. If no user is found, it syncs the Zustand store to null and throws `NotSignedInError` — preventing the Firebase "No user is signed in." error from surfacing as an unhandled Rollbar event.
- `handleDeleteAccount` and `handleCancelDeletion` in `settings.online.tsx` now catch `NotSignedInError` explicitly: the delete modal closes, a "no longer signed in" toast is shown, and nothing is logged to Rollbar (expected/recoverable condition).
- The interceptor guards against redundant store writes on concurrent stale-auth requests via a `loggedInUser !== null` check.
- Tests for the interceptor import `authRequestInterceptor` directly rather than capturing it through the axios mock, eliminating a brittle ESM-caching dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * If your session expires during account deletion or cancellation, the UI now closes the confirmation modal (when applicable) and shows a clear "not signed in" message prompting re-sign-in.
  * Added an English message for this scenario.

* **Bug Fixes**
  * Ensures the app clears stale sign-in state when needed to avoid misleading behavior.

* **Tests**
  * Added tests covering authenticated vs unauthenticated flows and the new error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->