### PR TITLE
fix: prevent iOS auto-zoom on form inputs

### DIFF
--- a/src/components/SimpleSystemSelect.tsx
+++ b/src/components/SimpleSystemSelect.tsx
@@ -65,7 +65,7 @@ export function SimpleSystemSelect({
       onChange={handleChange}
       disabled={gamesIndex.indexing || isLoading}
       className={classNames(
-        "border-input text-foreground w-full rounded-md border px-3 py-2 text-sm transition-colors focus:ring-2 focus:ring-white/20 focus:outline-none",
+        "border-input text-foreground w-full rounded-md border px-3 py-2 transition-colors focus:ring-2 focus:ring-white/20 focus:outline-none",
         {
           "hover:bg-white/10": !gamesIndex.indexing && !isLoading,
           "cursor-not-allowed opacity-50": gamesIndex.indexing || isLoading,

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -279,7 +279,7 @@ export function SystemSelector({
               placeholder={t("systemSelector.searchPlaceholder")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="border-input bg-background text-foreground w-full rounded-md border px-10 py-2 text-sm focus:ring-2 focus:ring-white/20 focus:outline-none"
+              className="border-input bg-background text-foreground w-full rounded-md border px-10 py-2 focus:ring-2 focus:ring-white/20 focus:outline-none"
             />
             {searchQuery && (
               <button

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -262,7 +262,7 @@ export function TagSelector({
               placeholder={t("tagSelector.searchPlaceholder")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="border-input bg-background text-foreground w-full rounded-md border px-10 py-2 text-sm focus:ring-2 focus:ring-white/20 focus:outline-none"
+              className="border-input bg-background text-foreground w-full rounded-md border px-10 py-2 focus:ring-2 focus:ring-white/20 focus:outline-none"
             />
             {searchQuery && (
               <button

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,13 @@
     color: var(--color-foreground);
   }
 
+  /* Prevent iOS WebView from auto-zooming when form controls are focused */
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+
   /* Style native select dropdown arrow for dark theme (especially iOS) */
   select {
     color-scheme: dark;


### PR DESCRIPTION
- Remove `text-sm` (14px) from the search inputs in `TagSelector` and `SystemSelector` and the `<select>` in `SimpleSystemSelect` — these were triggering iOS Safari/WebView auto-zoom on focus.
- Add `font-size: 16px` baseline for `input`, `textarea`, and `select` in `@layer base` of `index.css` to guard future inputs from the same regression.

iOS auto-zooms any form control with a computed font-size below 16px. All `wui/TextInput` usages were already safe (no explicit size class, inherit 16px); the three components above were the only at-risk elements.