### PR TITLE
fix: decode NDEF URI record identifier-code byte on NFC scan

### DIFF
--- a/__mocks__/@capawesome-team/capacitor-nfc.ts
+++ b/__mocks__/@capawesome-team/capacitor-nfc.ts
@@ -42,6 +42,66 @@ export const Nfc = {
   makeReadOnly: vi.fn().mockResolvedValue(undefined),
 };
 
+export enum TypeNameFormat {
+  Empty = 0,
+  WellKnown = 1,
+  MimeMedia = 2,
+  AbsoluteUri = 3,
+  External = 4,
+  Unknown = 5,
+  Unchanged = 6,
+}
+
+export enum RecordTypeDefinition {
+  AndroidApp = "android.com:pkg",
+  AlternativeCarrier = "ac",
+  HandoverCarrier = "Hc",
+  HandoverRequest = "Hr",
+  HandoverSelect = "Hs",
+  SmartPoster = "Sp",
+  Text = "T",
+  Uri = "U",
+}
+
+const URI_PREFIXES: Record<number, string> = {
+  0x00: "",
+  0x01: "http://www.",
+  0x02: "https://www.",
+  0x03: "http://",
+  0x04: "https://",
+  0x05: "tel:",
+  0x06: "mailto:",
+  0x07: "ftp://anonymous:anonymous@",
+  0x08: "ftp://ftp.",
+  0x09: "ftps://",
+  0x0a: "sftp://",
+  0x0b: "smb://",
+  0x0c: "nfs://",
+  0x0d: "ftp://",
+  0x0e: "dav://",
+  0x0f: "news:",
+  0x10: "telnet://",
+  0x11: "imap:",
+  0x12: "rtsp://",
+  0x13: "urn:",
+  0x14: "pop:",
+  0x15: "sip:",
+  0x16: "sips:",
+  0x17: "tftp:",
+  0x18: "btspp://",
+  0x19: "btl2cap://",
+  0x1a: "btgoep://",
+  0x1b: "tcpobex://",
+  0x1c: "irdaobex://",
+  0x1d: "file://",
+  0x1e: "urn:epc:id:",
+  0x1f: "urn:epc:tag:",
+  0x20: "urn:epc:pat:",
+  0x21: "urn:epc:raw:",
+  0x22: "urn:epc:",
+  0x23: "urn:nfc:",
+};
+
 export class NfcUtils {
   createNdefTextRecord = vi.fn().mockReturnValue({
     record: {
@@ -51,6 +111,48 @@ export class NfcUtils {
       type: [84], // 'T' for text
     },
   });
+
+  mapBytesToRecordTypeDefinition({ bytes }: { bytes: number[] }) {
+    if (bytes.length === 1) {
+      if (bytes[0] === 84) return { type: RecordTypeDefinition.Text };
+      if (bytes[0] === 85) return { type: RecordTypeDefinition.Uri };
+    }
+    return { type: undefined };
+  }
+
+  getTextFromNdefTextRecord({ record }: { record: { payload?: number[] } }) {
+    const payload = record.payload;
+    if (!payload) return { text: undefined };
+    const langLen = payload[0] ?? 0;
+    const decoder = new TextDecoder();
+    const text = decoder.decode(new Uint8Array(payload)).substring(langLen + 1);
+    return { text };
+  }
+
+  getIdentifierCodeFromNdefUriRecord({
+    record,
+  }: {
+    record: { payload?: number[] };
+  }) {
+    const payload = record.payload;
+    if (!payload || payload.length === 0) return { identifierCode: undefined };
+    const code = payload[0] as number;
+    return {
+      identifierCode: code in URI_PREFIXES ? code : undefined,
+    };
+  }
+
+  getUriFromNdefUriRecord({ record }: { record: { payload?: number[] } }) {
+    const payload = record.payload;
+    if (!payload || payload.length === 0) return { uri: undefined };
+    const decoder = new TextDecoder();
+    const uri = decoder.decode(new Uint8Array(payload.slice(1)));
+    return { uri };
+  }
+
+  mapUriIdentifierCodeToString({ identifierCode }: { identifierCode: number }) {
+    return { prefix: URI_PREFIXES[identifierCode] ?? "" };
+  }
 }
 
 /**

--- a/src/__tests__/unit/lib/nfc.pure.test.ts
+++ b/src/__tests__/unit/lib/nfc.pure.test.ts
@@ -120,15 +120,14 @@ describe("NFC Pure Functions", () => {
     });
 
     it("should extract text from NDEF text record with language code prefix", () => {
-      // NDEF text record format: [encoding byte, lang code bytes, text bytes]
-      // encoding byte = 2 means UTF-8 with 2-byte language code
       const event: NfcTagScannedEvent = {
         nfcTag: {
           id: [4, 123, 45, 67],
           message: {
             records: [
               {
-                tnf: 1, // NFC Forum well-known type
+                tnf: 1, // TypeNameFormat.WellKnown
+                type: [0x54], // 'T' = text record
                 payload: [2, 101, 110, 72, 101, 108, 108, 111], // 2, "en", "Hello"
               },
             ],
@@ -143,16 +142,44 @@ describe("NFC Pure Functions", () => {
       });
     });
 
-    it("should handle NDEF record without language code prefix", () => {
-      // Payload that doesn't start with 2 (language code byte)
+    it("should extract text from NDEF text record with 3-char language code", () => {
+      // Status byte 0x03 = UTF-8, language code length 3 (e.g. "eng")
+      const enc = new TextEncoder();
+      const langBytes = Array.from(enc.encode("eng"));
+      const textBytes = Array.from(enc.encode("Hi"));
       const event: NfcTagScannedEvent = {
         nfcTag: {
           id: [1, 2, 3, 4],
           message: {
             records: [
               {
-                tnf: 1, // NFC Forum well-known type
-                payload: [84, 101, 115, 116], // "Test" without prefix
+                tnf: 1,
+                type: [0x54],
+                payload: [3, ...langBytes, ...textBytes],
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "Hi",
+      });
+    });
+
+    it("should fall back to raw bytes for well-known record with unrecognised 1-byte type", () => {
+      // tnf=1 with a type byte that is not 'T' (0x54) or 'U' (0x55) → int2char fallback
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1, // TypeNameFormat.WellKnown
+                type: [0x50], // unknown 1-byte type → falls back to int2char
+                payload: [84, 101, 115, 116], // "Test"
               },
             ],
           },
@@ -166,15 +193,41 @@ describe("NFC Pure Functions", () => {
       });
     });
 
-    it("should handle short payload gracefully", () => {
+    it("should fall back to raw bytes for non-WellKnown TNF", () => {
+      // tnf: 2 = MimeMedia — hits the outer else branch → int2char fallback
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 2, // TypeNameFormat.MimeMedia
+                type: [0x74, 0x65, 0x78, 0x74], // "text"
+                payload: [72, 105], // "Hi"
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "Hi",
+      });
+    });
+
+    it("should handle short text payload gracefully", () => {
+      // Status byte claims 2-char lang code but there is no more data → empty text
       const event: NfcTagScannedEvent = {
         nfcTag: {
           id: [1, 2],
           message: {
             records: [
               {
-                tnf: 1, // NFC Forum well-known type
-                payload: [2], // Only encoding byte, no text
+                tnf: 1,
+                type: [0x54],
+                payload: [2], // status byte only, no lang code or text
               },
             ],
           },
@@ -184,7 +237,132 @@ describe("NFC Pure Functions", () => {
       const result = readNfcEvent(event);
       expect(result).toEqual({
         uid: "0102",
-        text: "\u0002", // Single byte as char
+        text: "",
+      });
+    });
+
+    it("should decode NDEF URI record with https:// identifier code", () => {
+      const enc = new TextEncoder();
+      const uriBytes = Array.from(enc.encode("zpr.au/xyz"));
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1, // TypeNameFormat.WellKnown
+                type: [0x55], // 'U' = URI record
+                payload: [0x04, ...uriBytes], // 0x04 = https://
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "https://zpr.au/xyz",
+      });
+    });
+
+    it("should decode NDEF URI record with http://www. identifier code", () => {
+      const enc = new TextEncoder();
+      const uriBytes = Array.from(enc.encode("example.com/page"));
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1,
+                type: [0x55],
+                payload: [0x01, ...uriBytes], // 0x01 = http://www.
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "http://www.example.com/page",
+      });
+    });
+
+    it("should decode NDEF URI record with no prefix (identifier code 0x00)", () => {
+      const enc = new TextEncoder();
+      const uriBytes = Array.from(enc.encode("custom://thing"));
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1,
+                type: [0x55],
+                payload: [0x00, ...uriBytes], // 0x00 = no prefix
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "custom://thing",
+      });
+    });
+
+    it("should use empty prefix for unknown URI identifier code", () => {
+      // 0xFF is not in the NFC Forum URI identifier table → identifierCode: undefined → prefix ""
+      const enc = new TextEncoder();
+      const uriBytes = Array.from(enc.encode("example.com"));
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1,
+                type: [0x55],
+                payload: [0xff, ...uriBytes],
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "example.com",
+      });
+    });
+
+    it("should produce prefix-only text when URI body is empty", () => {
+      // payload contains only the identifier byte, no URI characters
+      const event: NfcTagScannedEvent = {
+        nfcTag: {
+          id: [1, 2, 3, 4],
+          message: {
+            records: [
+              {
+                tnf: 1,
+                type: [0x55],
+                payload: [0x04], // 0x04 = https://, no URI body
+              },
+            ],
+          },
+        },
+      };
+
+      const result = readNfcEvent(event);
+      expect(result).toEqual({
+        uid: "01020304",
+        text: "https://",
       });
     });
   });

--- a/src/__tests__/unit/lib/nfc.test.ts
+++ b/src/__tests__/unit/lib/nfc.test.ts
@@ -80,16 +80,15 @@ const {
   };
 });
 
-// Mock the NFC plugin
-vi.mock("@capawesome-team/capacitor-nfc", () => {
-  // Create a persistent mock for NfcUtils that can be instantiated
-  class MockNfcUtils {
-    createNdefTextRecord() {
-      return { record: { payload: [] } };
-    }
-  }
+// Mock the NFC plugin — keep real NfcUtils, TypeNameFormat, RecordTypeDefinition
+// (pure JS, no native code) and only replace the Nfc singleton.
+vi.mock("@capawesome-team/capacitor-nfc", async () => {
+  const actual = await vi.importActual<
+    typeof import("@capawesome-team/capacitor-nfc")
+  >("@capawesome-team/capacitor-nfc");
 
   return {
+    ...actual,
     Nfc: {
       addListener: mockAddListener,
       startScanSession: mockStartScanSession,
@@ -101,10 +100,6 @@ vi.mock("@capawesome-team/capacitor-nfc", () => {
       connect: mockConnect,
       close: mockClose,
       isSupported: mockIsSupported,
-    },
-    NfcUtils: MockNfcUtils,
-    NfcTagTechType: {
-      NdefFormatable: "NDEF_FORMATABLE",
     },
   };
 });
@@ -720,6 +715,8 @@ describe("nfc", () => {
           message: {
             records: [
               {
+                tnf: 1, // TypeNameFormat.WellKnown
+                type: [0x54], // 'T' = text record
                 payload: [2, 101, 110, 72, 101, 108, 108, 111], // 2 + "en" + "Hello"
               },
             ],
@@ -784,6 +781,37 @@ describe("nfc", () => {
       const result = await readPromise;
 
       expect(result.info.tag).toBeNull();
+    });
+
+    it("should decode NDEF URI record with https:// identifier code", async () => {
+      const readPromise = readTag();
+
+      await vi.waitFor(() => {
+        expect(mockState.nfcTagScannedCallback).not.toBeNull();
+      });
+
+      const enc = new TextEncoder();
+      const uriBytes = Array.from(enc.encode("zpr.au/xyz"));
+
+      mockState.nfcTagScannedCallback?.({
+        nfcTag: {
+          id: [170, 187, 204, 221],
+          message: {
+            records: [
+              {
+                tnf: 1, // TypeNameFormat.WellKnown
+                type: [0x55], // 'U' = URI record
+                payload: [0x04, ...uriBytes], // 0x04 = https://
+              },
+            ],
+          },
+        },
+      } as unknown as NfcTagScannedEvent);
+
+      const result = await readPromise;
+
+      expect(result.info.tag?.text).toBe("https://zpr.au/xyz");
+      expect(result.info.tag?.uid).toBe("aabbccdd");
     });
   });
 });

--- a/src/lib/nfc.ts
+++ b/src/lib/nfc.ts
@@ -4,6 +4,8 @@ import {
   NfcTag,
   NfcTagScannedEvent,
   NfcUtils,
+  RecordTypeDefinition,
+  TypeNameFormat,
 } from "@capawesome-team/capacitor-nfc";
 import { logger } from "./logger";
 import {
@@ -175,11 +177,32 @@ export function readNfcEvent(event: NfcTagScannedEvent): Tag | null {
     const ndef = event.nfcTag.message.records[0];
 
     if (ndef?.payload) {
-      let bs = ndef.payload;
-      if (bs.length > 3 && bs[0] == 2) {
-        bs = bs.slice(3);
+      const utils = new NfcUtils();
+
+      if (ndef.tnf === TypeNameFormat.WellKnown) {
+        const { type: recordType } = utils.mapBytesToRecordTypeDefinition({
+          bytes: ndef.type ?? [],
+        });
+
+        if (recordType === RecordTypeDefinition.Text) {
+          text = utils.getTextFromNdefTextRecord({ record: ndef }).text ?? "";
+        } else if (recordType === RecordTypeDefinition.Uri) {
+          const { identifierCode } = utils.getIdentifierCodeFromNdefUriRecord({
+            record: ndef,
+          });
+          const prefix =
+            identifierCode === undefined
+              ? ""
+              : (utils.mapUriIdentifierCodeToString({ identifierCode })
+                  ?.prefix ?? "");
+          const { uri } = utils.getUriFromNdefUriRecord({ record: ndef });
+          text = prefix + (uri ?? "");
+        } else {
+          text = int2char(ndef.payload);
+        }
+      } else {
+        text = int2char(ndef.payload);
       }
-      text = int2char(bs);
     }
   }
 


### PR DESCRIPTION
- NDEF URI records (e.g. Zaparoo-branded `https://zpr.au/...` cards) were decoded as `\u0004zpr.au/...` because the URI identifier-code byte (`0x04` = `https://`) was passed raw through `int2char` with no prefix expansion. This caused `isZapUrl` to silently return false and forwarded a malformed string to `CoreAPI.run`.
- `readNfcEvent` in `src/lib/nfc.ts` now checks `record.tnf` and `record.type`, delegating to the plugin's existing `NfcUtils` helpers: `getTextFromNdefTextRecord` for Text records (also fixes variable-length language code handling) and `getUriFromNdefUriRecord` + `mapUriIdentifierCodeToString` for URI records. Non-WellKnown and unrecognised types fall back to the previous `int2char` behaviour.
- Updated the global NFC automock (`__mocks__/@capawesome-team/capacitor-nfc.ts`) to export `TypeNameFormat` and `RecordTypeDefinition` enums and implement the full set of `NfcUtils` methods used by `readNfcEvent`.
- Extended `nfc.pure.test.ts` and `nfc.test.ts` with URI record cases covering `https://`, `http://www.`, no-prefix, unknown identifier code, empty URI body, and non-WellKnown TNF fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFC tag reading with better parsing of text and URI records from NDEF records.

* **Tests**
  * Added comprehensive test coverage for NDEF text record decoding with various language codes and edge cases.
  * Added test coverage for NDEF URI record decoding with multiple URI prefix identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->