### PR TITLE
feat: add Core version gating infrastructure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,12 +73,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
-          subject-path: 'zaparoo_app-web-*.tar.gz'
+          subject-path: "zaparoo_app-web-*.tar.gz"
       - name: Attest SBOM
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
-          subject-path: 'zaparoo_app-web-*.tar.gz'
+          subject-path: "zaparoo_app-web-*.tar.gz"
           sbom-path: sbom.spdx.json
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,50 @@ try {
 
 ---
 
+## Core Version Gating
+
+The app must gracefully degrade when connected to older Core versions during migration periods. This is handled client-side via semver comparison — no Core changes required.
+
+### Key files
+
+- `src/lib/coreVersion.ts` — semver helpers: `isDevelopmentVersion`, `parseVersion`, `compareVersions`, `satisfies`
+- `src/lib/featureGates.ts` — **registry of gated features** (edit this to gate new features)
+- `src/hooks/useCoreFeature.ts` — React hook returning `{ available, requiredVersion, marquee }`
+- `src/components/GatedFeature.tsx` — wrapper component
+- `src/components/CoreOutdatedNotice.tsx` — settings page notice (auto-shown when any gate fails)
+
+### How to gate a new feature
+
+1. Add an entry to `FEATURE_GATES` in `src/lib/featureGates.ts`:
+
+```ts
+export const FEATURE_GATES: Record<string, FeatureGate> = {
+  screenshot: {
+    since: "2.6.0",
+    marquee: true,
+    labelKey: "features.screenshot",
+  },
+};
+```
+
+- `since` — minimum Core version (semver)
+- `marquee` — `true`: show disabled with tooltip; `false`: hide silently
+- `labelKey` — i18n key used in the outdated notice list
+
+2. Add the translation key to `src/translations/en-US.json` under `"features"`.
+
+3. Wrap UI in `<GatedFeature featureId="screenshot">` or call `useCoreFeature("screenshot")` directly.
+
+### Dev build handling
+
+Versions matching `DEVELOPMENT`, empty string, or containing `-dev`/`-rc`/`-beta`/`-alpha` are treated as dev builds and **pass all gates automatically**. This mirrors Core's `config.IsDevelopmentVersion` semantics.
+
+### Store state
+
+`coreVersion` and `corePlatform` are fetched once per connect in `ConnectionProvider.handleConnectionOpen` and stored in `useStatusStore`. They are cleared by `resetConnectionState()` on device switch. Do not maintain a separate version query in components — read from the store.
+
+---
+
 ## Common Gotchas
 
 1. **NFC Cancellation**: Check `error.message.includes("cancelled")` - fragile but necessary

--- a/src/__tests__/integration/CoreOutdatedNotice.test.tsx
+++ b/src/__tests__/integration/CoreOutdatedNotice.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "../../test-utils";
+import { useStatusStore, ConnectionState } from "@/lib/store";
+import { FEATURE_GATES } from "@/lib/featureGates";
+import { CoreOutdatedNotice } from "@/components/CoreOutdatedNotice";
+
+const originalGates = { ...FEATURE_GATES };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  Object.assign(FEATURE_GATES, {
+    testFeatureA: {
+      since: "2.5.0",
+      marquee: false,
+      labelKey: "features.testFeatureA",
+    },
+  });
+
+  useStatusStore.setState({
+    ...useStatusStore.getInitialState(),
+    connected: true,
+    connectionState: ConnectionState.CONNECTED,
+    coreVersion: "2.4.0",
+    coreVersionPending: false,
+  });
+});
+
+afterEach(() => {
+  Object.keys(FEATURE_GATES).forEach((k) => {
+    if (!(k in originalGates))
+      delete (FEATURE_GATES as Record<string, unknown>)[k];
+  });
+  vi.restoreAllMocks();
+});
+
+describe("CoreOutdatedNotice", () => {
+  it("should render notice when connected Core is below a gate version", () => {
+    render(<CoreOutdatedNotice />);
+    expect(screen.getByText("settings.coreOutdated.title")).toBeInTheDocument();
+    expect(
+      screen.getByText("settings.coreOutdated.description"),
+    ).toBeInTheDocument();
+  });
+
+  it("should list unavailable features in the notice", () => {
+    render(<CoreOutdatedNotice />);
+    expect(screen.getByText("features.testFeatureA")).toBeInTheDocument();
+  });
+
+  it("should not render when Core version meets all gates", () => {
+    useStatusStore.setState({ coreVersion: "2.5.0" });
+    render(<CoreOutdatedNotice />);
+    expect(
+      screen.queryByText("settings.coreOutdated.title"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not render when disconnected", () => {
+    useStatusStore.setState({
+      connected: false,
+      connectionState: ConnectionState.DISCONNECTED,
+    });
+    render(<CoreOutdatedNotice />);
+    expect(
+      screen.queryByText("settings.coreOutdated.title"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not render while version is pending", () => {
+    useStatusStore.setState({ coreVersionPending: true });
+    render(<CoreOutdatedNotice />);
+    expect(
+      screen.queryByText("settings.coreOutdated.title"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not render when coreVersion is null", () => {
+    useStatusStore.setState({ coreVersion: null, coreVersionPending: false });
+    render(<CoreOutdatedNotice />);
+    expect(
+      screen.queryByText("settings.coreOutdated.title"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should not render when Core is a dev build", () => {
+    useStatusStore.setState({ coreVersion: "DEVELOPMENT" });
+    render(<CoreOutdatedNotice />);
+    expect(
+      screen.queryByText("settings.coreOutdated.title"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -11,6 +11,7 @@ import { ConnectionProvider } from "../../../components/ConnectionProvider";
 import { useConnection } from "../../../hooks/useConnection";
 import { connectionManager } from "../../../lib/transport";
 import { CoreAPI } from "../../../lib/coreApi";
+import { useStatusStore } from "@/lib/store";
 import type { TransportState } from "../../../lib/transport/types";
 import type { NotificationRequest } from "../../../lib/coreApi";
 import { Notification } from "../../../lib/models";
@@ -64,67 +65,17 @@ vi.mock("../../../lib/coreApi", () => ({
     processReceived: vi.fn().mockResolvedValue(null),
     media: vi.fn().mockResolvedValue({ database: {}, active: [] }),
     tokens: vi.fn().mockResolvedValue({ last: null }),
+    version: vi.fn().mockResolvedValue({ version: "2.5.0", platform: "test" }),
   },
   getDeviceAddress: vi.fn(() => "192.168.1.100:7497"),
   getWsUrl: vi.fn(() => "ws://192.168.1.100:7497"),
   isCancelled: vi.fn(() => false),
 }));
 
-// Use vi.hoisted to define mock functions that can be used in vi.mock
-const { mockSetPlaying, mockSetLastToken, mockSetGamesIndex } = vi.hoisted(
-  () => ({
-    mockSetPlaying: vi.fn(),
-    mockSetLastToken: vi.fn(),
-    mockSetGamesIndex: vi.fn(),
-  }),
-);
-
-vi.mock("../../../lib/store", () => {
-  // Track gamesIndex state for change detection
-  const mockGamesIndexState = {
-    indexing: false,
-    optimizing: false,
-    exists: false,
-    totalMedia: 0,
-  };
-
-  return {
-    useStatusStore: Object.assign(
-      vi.fn((selector) => {
-        const state = {
-          targetDeviceAddress: "192.168.1.100:7497",
-          setTargetDeviceAddress: vi.fn(),
-          setConnectionState: vi.fn(),
-          setConnectionError: vi.fn(),
-          setPlaying: mockSetPlaying,
-          setGamesIndex: mockSetGamesIndex,
-          setLastToken: mockSetLastToken,
-          addDeviceHistory: vi.fn(),
-          setDeviceHistory: vi.fn(),
-          gamesIndex: mockGamesIndexState,
-        };
-        return selector(state);
-      }),
-      {
-        getState: () => ({
-          gamesIndex: mockGamesIndexState,
-        }),
-      },
-    ),
-    ConnectionState: {
-      IDLE: "idle",
-      CONNECTING: "connecting",
-      CONNECTED: "connected",
-      RECONNECTING: "reconnecting",
-      DISCONNECTED: "disconnected",
-      ERROR: "error",
-    },
-  };
-});
-
 vi.mock("@capacitor/preferences", () => ({
   Preferences: {
     get: vi.fn().mockResolvedValue({ value: null }),
+    set: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -194,9 +145,18 @@ function ConnectionConsumer() {
   );
 }
 
+// Pre-set targetDeviceAddress to skip the async polling initialization
+function resetStore() {
+  useStatusStore.setState({
+    ...useStatusStore.getInitialState(),
+    targetDeviceAddress: "192.168.1.100:7497",
+  });
+}
+
 describe("ConnectionProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetStore();
   });
 
   describe("rendering", () => {
@@ -300,6 +260,11 @@ describe("ConnectionProvider", () => {
 });
 
 describe("useConnection hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
   it("should return connection context values with expected initial state", () => {
     render(
       <ConnectionProvider>
@@ -324,10 +289,7 @@ describe("notification processing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
-    // Clear hoisted mocks explicitly
-    mockSetPlaying.mockClear();
-    mockSetLastToken.mockClear();
-    mockSetGamesIndex.mockClear();
+    resetStore();
     mockToast.mockClear();
     mockAnnounce.mockClear();
   });
@@ -359,7 +321,7 @@ describe("notification processing", () => {
       await capturedEventHandlers.onMessage!("test-device", {});
 
       await waitFor(() => {
-        expect(mockSetPlaying).toHaveBeenCalledWith({
+        expect(useStatusStore.getState().playing).toEqual({
           systemId: "snes",
           systemName: "Super Nintendo",
           mediaPath: "/games/mario.sfc",
@@ -390,7 +352,7 @@ describe("notification processing", () => {
       await capturedEventHandlers.onMessage!("test-device", {});
 
       await waitFor(() => {
-        expect(mockSetPlaying).toHaveBeenCalledWith({
+        expect(useStatusStore.getState().playing).toEqual({
           systemId: "",
           systemName: "",
           mediaPath: "",
@@ -426,7 +388,7 @@ describe("notification processing", () => {
       await capturedEventHandlers.onMessage!("test-device", {});
 
       await waitFor(() => {
-        expect(mockSetLastToken).toHaveBeenCalledWith({
+        expect(useStatusStore.getState().lastToken).toEqual({
           uid: "ABC123",
           text: "**launch:snes/mario.sfc",
           data: "launch data",
@@ -518,7 +480,7 @@ describe("notification processing", () => {
       await capturedEventHandlers.onMessage!("test-device", {});
 
       await waitFor(() => {
-        expect(mockSetGamesIndex).toHaveBeenCalledWith({
+        expect(useStatusStore.getState().gamesIndex).toMatchObject({
           indexing: true,
           optimizing: false,
           exists: true,
@@ -532,6 +494,8 @@ describe("notification processing", () => {
     it("should not update state when processReceived returns null", async () => {
       vi.mocked(CoreAPI.processReceived).mockResolvedValueOnce(null);
 
+      const initialState = useStatusStore.getInitialState();
+
       render(
         <ConnectionProvider>
           <div>Test</div>
@@ -541,9 +505,11 @@ describe("notification processing", () => {
       expect(capturedEventHandlers.onMessage).toBeDefined();
       await capturedEventHandlers.onMessage!("test-device", {});
 
-      // Handler completes synchronously after await, so we can assert immediately
-      expect(mockSetPlaying).not.toHaveBeenCalled();
-      expect(mockSetLastToken).not.toHaveBeenCalled();
+      // State should remain at initial values
+      expect(useStatusStore.getState().playing).toEqual(initialState.playing);
+      expect(useStatusStore.getState().lastToken).toEqual(
+        initialState.lastToken,
+      );
     });
 
     it("should handle unknown notification method gracefully", async () => {
@@ -567,8 +533,11 @@ describe("notification processing", () => {
       await capturedEventHandlers.onMessage!("test-device", {});
 
       // State should not be updated for unknown notifications
-      expect(mockSetPlaying).not.toHaveBeenCalled();
-      expect(mockSetLastToken).not.toHaveBeenCalled();
+      const initialState = useStatusStore.getInitialState();
+      expect(useStatusStore.getState().playing).toEqual(initialState.playing);
+      expect(useStatusStore.getState().lastToken).toEqual(
+        initialState.lastToken,
+      );
     });
 
     it("should show toast when processReceived throws an error", async () => {
@@ -627,6 +596,7 @@ describe("connection event handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
+    resetStore();
     // Re-setup mock after clearAllMocks - use the address from store mock
     vi.mocked(connectionManager.getActiveDeviceId).mockReturnValue(
       "192.168.1.100:7497",
@@ -653,6 +623,34 @@ describe("connection event handling", () => {
       expect(CoreAPI.flushQueue).toHaveBeenCalled();
       expect(CoreAPI.media).toHaveBeenCalled();
       expect(CoreAPI.tokens).toHaveBeenCalled();
+      expect(CoreAPI.version).toHaveBeenCalled();
+      expect(useStatusStore.getState().coreVersion).toBe("2.5.0");
+      expect(useStatusStore.getState().corePlatform).toBe("test");
+      expect(useStatusStore.getState().coreVersionPending).toBe(false);
+    });
+  });
+
+  it("should set coreVersion to null when version fetch fails", async () => {
+    vi.mocked(CoreAPI.version).mockRejectedValueOnce(
+      new Error("Network error"),
+    );
+
+    render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(useStatusStore.getState().coreVersion).toBeNull();
+      expect(useStatusStore.getState().corePlatform).toBeNull();
+      expect(useStatusStore.getState().coreVersionPending).toBe(false);
     });
   });
 
@@ -712,6 +710,7 @@ describe("cancelled request handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
+    resetStore();
     // Ensure getActiveDeviceId returns the device we're testing with
     vi.mocked(connectionManager.getActiveDeviceId).mockReturnValue(
       "192.168.1.100:7497",
@@ -743,7 +742,9 @@ describe("cancelled request handling", () => {
   });
 
   it("should handle cancelled tokens response gracefully", async () => {
-    vi.mocked(CoreAPI.tokens).mockResolvedValueOnce({ cancelled: true } as any);
+    vi.mocked(CoreAPI.tokens).mockResolvedValueOnce({
+      cancelled: true,
+    } as any);
 
     render(
       <ConnectionProvider>
@@ -771,6 +772,7 @@ describe("API error handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
+    resetStore();
     // Ensure getActiveDeviceId returns the device we're testing with
     vi.mocked(connectionManager.getActiveDeviceId).mockReturnValue(
       "192.168.1.100:7497",
@@ -834,6 +836,7 @@ describe("app lifecycle handling", () => {
     vi.clearAllMocks();
     resumeCallback = null;
     pauseCallback = null;
+    resetStore();
 
     // Capture the callbacks passed to App.addListener
     const { App } = await import("@capacitor/app");
@@ -927,6 +930,7 @@ describe("app lifecycle handling", () => {
 describe("browser visibility handling (web platform)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetStore();
   });
 
   it("should call connectionManager.resumeAll when tab becomes visible", async () => {
@@ -989,6 +993,7 @@ describe("edge cases", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
+    resetStore();
   });
 
   describe("stale connection events", () => {
@@ -1037,6 +1042,7 @@ describe("network status handling (native platform)", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     networkListener = null;
+    resetStore();
 
     // Mock Capacitor as native platform
     const { Capacitor } = await import("@capacitor/core");
@@ -1157,6 +1163,7 @@ describe("processNotification error handling", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
+    resetStore();
     mockToast.mockClear();
     mockToastError.mockClear();
     // Reset toast rate limiter to ensure toast shows

--- a/src/__tests__/unit/components/GatedFeature.test.tsx
+++ b/src/__tests__/unit/components/GatedFeature.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "../../../test-utils";
+import { GatedFeature } from "@/components/GatedFeature";
+import type { FeatureId } from "@/lib/featureGates";
+
+vi.mock("@/hooks/useCoreFeature", () => ({
+  useCoreFeature: vi.fn(),
+}));
+
+import { useCoreFeature } from "@/hooks/useCoreFeature";
+
+const mockFeatureId = "testFeature" as FeatureId;
+
+describe("GatedFeature", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render children when feature is available", () => {
+    vi.mocked(useCoreFeature).mockReturnValue({
+      available: true,
+      requiredVersion: "2.5.0",
+      currentVersion: "2.6.0",
+      marquee: false,
+    });
+
+    render(
+      <GatedFeature featureId={mockFeatureId}>
+        <span>Feature content</span>
+      </GatedFeature>,
+    );
+
+    expect(screen.getByText("Feature content")).toBeInTheDocument();
+  });
+
+  it("should render nothing when feature is unavailable and not marquee", () => {
+    vi.mocked(useCoreFeature).mockReturnValue({
+      available: false,
+      requiredVersion: "2.5.0",
+      currentVersion: "2.4.0",
+      marquee: false,
+    });
+
+    render(
+      <GatedFeature featureId={mockFeatureId}>
+        <span>Feature content</span>
+      </GatedFeature>,
+    );
+
+    expect(screen.queryByText("Feature content")).not.toBeInTheDocument();
+  });
+
+  it("should render disabled wrapper with tooltip when feature is unavailable and marquee", () => {
+    vi.mocked(useCoreFeature).mockReturnValue({
+      available: false,
+      requiredVersion: "2.5.0",
+      currentVersion: "2.4.0",
+      marquee: true,
+    });
+
+    render(
+      <GatedFeature featureId={mockFeatureId}>
+        <span>Feature content</span>
+      </GatedFeature>,
+    );
+
+    expect(screen.getByText("Feature content")).toBeInTheDocument();
+    const wrapper = screen
+      .getByText("Feature content")
+      .closest('[title="features.requiresCoreVersion"]');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute(
+      "aria-label",
+      "features.requiresCoreVersion",
+    );
+  });
+});

--- a/src/__tests__/unit/coreVersion.test.ts
+++ b/src/__tests__/unit/coreVersion.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  isDevelopmentVersion,
+  parseVersion,
+  compareVersions,
+  satisfies,
+} from "../../lib/coreVersion";
+
+describe("isDevelopmentVersion", () => {
+  it.each([
+    ["", true],
+    ["DEVELOPMENT", true],
+    ["2.5.0-dev", true],
+    ["2.5.0-rc1", true],
+    ["2.5.0-beta", true],
+    ["2.5.0-alpha.1", true],
+    ["notasemver", true],
+    ["v2.5.0", true],
+  ])("should return true for dev-like version %s", (raw, expected) => {
+    expect(isDevelopmentVersion(raw)).toBe(expected);
+  });
+
+  it.each([["2.5.0"], ["1.0.0"], ["10.20.30"], ["2.5.1"]])(
+    "should return false for release version %s",
+    (raw) => {
+      expect(isDevelopmentVersion(raw)).toBe(false);
+    },
+  );
+});
+
+describe("parseVersion", () => {
+  it("should parse standard semver strings", () => {
+    expect(parseVersion("2.5.0")).toEqual({ major: 2, minor: 5, patch: 0 });
+    expect(parseVersion("1.10.3")).toEqual({ major: 1, minor: 10, patch: 3 });
+  });
+
+  it("should return null for unparseable strings", () => {
+    expect(parseVersion("DEVELOPMENT")).toBeNull();
+    expect(parseVersion("")).toBeNull();
+    expect(parseVersion("notaversion")).toBeNull();
+  });
+});
+
+describe("compareVersions", () => {
+  it("should return 0 for equal versions", () => {
+    expect(compareVersions("2.5.0", "2.5.0")).toBe(0);
+  });
+
+  it("should correctly compare patch versions", () => {
+    expect(compareVersions("2.5.1", "2.5.0")).toBe(1);
+    expect(compareVersions("2.5.0", "2.5.1")).toBe(-1);
+  });
+
+  it("should correctly compare minor versions", () => {
+    expect(compareVersions("2.10.0", "2.9.0")).toBe(1);
+    expect(compareVersions("1.9.0", "1.10.0")).toBe(-1);
+  });
+
+  it("should correctly compare major versions", () => {
+    expect(compareVersions("3.0.0", "2.9.9")).toBe(1);
+    expect(compareVersions("1.0.0", "2.0.0")).toBe(-1);
+  });
+
+  it("should return 0 when versions cannot be parsed", () => {
+    expect(compareVersions("DEVELOPMENT", "2.5.0")).toBe(0);
+    expect(compareVersions("2.5.0", "bad")).toBe(0);
+  });
+});
+
+describe("satisfies", () => {
+  it("should return false when current version is null", () => {
+    expect(satisfies(null, "2.5.0")).toBe(false);
+  });
+
+  it("should return true for dev build versions", () => {
+    expect(satisfies("DEVELOPMENT", "2.5.0")).toBe(true);
+    expect(satisfies("", "2.5.0")).toBe(true);
+    expect(satisfies("2.5.0-dev", "99.0.0")).toBe(true);
+  });
+
+  it("should return true when current meets minimum exactly", () => {
+    expect(satisfies("2.5.0", "2.5.0")).toBe(true);
+  });
+
+  it("should return true when current is above minimum", () => {
+    expect(satisfies("2.5.1", "2.5.0")).toBe(true);
+    expect(satisfies("2.6.0", "2.5.0")).toBe(true);
+    expect(satisfies("3.0.0", "2.5.0")).toBe(true);
+  });
+
+  it("should return false when current is below minimum", () => {
+    expect(satisfies("2.4.9", "2.5.0")).toBe(false);
+    expect(satisfies("2.5.0", "2.5.1")).toBe(false);
+    expect(satisfies("1.99.99", "2.0.0")).toBe(false);
+  });
+});

--- a/src/__tests__/unit/coreVersion.test.ts
+++ b/src/__tests__/unit/coreVersion.test.ts
@@ -93,4 +93,10 @@ describe("satisfies", () => {
     expect(satisfies("2.5.0", "2.5.1")).toBe(false);
     expect(satisfies("1.99.99", "2.0.0")).toBe(false);
   });
+
+  it("should return false when minimum is malformed", () => {
+    expect(satisfies("2.5.0", "bad")).toBe(false);
+    expect(satisfies("2.5.0", "")).toBe(false);
+    expect(satisfies("2.5.0", "DEVELOPMENT")).toBe(false);
+  });
 });

--- a/src/__tests__/unit/featureGates.test.ts
+++ b/src/__tests__/unit/featureGates.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { FEATURE_GATES, isCoreFeatureAvailable } from "../../lib/featureGates";
+
+describe("isCoreFeatureAvailable", () => {
+  const originalGates = { ...FEATURE_GATES };
+
+  beforeEach(() => {
+    // Inject a test gate without modifying the real registry permanently
+    Object.assign(FEATURE_GATES, {
+      testFeature: {
+        since: "2.5.0",
+        marquee: false,
+        labelKey: "features.testFeature",
+      },
+    });
+  });
+
+  afterEach(() => {
+    // Restore original registry
+    Object.keys(FEATURE_GATES).forEach((k) => {
+      if (!(k in originalGates))
+        delete (FEATURE_GATES as Record<string, unknown>)[k];
+    });
+  });
+
+  it("should return true for unknown feature id (no gate = no restriction)", () => {
+    expect(isCoreFeatureAvailable("unknownId" as never, "2.0.0")).toBe(true);
+  });
+
+  it("should return false when version is null", () => {
+    expect(isCoreFeatureAvailable("testFeature", null)).toBe(false);
+  });
+
+  it("should return true for dev build versions", () => {
+    expect(isCoreFeatureAvailable("testFeature", "DEVELOPMENT")).toBe(true);
+    expect(isCoreFeatureAvailable("testFeature", "2.5.0-dev")).toBe(true);
+  });
+
+  it("should return true when version meets requirement", () => {
+    expect(isCoreFeatureAvailable("testFeature", "2.5.0")).toBe(true);
+    expect(isCoreFeatureAvailable("testFeature", "2.6.0")).toBe(true);
+  });
+
+  it("should return false when version is below requirement", () => {
+    expect(isCoreFeatureAvailable("testFeature", "2.4.9")).toBe(false);
+    expect(isCoreFeatureAvailable("testFeature", "1.0.0")).toBe(false);
+  });
+});

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -303,11 +303,13 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     CoreAPI.version()
       .then((v) => {
         if (isCancelled(v)) {
+          // Don't clear pending — a new connection will manage its own pending state
           logger.log("Version request was cancelled, skipping");
           return;
         }
         setCoreVersion(v.version);
         setCorePlatform(v.platform);
+        setCoreVersionPending(false);
       })
       .catch((e) => {
         logger.error("Failed to get Core version:", e, {
@@ -317,8 +319,6 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         });
         setCoreVersion(null);
         setCorePlatform(null);
-      })
-      .finally(() => {
         setCoreVersionPending(false);
       });
 

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -82,6 +82,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setLastToken,
     addDeviceHistory,
     setDeviceHistory,
+    setCoreVersion,
+    setCorePlatform,
+    setCoreVersionPending,
   } = useStatusStore(
     useShallow((state) => ({
       targetDeviceAddress: state.targetDeviceAddress,
@@ -93,6 +96,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       setLastToken: state.setLastToken,
       addDeviceHistory: state.addDeviceHistory,
       setDeviceHistory: state.setDeviceHistory,
+      setCoreVersion: state.setCoreVersion,
+      setCorePlatform: state.setCorePlatform,
+      setCoreVersionPending: state.setCoreVersionPending,
     })),
   );
 
@@ -292,6 +298,30 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     // Flush any queued API requests
     CoreAPI.flushQueue();
 
+    // Fetch Core version for feature gating
+    setCoreVersionPending(true);
+    CoreAPI.version()
+      .then((v) => {
+        if (isCancelled(v)) {
+          logger.log("Version request was cancelled, skipping");
+          return;
+        }
+        setCoreVersion(v.version);
+        setCorePlatform(v.platform);
+      })
+      .catch((e) => {
+        logger.error("Failed to get Core version:", e, {
+          category: "api",
+          action: "version",
+          severity: "warning",
+        });
+        setCoreVersion(null);
+        setCorePlatform(null);
+      })
+      .finally(() => {
+        setCoreVersionPending(false);
+      });
+
     // Load device history
     Preferences.get({ key: "deviceHistory" })
       .then((v) => {
@@ -365,6 +395,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setGamesIndex,
     setPlaying,
     setLastToken,
+    setCoreVersion,
+    setCorePlatform,
+    setCoreVersionPending,
     t,
   ]);
 

--- a/src/components/CoreOutdatedNotice.tsx
+++ b/src/components/CoreOutdatedNotice.tsx
@@ -1,0 +1,54 @@
+import { TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStatusStore } from "@/lib/store";
+import { FEATURE_GATES, isCoreFeatureAvailable } from "@/lib/featureGates";
+import { compareVersions } from "@/lib/coreVersion";
+import { Card } from "./wui/Card";
+
+export function CoreOutdatedNotice() {
+  const { t } = useTranslation();
+  const connected = useStatusStore((state) => state.connected);
+  const coreVersion = useStatusStore((state) => state.coreVersion);
+  const coreVersionPending = useStatusStore(
+    (state) => state.coreVersionPending,
+  );
+
+  if (!connected || coreVersionPending || coreVersion === null) return null;
+
+  const outdatedFeatures = Object.entries(FEATURE_GATES).filter(
+    ([id]) => !isCoreFeatureAvailable(id, coreVersion),
+  );
+
+  if (outdatedFeatures.length === 0) return null;
+
+  const highestRequired = outdatedFeatures.reduce((max, [, gate]) => {
+    return compareVersions(gate.since, max) > 0 ? gate.since : max;
+  }, "0.0.0");
+
+  return (
+    <div role="alert" aria-live="polite">
+      <Card className="border-yellow-500/40 bg-yellow-500/10">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <TriangleAlert
+              size={18}
+              className="text-warning shrink-0"
+              aria-hidden="true"
+            />
+            <p className="text-warning text-sm font-medium">
+              {t("settings.coreOutdated.title", { version: highestRequired })}
+            </p>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {t("settings.coreOutdated.description")}
+          </p>
+          <ul className="text-muted-foreground list-inside list-disc text-sm">
+            {outdatedFeatures.map(([id, gate]) => (
+              <li key={id}>{t(gate.labelKey)}</li>
+            ))}
+          </ul>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/DeviceConnectionCard.tsx
+++ b/src/components/DeviceConnectionCard.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 import { Capacitor } from "@capacitor/core";
 import { ArrowLeftRightIcon, SearchIcon } from "lucide-react";
 import { useConnection } from "@/hooks/useConnection";
-import { CoreAPI, getDeviceAddress } from "@/lib/coreApi";
+import { getDeviceAddress } from "@/lib/coreApi";
+import { useStatusStore } from "@/lib/store";
 import { Card } from "./wui/Card";
 import { Button } from "./wui/Button";
 import { TextInput } from "./wui/TextInput";
@@ -31,17 +31,21 @@ export function DeviceConnectionCard({
   const { t } = useTranslation();
   const { isConnected } = useConnection();
 
-  // Fetch version info when connected
   const savedAddress = getDeviceAddress();
-  const { data: version, isLoading: isVersionLoading } = useQuery({
-    queryKey: ["version", savedAddress],
-    queryFn: () => CoreAPI.version(),
-    enabled: isConnected && !!savedAddress,
-  });
+  const coreVersion = useStatusStore((state) => state.coreVersion);
+  const corePlatform = useStatusStore((state) => state.corePlatform);
+  const coreVersionPending = useStatusStore(
+    (state) => state.coreVersionPending,
+  );
 
-  // Settings page shows version/platform info as subtitle
-  const connectedSubtitle = version
-    ? `${version.platform} (${/^\d+\.\d+\.\d+/.test(version.version) ? "v" : ""}${version.version})`
+  const versionLabel =
+    coreVersion !== null
+      ? `${/^\d+\.\d+\.\d+/.test(coreVersion) ? "v" : ""}${coreVersion}`
+      : undefined;
+  const connectedSubtitle = versionLabel
+    ? corePlatform
+      ? `${corePlatform} (${versionLabel})`
+      : versionLabel
     : undefined;
 
   return (
@@ -68,7 +72,7 @@ export function DeviceConnectionCard({
           <ConnectionStatusDisplay
             connectionError={connectionError}
             connectedSubtitle={connectedSubtitle}
-            connectedSubtitleLoading={isVersionLoading}
+            connectedSubtitleLoading={isConnected && coreVersionPending}
             action={
               <div className="flex items-center gap-1">
                 {/* Network scan button - only on native platforms */}

--- a/src/components/GatedFeature.tsx
+++ b/src/components/GatedFeature.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { type FeatureId } from "@/lib/featureGates";
+import { useCoreFeature } from "@/hooks/useCoreFeature";
+
+interface GatedFeatureProps {
+  featureId: FeatureId;
+  children: ReactNode;
+}
+
+// Conditionally renders children based on Core feature availability.
+// - Non-marquee unavailable: renders nothing (hide silently).
+// - Marquee unavailable: renders children visually disabled with a tooltip.
+// - Available: renders children unchanged.
+export function GatedFeature({ featureId, children }: GatedFeatureProps) {
+  const { t } = useTranslation();
+  const { available, requiredVersion, marquee } = useCoreFeature(featureId);
+
+  if (available) return <>{children}</>;
+
+  if (!marquee) return null;
+
+  return (
+    <div
+      title={t("features.requiresCoreVersion", { version: requiredVersion })}
+      aria-label={t("features.requiresCoreVersion", {
+        version: requiredVersion,
+      })}
+      className="cursor-not-allowed"
+    >
+      <div className="pointer-events-none opacity-50">{children}</div>
+    </div>
+  );
+}

--- a/src/hooks/useCoreFeature.ts
+++ b/src/hooks/useCoreFeature.ts
@@ -1,0 +1,30 @@
+import { useStatusStore } from "@/lib/store";
+import {
+  FEATURE_GATES,
+  type FeatureId,
+  isCoreFeatureAvailable,
+} from "@/lib/featureGates";
+
+interface CoreFeatureResult {
+  available: boolean;
+  requiredVersion: string;
+  currentVersion: string | null;
+  marquee: boolean;
+}
+
+export function useCoreFeature(id: FeatureId): CoreFeatureResult {
+  const coreVersion = useStatusStore((state) => state.coreVersion);
+  const coreVersionPending = useStatusStore(
+    (state) => state.coreVersionPending,
+  );
+  const gate = FEATURE_GATES[id];
+  // When version is unknown (null or still loading), treat as available so we
+  // don't falsely show features as "outdated" — consistent with CoreOutdatedNotice.
+  const versionUnknown = coreVersion === null || coreVersionPending;
+  return {
+    available: versionUnknown || isCoreFeatureAvailable(id, coreVersion),
+    requiredVersion: gate?.since ?? "",
+    currentVersion: coreVersion,
+    marquee: gate?.marquee ?? false,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -212,6 +212,9 @@
   .text-error {
     color: var(--color-error);
   }
+  .text-warning {
+    color: var(--color-warning);
+  }
   .text-primary {
     color: var(--color-primary);
   }
@@ -326,6 +329,7 @@
   --color-primary: #3faeec;
   --color-success: #36d24f;
   --color-error: #e87171;
+  --color-warning: #facc15;
   --color-border-filled: rgba(255, 255, 255, 0.4);
   --color-border-outline: #b4bbd9;
   --color-border-input: #9197ae;

--- a/src/lib/coreVersion.ts
+++ b/src/lib/coreVersion.ts
@@ -1,0 +1,43 @@
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+// Mirrors Core's config.IsDevelopmentVersion logic.
+// Treats empty, "DEVELOPMENT", pre-release suffixes, and unrecognised formats as
+// dev builds, which automatically satisfy all feature gates.
+export function isDevelopmentVersion(raw: string): boolean {
+  if (!raw || raw === "DEVELOPMENT") return true;
+  if (
+    raw.includes("-dev") ||
+    raw.includes("-rc") ||
+    raw.includes("-beta") ||
+    raw.includes("-alpha")
+  )
+    return true;
+  return !SEMVER_RE.test(raw);
+}
+
+export function parseVersion(
+  raw: string,
+): { major: number; minor: number; patch: number } | null {
+  const m = SEMVER_RE.exec(raw);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  if (pa.major !== pb.major) return pa.major > pb.major ? 1 : -1;
+  if (pa.minor !== pb.minor) return pa.minor > pb.minor ? 1 : -1;
+  if (pa.patch !== pb.patch) return pa.patch > pb.patch ? 1 : -1;
+  return 0;
+}
+
+// Returns true when `current` is at or above `minimum`.
+// null current → false (unknown version, conservatively deny).
+// Dev build → true (dev builds pass every gate).
+export function satisfies(current: string | null, minimum: string): boolean {
+  if (current === null) return false;
+  if (isDevelopmentVersion(current)) return true;
+  return compareVersions(current, minimum) >= 0;
+}

--- a/src/lib/coreVersion.ts
+++ b/src/lib/coreVersion.ts
@@ -36,8 +36,10 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
 // Returns true when `current` is at or above `minimum`.
 // null current → false (unknown version, conservatively deny).
 // Dev build → true (dev builds pass every gate).
+// Malformed minimum → false (bad gate definition, conservatively deny).
 export function satisfies(current: string | null, minimum: string): boolean {
   if (current === null) return false;
   if (isDevelopmentVersion(current)) return true;
+  if (!parseVersion(minimum)) return false;
   return compareVersions(current, minimum) >= 0;
 }

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -1,0 +1,28 @@
+import { satisfies as versionSatisfies } from "./coreVersion";
+
+type FeatureGate = { since: string; marquee: boolean; labelKey: string };
+
+// Feature gate registry.
+//
+// Add an entry here when a new Core feature is being introduced and the app
+// needs to gracefully degrade on older Core versions during the migration period.
+//
+// Fields:
+//   since    – minimum Core version that supports this feature (semver string)
+//   marquee  – when true, show the UI element disabled with a tooltip instead of hiding it
+//   labelKey – i18n key used to name this feature in the "Core outdated" settings notice
+//
+// Example entry (uncomment and populate when gating a real feature):
+//   screenshot: { since: "2.0.0", marquee: true, labelKey: "features.screenshot" },
+export const FEATURE_GATES: Record<string, FeatureGate> = {};
+
+export type FeatureId = keyof typeof FEATURE_GATES;
+
+export function isCoreFeatureAvailable(
+  id: FeatureId,
+  version: string | null,
+): boolean {
+  const gate = FEATURE_GATES[id];
+  if (!gate) return true;
+  return versionSatisfies(version, gate.since);
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -83,6 +83,13 @@ interface StatusState {
   writeQueue: string;
   setWriteQueue: (writeQueue: string) => void;
 
+  coreVersion: string | null;
+  corePlatform: string | null;
+  setCoreVersion: (version: string | null) => void;
+  setCorePlatform: (platform: string | null) => void;
+  coreVersionPending: boolean;
+  setCoreVersionPending: (pending: boolean) => void;
+
   resetConnectionState: () => void;
 }
 
@@ -196,6 +203,13 @@ export const useStatusStore = create<StatusState>()((set) => ({
   writeQueue: "",
   setWriteQueue: (writeQueue) => set({ writeQueue }),
 
+  coreVersion: null,
+  corePlatform: null,
+  setCoreVersion: (version) => set({ coreVersion: version }),
+  setCorePlatform: (platform) => set({ corePlatform: platform }),
+  coreVersionPending: false,
+  setCoreVersionPending: (pending) => set({ coreVersionPending: pending }),
+
   resetConnectionState: () => {
     // Reset all connection-related state
     set({
@@ -223,6 +237,9 @@ export const useStatusStore = create<StatusState>()((set) => ({
         mediaName: "",
         mediaPath: "",
       },
+      coreVersion: null,
+      corePlatform: null,
+      coreVersionPending: false,
     });
   },
 }));

--- a/src/routes/settings.index.tsx
+++ b/src/routes/settings.index.tsx
@@ -19,6 +19,7 @@ import { ExternalIcon, NextIcon } from "@/lib/images";
 import { getDeviceAddress, setDeviceAddress, CoreAPI } from "@/lib/coreApi.ts";
 import { MediaDatabaseCard } from "@/components/MediaDatabaseCard";
 import { DeviceConnectionCard } from "@/components/DeviceConnectionCard";
+import { CoreOutdatedNotice } from "@/components/CoreOutdatedNotice";
 
 export const Route = createFileRoute("/settings/")({
   component: Settings,
@@ -101,6 +102,8 @@ function Settings() {
               onScanClick={() => setScanOpen(true)}
             />
           </div>
+
+          <CoreOutdatedNotice />
 
           {/* Device History Modal */}
           <SlideModal

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -378,6 +378,10 @@
       },
       "connectionFailed": "Unable to connect to device",
       "notConnected": "Not connected",
+      "coreOutdated": {
+        "title": "Core update recommended (v{{version}}+)",
+        "description": "The connected device is running an older version of Zaparoo Core. The following features are unavailable:"
+      },
       "enterDeviceAddress": "Enter a device address",
       "deleteDevice": "Remove device from history",
       "about": {
@@ -598,6 +602,9 @@
     "connection": {
       "connecting": "Connecting...",
       "reconnecting": "Reconnecting..."
+    },
+    "features": {
+      "requiresCoreVersion": "Requires Zaparoo Core v{{version}} or later"
     },
     "deepLinks": {
       "invalidUrl": "Invalid link format"


### PR DESCRIPTION
- Add `coreVersion.ts` with semver helpers (`isDevelopmentVersion`, `parseVersion`, `compareVersions`, `satisfies`) mirroring Core's `IsDevelopmentVersion` semantics — dev/rc/alpha/beta builds pass all gates automatically.
- Add `featureGates.ts` as a registry of minimum Core version requirements per feature; new features are gated by adding an entry with `since`, `marquee`, and `labelKey`.
- Add `useCoreFeature` hook and `GatedFeature` component to conditionally render version-gated UI — marquee features show disabled with a tooltip, non-marquee features hide silently.
- Add `CoreOutdatedNotice` component that renders automatically in Settings when the connected Core is below any gate's minimum version.
- Fetch Core version once per connection in `ConnectionProvider.handleConnectionOpen`, store in `useStatusStore` (`coreVersion`, `corePlatform`, `coreVersionPending`); cleared on device switch via `resetConnectionState`.
- Remove the per-component `useQuery` version fetch from `DeviceConnectionCard` in favour of reading store state directly.
- Add `--color-warning` semantic token to `index.css` alongside the existing `--color-success`/`--color-error` tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core version gating: UI hides or marks features that require newer Core versions.
  * GatedFeature component and CoreOutdatedNotice added; notice shown on Settings when device Core is outdated.
  * Connection flow now surfaces Core version/platform to the UI and drives device status displays.

* **Documentation**
  * Added Core Version Gating docs and implementation guidance.

* **Translations**
  * Added English strings for outdated-core notice and requirement labels.

* **Style**
  * Added a warning color utility (.text-warning).

* **Tests**
  * New unit and integration tests covering gating, version logic, and UI notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->