### PR TITLE
feat(media): support paused indexing with resume action

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -12,7 +12,7 @@ import { ConnectionProvider } from "../../../components/ConnectionProvider";
 import { useConnection } from "../../../hooks/useConnection";
 import { connectionManager } from "../../../lib/transport";
 import { CoreAPI } from "../../../lib/coreApi";
-import { useStatusStore } from "@/lib/store";
+import { ConnectionState, useStatusStore } from "@/lib/store";
 import type { TransportState } from "../../../lib/transport/types";
 import type { NotificationRequest } from "../../../lib/coreApi";
 import { Notification } from "../../../lib/models";
@@ -843,7 +843,7 @@ describe("cancelled request handling", () => {
 });
 
 describe("API error handling", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     capturedEventHandlers = {};
     resetStore();
@@ -851,6 +851,9 @@ describe("API error handling", () => {
     vi.mocked(connectionManager.getActiveDeviceId).mockReturnValue(
       "192.168.1.100:7497",
     );
+    // Reset rate limiter so toast assertions aren't masked by inter-test cooldown.
+    const { resetToastRateLimiter } = await import("@/lib/toastUtils");
+    resetToastRateLimiter();
   });
 
   it("should handle media API failure gracefully", async () => {
@@ -899,6 +902,102 @@ describe("API error handling", () => {
 
     // Should not crash
     expect(screen.getByText("Test")).toBeInTheDocument();
+  });
+
+  it("should show error toast when media fetch fails while CONNECTED", async () => {
+    vi.mocked(CoreAPI.media).mockRejectedValueOnce(new Error("Network error"));
+
+    render(
+      <ConnectionProvider>
+        <div>Test</div>
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.any(String));
+    });
+  });
+
+  it("should suppress error toast when media fetch fails after RECONNECTING", async () => {
+    // Reject after we flip to RECONNECTING — simulates a transport flap that
+    // rejects pending requests via CoreAPI.reset() while reconnect is in flight.
+    let rejectMedia: (e: Error) => void = () => {};
+    vi.mocked(CoreAPI.media).mockReturnValueOnce(
+      new Promise<never>((_, rej) => {
+        rejectMedia = rej;
+      }),
+    );
+
+    render(
+      <ConnectionProvider>
+        <div>Test</div>
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(CoreAPI.media).toHaveBeenCalled();
+    });
+
+    // Flip the store to RECONNECTING before resolving the rejection.
+    useStatusStore.setState({
+      connectionState: ConnectionState.RECONNECTING,
+      connected: true,
+    });
+    rejectMedia(new Error("Request cancelled: connection reset"));
+
+    // Give the catch handler a chance to run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should suppress error toast when tokens fetch fails after RECONNECTING", async () => {
+    let rejectTokens: (e: Error) => void = () => {};
+    vi.mocked(CoreAPI.tokens).mockReturnValueOnce(
+      new Promise<never>((_, rej) => {
+        rejectTokens = rej;
+      }),
+    );
+
+    render(
+      <ConnectionProvider>
+        <div>Test</div>
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(CoreAPI.tokens).toHaveBeenCalled();
+    });
+
+    useStatusStore.setState({
+      connectionState: ConnectionState.RECONNECTING,
+      connected: true,
+    });
+    rejectTokens(new Error("Request cancelled: connection reset"));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -815,6 +815,90 @@ describe("cancelled request handling", () => {
     expect(screen.getByText("Test")).toBeInTheDocument();
   });
 
+  it("should retry media() once after a cancelled response on initial connect", async () => {
+    // Reconnect can race with the transport coming back up; the first call may
+    // resolve as cancelled (request reset). We schedule one delayed retry —
+    // without it the settings card and store stay stale until the next
+    // notification arrives.
+    const { isCancelled } = await import("../../../lib/coreApi");
+    vi.mocked(isCancelled)
+      .mockReturnValueOnce(true) // first call: cancelled, schedules retry
+      .mockReturnValue(false); // retry: not cancelled, processed normally
+    vi.mocked(CoreAPI.media)
+      .mockResolvedValueOnce({ cancelled: true } as any)
+      .mockResolvedValueOnce({
+        database: { exists: true, indexing: false },
+        active: [],
+      } as any);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+        state: "connected",
+        hasData: false,
+        hasConnectedBefore: false,
+      });
+
+      await waitFor(() => {
+        expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+      });
+
+      // Advance past the 500ms scheduled retry.
+      await vi.advanceTimersByTimeAsync(600);
+
+      await waitFor(() => {
+        expect(CoreAPI.media).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+      vi.mocked(isCancelled).mockReturnValue(false);
+    }
+  });
+
+  it("should clear a pending media retry timer on unmount", async () => {
+    // If the user switches devices while a retry is pending the timer must
+    // not fire and write stale data into the new connection's store.
+    const { isCancelled } = await import("../../../lib/coreApi");
+    vi.mocked(isCancelled).mockReturnValueOnce(true);
+    vi.mocked(CoreAPI.media).mockResolvedValueOnce({ cancelled: true } as any);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      const { unmount } = render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+        state: "connected",
+        hasData: false,
+        hasConnectedBefore: false,
+      });
+
+      await waitFor(() => {
+        expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+
+      // Even after the retry window, no second call — the cleanup cleared it.
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      vi.mocked(isCancelled).mockReturnValue(false);
+    }
+  });
+
   it("should handle cancelled tokens response gracefully", async () => {
     vi.mocked(CoreAPI.tokens).mockResolvedValueOnce({
       cancelled: true,

--- a/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
+++ b/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
@@ -377,6 +377,41 @@ describe("MediaDatabaseCard", () => {
     expect(CoreAPI.mediaGenerateResume).toHaveBeenCalledOnce();
   });
 
+  it("should re-enable the Resume button after a failed resume so user can retry", async () => {
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: false,
+      totalFiles: 0,
+      currentStep: 2,
+      totalSteps: 11,
+      currentStepDisplay: "Atari 2600",
+      paused: true,
+    };
+    const { CoreAPI } = await import("../../../lib/coreApi");
+    vi.mocked(CoreAPI.mediaGenerateResume).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    render(<MediaDatabaseCard />);
+
+    const resumeButton = screen.getByRole("button", {
+      name: /settings\.updateDb\.resume/i,
+    });
+    fireEvent.click(resumeButton);
+
+    // Once the rejection settles, the button must return to "Resume" (enabled),
+    // not stay stuck in "Resuming…" — otherwise the user can't try again.
+    await vi.waitFor(() => {
+      expect(CoreAPI.mediaGenerateResume).toHaveBeenCalledOnce();
+    });
+    await vi.waitFor(() => {
+      const button = screen.getByRole("button", {
+        name: /settings\.updateDb\.resume/i,
+      });
+      expect(button).not.toBeDisabled();
+    });
+  });
+
   it("should show Reconnecting indicator when reconnecting mid-index", () => {
     // Real reconnect path: store.connected stays true during RECONNECTING
     // (see src/lib/store.ts) — only connectionState distinguishes the live

--- a/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
+++ b/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../../../lib/coreApi", () => ({
   CoreAPI: {
     mediaGenerate: vi.fn(),
     mediaGenerateCancel: vi.fn(),
+    mediaGenerateResume: vi.fn(),
     media: vi.fn(),
   },
 }));
@@ -33,25 +34,47 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 });
 
 // Mock zustand store
-const mockStore = {
-  connected: true,
-  gamesIndex: {
-    indexing: false,
-    exists: true,
-    totalFiles: 100,
-    currentStep: 0,
-    totalSteps: 0,
-    currentStepDisplay: "",
-  },
-  safeInsets: {
-    top: "0px",
-    bottom: "0px",
-    left: "0px",
-    right: "0px",
-  },
-};
+const { ConnectionState, mockStore } = vi.hoisted(() => {
+  const ConnectionState = {
+    IDLE: "IDLE",
+    CONNECTING: "CONNECTING",
+    CONNECTED: "CONNECTED",
+    RECONNECTING: "RECONNECTING",
+    DISCONNECTING: "DISCONNECTING",
+    DISCONNECTED: "DISCONNECTED",
+    ERROR: "ERROR",
+  } as const;
+  const mockStore = {
+    connected: true,
+    connectionState: ConnectionState.CONNECTED as string,
+    gamesIndex: {
+      indexing: false,
+      exists: true,
+      totalFiles: 100,
+      currentStep: 0,
+      totalSteps: 0,
+      currentStepDisplay: "",
+    } as {
+      indexing: boolean;
+      exists: boolean;
+      totalFiles: number;
+      currentStep: number;
+      totalSteps: number;
+      currentStepDisplay: string;
+      paused?: boolean;
+    },
+    safeInsets: {
+      top: "0px",
+      bottom: "0px",
+      left: "0px",
+      right: "0px",
+    },
+  };
+  return { ConnectionState, mockStore };
+});
 
 vi.mock("../../../lib/store", () => ({
+  ConnectionState,
   useStatusStore: (selector: any) => selector(mockStore),
 }));
 
@@ -60,6 +83,7 @@ describe("MediaDatabaseCard", () => {
     vi.clearAllMocks();
     // Reset mock store state
     mockStore.connected = true;
+    mockStore.connectionState = ConnectionState.CONNECTED;
     mockStore.gamesIndex = {
       indexing: false,
       exists: true,
@@ -226,20 +250,157 @@ describe("MediaDatabaseCard", () => {
     expect(screen.getAllByText("toast.preparingDb").length).toBeGreaterThan(0);
   });
 
-  it("should show writing message when on final step", () => {
+  it("should render core-supplied step text verbatim when currentStep===totalSteps", () => {
+    // Regression: previously the card hardcoded toast.writingDb whenever
+    // currentStep===totalSteps, hiding Core's split phases (Writing database /
+    // Creating indexes / Building search caches).
     mockStore.gamesIndex = {
       indexing: true,
       exists: true,
       totalFiles: 100,
       currentStep: 10,
       totalSteps: 10,
-      currentStepDisplay: "Finalizing",
+      currentStepDisplay: "Building search caches",
     };
 
     render(<MediaDatabaseCard />);
 
-    // Text appears both in visible UI and aria-live announcement region
-    expect(screen.getAllByText("toast.writingDb").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Building search caches").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("toast.writingDb")).not.toBeInTheDocument();
+  });
+
+  it("should not render a stray '0' during phases where totalSteps is 0", () => {
+    // Regression: hasDetailedProgress used to short-circuit to the number 0
+    // when totalSteps was 0, which React rendered as the literal text "0"
+    // wherever the chain ended in JSX (notably in the spinner slot).
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: true,
+      totalFiles: 0,
+      currentStep: 0,
+      totalSteps: 0,
+      currentStepDisplay: "Finding media folders",
+    };
+
+    render(<MediaDatabaseCard />);
+
+    expect(screen.getAllByText("Finding media folders").length).toBeGreaterThan(
+      0,
+    );
+    // The progress card must not contain a bare "0" — only screen-reader
+    // announce content lives outside the card.
+    expect(
+      screen.queryByText((_, el) => (el?.textContent ?? "").trim() === "0"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should hide the spinner during phase steps (currentStep===0)", () => {
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: true,
+      totalFiles: 0,
+      currentStep: 0,
+      totalSteps: 0,
+      currentStepDisplay: "Initializing database",
+    };
+
+    render(<MediaDatabaseCard />);
+
+    expect(
+      screen.queryByRole("status", { name: "Loading" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should hide the spinner during the writing phase (currentStep===totalSteps)", () => {
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: true,
+      totalFiles: 100,
+      currentStep: 11,
+      totalSteps: 11,
+      currentStepDisplay: "Writing database",
+    };
+
+    render(<MediaDatabaseCard />);
+
+    expect(
+      screen.queryByRole("status", { name: "Loading" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the spinner during per-system steps", () => {
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: true,
+      totalFiles: 50,
+      currentStep: 3,
+      totalSteps: 11,
+      currentStepDisplay: "Nintendo Entertainment System",
+    };
+
+    render(<MediaDatabaseCard />);
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("should show Resume button and call mediaGenerateResume when paused", async () => {
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: false,
+      totalFiles: 0,
+      currentStep: 2,
+      totalSteps: 11,
+      currentStepDisplay: "Atari 2600",
+      paused: true,
+    };
+    const { CoreAPI } = await import("../../../lib/coreApi");
+    vi.mocked(CoreAPI.mediaGenerateResume).mockResolvedValue(undefined);
+
+    render(<MediaDatabaseCard />);
+
+    expect(
+      screen.getAllByText("settings.updateDb.status.paused").length,
+    ).toBeGreaterThan(0);
+    const resumeButton = screen.getByRole("button", {
+      name: /settings\.updateDb\.resume/i,
+    });
+    expect(resumeButton).toBeInTheDocument();
+
+    // No cancel button while paused
+    expect(
+      screen.queryByRole("button", { name: /settings\.updateDb\.cancel/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(resumeButton);
+    expect(CoreAPI.mediaGenerateResume).toHaveBeenCalledOnce();
+  });
+
+  it("should show Reconnecting indicator when reconnecting mid-index", () => {
+    // Real reconnect path: store.connected stays true during RECONNECTING
+    // (see src/lib/store.ts) — only connectionState distinguishes the live
+    // CONNECTED state from a transient drop.
+    mockStore.connected = true;
+    mockStore.connectionState = ConnectionState.RECONNECTING;
+    mockStore.gamesIndex = {
+      indexing: true,
+      exists: false,
+      totalFiles: 10,
+      currentStep: 4,
+      totalSteps: 11,
+      currentStepDisplay: "Sega Genesis",
+    };
+
+    render(<MediaDatabaseCard />);
+
+    expect(
+      screen.getAllByText("settings.updateDb.status.reconnecting").length,
+    ).toBeGreaterThan(0);
+    // Spinner is suppressed while reconnecting — updates are paused.
+    expect(
+      screen.queryByRole("status", { name: "Loading" }),
+    ).not.toBeInTheDocument();
   });
 
   it("should show cancel button when indexing", () => {

--- a/src/__tests__/unit/components/MediaIndexingToast.test.tsx
+++ b/src/__tests__/unit/components/MediaIndexingToast.test.tsx
@@ -61,13 +61,18 @@ describe("MediaIndexingToast", () => {
     expect(screen.getByText("toast.preparingDb")).toBeInTheDocument();
   });
 
-  it("should display writing message when at final step", () => {
+  it("should render Core-supplied step text verbatim, even when Step===Total", () => {
+    // Regression: previously the toast hardcoded toast.writingDb whenever
+    // currentStep===totalSteps, hiding Core's split phases (Writing database /
+    // Creating indexes / Building search caches).
     mockGamesIndex.currentStep = 10;
     mockGamesIndex.totalSteps = 10;
+    mockGamesIndex.currentStepDisplay = "Building search caches";
 
     render(<MediaIndexingToast id="test-id" setHideToast={mockSetHideToast} />);
 
-    expect(screen.getByText("toast.writingDb")).toBeInTheDocument();
+    expect(screen.getByText("Building search caches")).toBeInTheDocument();
+    expect(screen.queryByText("toast.writingDb")).not.toBeInTheDocument();
   });
 
   it("should render Hide button", () => {

--- a/src/__tests__/unit/coreApi.api-contract.test.ts
+++ b/src/__tests__/unit/coreApi.api-contract.test.ts
@@ -75,6 +75,16 @@ describe("CoreAPI API Contract", () => {
       const sentData = JSON.parse(mockSend.mock.calls[0]![0]);
       expect(sentData.method).toBe("settings");
     });
+
+    it("mediaGenerateResume should send correct JSON-RPC format", async () => {
+      const promise = CoreAPI.mediaGenerateResume();
+      simulateResponse(mockSend, null);
+      await promise;
+
+      const sentData = JSON.parse(mockSend.mock.calls[0]![0]);
+      expect(sentData.method).toBe("media.generate.resume");
+      expect(sentData.params).toBeUndefined();
+    });
   });
 
   describe("Error Handling", () => {

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -65,6 +65,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   const isInitialized = useRef(false);
   // Track current connection to prevent stale events from old connections
   const currentConnectionId = useRef<string | null>(null);
+  // Pending media-fetch retry; cleared on cleanup so a stale connection
+  // can't write its state into the freshly-mounted one.
+  const mediaRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pairing modal is auto-opened when the transport reports the server requires
   // encryption (or rejects our credentials). Closed on success or user dismiss.
   const [pairingOpen, setPairingOpen] = useState(false);
@@ -362,30 +365,66 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           });
       });
 
-    // Fetch media information
-    CoreAPI.media()
-      .then((v) => {
-        // Skip processing if request was cancelled (stale, aborted, or connection reset)
-        if (isCancelled(v)) {
-          logger.log("Media request was cancelled, skipping");
-          return;
-        }
-        try {
-          setGamesIndex(v.database);
-          const firstActive = v.active[0];
-          if (firstActive) {
-            setPlaying(firstActive);
+    // Fetch media information so the in-memory gamesIndex reflects whatever
+    // state Core is in right now (e.g. an indexing run that started while we
+    // were disconnected). Also drop any cached ["media"] query so the settings
+    // card refetches.
+    queryClient.invalidateQueries({ queryKey: ["media"] });
+
+    const fetchMediaState = (retryDelayMs: number) => {
+      const scheduledFor = currentConnectionId.current;
+      CoreAPI.media()
+        .then((v) => {
+          if (isCancelled(v)) {
+            logger.log("Media request was cancelled, retrying once");
+            // The first call after a reconnect can race with the transport
+            // re-coming up; one delayed retry is enough to catch up.
+            if (retryDelayMs > 0) {
+              if (mediaRetryTimer.current) {
+                clearTimeout(mediaRetryTimer.current);
+              }
+              mediaRetryTimer.current = setTimeout(() => {
+                mediaRetryTimer.current = null;
+                // Bail if the connection has changed under us — otherwise
+                // we'd write a stale connection's state into a newer one.
+                if (currentConnectionId.current !== scheduledFor) {
+                  return;
+                }
+                fetchMediaState(0);
+              }, retryDelayMs);
+            }
+            return;
           }
-        } catch (e) {
-          logger.error("Error processing media data:", e);
-          toast.error(t("error", { msg: "Failed to process media data" }));
-        }
-      })
-      .catch((e) => {
-        logger.error("Failed to get media information:", e);
-        // Use rate-limited toast to prevent spam on connection issues
-        showRateLimitedErrorToast(t("error", { msg: "Failed to fetch media" }));
-      });
+          try {
+            setGamesIndex(v.database);
+            const firstActive = v.active[0];
+            if (firstActive) {
+              setPlaying(firstActive);
+            }
+          } catch (e) {
+            logger.error("Error processing media data:", e);
+            toast.error(t("error", { msg: "Failed to process media data" }));
+          }
+        })
+        .catch((e) => {
+          logger.error("Failed to get media information:", e);
+          // Suppress the toast unless we're actually live-connected — the
+          // connection-state UI already conveys reconnect/disconnect, and
+          // WS transport flapping makes these rejections common. (Note: the
+          // store's `connected` flag stays true during RECONNECTING, so we
+          // intentionally check `connectionState` here, not `connected`.)
+          if (
+            useStatusStore.getState().connectionState ===
+            ConnectionState.CONNECTED
+          ) {
+            showRateLimitedErrorToast(
+              t("error", { msg: "Failed to fetch media" }),
+            );
+          }
+        });
+    };
+
+    fetchMediaState(500);
 
     // Fetch tokens information
     CoreAPI.tokens()
@@ -406,10 +445,14 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       })
       .catch((e) => {
         logger.error("Failed to get tokens information:", e);
-        // Use rate-limited toast to prevent spam on connection issues
-        showRateLimitedErrorToast(
-          t("error", { msg: "Failed to fetch tokens" }),
-        );
+        if (
+          useStatusStore.getState().connectionState ===
+          ConnectionState.CONNECTED
+        ) {
+          showRateLimitedErrorToast(
+            t("error", { msg: "Failed to fetch tokens" }),
+          );
+        }
       });
   }, [
     setConnectionError,
@@ -422,6 +465,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setCoreVersion,
     setCorePlatform,
     setCoreVersionPending,
+    queryClient,
     t,
   ]);
 
@@ -666,6 +710,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       // Clear connection ID if it's still ours (prevents race with new connection)
       if (currentConnectionId.current === connectionId) {
         currentConnectionId.current = null;
+      }
+      // Drop any pending media retry so it can't fire against the next connection.
+      if (mediaRetryTimer.current) {
+        clearTimeout(mediaRetryTimer.current);
+        mediaRetryTimer.current = null;
       }
       // Reset CoreAPI to clear any pending requests for this connection
       CoreAPI.reset();

--- a/src/components/MediaDatabaseCard.tsx
+++ b/src/components/MediaDatabaseCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useStatusStore } from "@/lib/store";
+import { ConnectionState, useStatusStore } from "@/lib/store";
 import { CoreAPI } from "@/lib/coreApi";
 import { DatabaseIcon } from "@/lib/images";
 import { logger } from "@/lib/logger";
@@ -15,21 +15,35 @@ export function MediaDatabaseCard() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const connected = useStatusStore((state) => state.connected);
+  const connectionState = useStatusStore((state) => state.connectionState);
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
+  const isLiveConnected = connectionState === ConnectionState.CONNECTED;
   const [cancelRequested, setCancelRequested] = useState(false);
+  const [resumeRequested, setResumeRequested] = useState(false);
   const [selectedSystems, setSelectedSystems] = useState<string[]>([]);
   const [systemSelectorOpen, setSystemSelectorOpen] = useState(false);
 
+  const isPaused = gamesIndex.paused === true;
+
   // Derive isCancelling: true only if we requested cancel AND indexing is still happening
   const isCancelling = cancelRequested && gamesIndex.indexing;
+  // Derive isResuming: true only if we requested resume AND indexing is still paused
+  const isResuming = resumeRequested && isPaused;
 
-  // Reset cancel request when indexing stops (syncing with external Zustand store state)
+  // Reset cancel/resume request when state changes (syncing with external Zustand store state)
   useEffect(() => {
     if (!gamesIndex.indexing && cancelRequested) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing local UI state with external store
       setCancelRequested(false);
     }
   }, [gamesIndex.indexing, cancelRequested]);
+
+  useEffect(() => {
+    if ((!isPaused || !gamesIndex.indexing) && resumeRequested) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing local UI state with external store
+      setResumeRequested(false);
+    }
+  }, [isPaused, gamesIndex.indexing, resumeRequested]);
 
   // Fetch real-time database status
   const { data: mediaStatus, isLoading } = useQuery({
@@ -79,10 +93,33 @@ export function MediaDatabaseCard() {
     }
   };
 
+  const handleResumeUpdate = async () => {
+    setResumeRequested(true);
+    try {
+      await CoreAPI.mediaGenerateResume();
+      queryClient.invalidateQueries({ queryKey: ["media"] });
+    } catch (error) {
+      logger.error("Failed to resume media generation:", error, {
+        category: "api",
+        action: "mediaGenerateResume",
+        severity: "warning",
+      });
+      setResumeRequested(false);
+    }
+  };
+
   // Check various states from both store and API
   const isOptimizing =
     gamesIndex.optimizing || mediaStatus?.database?.optimizing;
   const isIndexing = gamesIndex.indexing || mediaStatus?.database?.indexing;
+
+  // Display string for the current step. Core sends `currentStepDisplay` for
+  // every phase (folder discovery, per-system loop, writing, indexes, caches);
+  // empty/undefined means we haven't received the first notification yet.
+  const stepText =
+    gamesIndex.currentStepDisplay && gamesIndex.currentStepDisplay !== ""
+      ? gamesIndex.currentStepDisplay
+      : t("toast.preparingDb");
 
   const renderStatus = () => {
     // Check optimization status first - this takes priority
@@ -111,42 +148,37 @@ export function MediaDatabaseCard() {
 
     // Show progress when indexing (either from store or API)
     if (isIndexing) {
-      // Prefer gamesIndex data if available (has detailed progress), otherwise use generic preparing state
-      const hasDetailedProgress =
-        gamesIndex.indexing &&
-        gamesIndex.totalSteps &&
-        gamesIndex.totalSteps > 0;
+      const totalSteps = gamesIndex.totalSteps ?? 0;
+      const currentStep = gamesIndex.currentStep ?? 0;
+      const hasDetailedProgress = Boolean(
+        gamesIndex.indexing && totalSteps > 0,
+      );
+      const isSystemStep =
+        hasDetailedProgress && currentStep > 0 && currentStep < totalSteps;
+      const progressPercent = hasDetailedProgress
+        ? Math.round((currentStep / totalSteps) * 100)
+        : 0;
 
       return (
         <div className="mt-3 space-y-3">
           <div className="space-y-2">
             <div className="flex items-center justify-between text-sm">
-              <span>
-                {hasDetailedProgress && gamesIndex.currentStepDisplay
-                  ? gamesIndex.currentStep === gamesIndex.totalSteps
-                    ? t("toast.writingDb")
-                    : gamesIndex.currentStepDisplay
-                  : t("toast.preparingDb")}
-              </span>
-              {/* Only show spinner for system-specific steps (not preparing/writing) */}
-              {isIndexing &&
-                hasDetailedProgress &&
-                gamesIndex.currentStepDisplay &&
-                gamesIndex.currentStep !== gamesIndex.totalSteps && (
-                  <LoadingSpinner size={16} className="text-muted-foreground" />
-                )}
+              <span>{stepText}</span>
+              {/* Only show spinner for system-specific steps (not phase steps) */}
+              {isSystemStep && isLiveConnected && !isPaused ? (
+                <LoadingSpinner size={16} className="text-muted-foreground" />
+              ) : null}
             </div>
+            {(isPaused || !isLiveConnected) && (
+              <div className="text-muted-foreground text-xs">
+                {isPaused
+                  ? t("settings.updateDb.status.paused")
+                  : t("settings.updateDb.status.reconnecting")}
+              </div>
+            )}
             <div
               role="progressbar"
-              aria-valuenow={
-                hasDetailedProgress &&
-                gamesIndex.currentStep &&
-                gamesIndex.totalSteps
-                  ? Math.round(
-                      (gamesIndex.currentStep / gamesIndex.totalSteps) * 100,
-                    )
-                  : 0
-              }
+              aria-valuenow={progressPercent}
               aria-valuemin={0}
               aria-valuemax={100}
               aria-label={t("settings.updateDb.progressLabel")}
@@ -156,34 +188,39 @@ export function MediaDatabaseCard() {
                 className={classNames(
                   "border-background bg-button-pattern h-[8px] rounded-full border border-solid",
                   {
-                    hidden: hasDetailedProgress && gamesIndex.currentStep === 0,
+                    hidden: hasDetailedProgress && currentStep === 0,
                     "animate-pulse":
-                      !hasDetailedProgress ||
-                      gamesIndex.currentStep === 0 ||
-                      gamesIndex.currentStep === gamesIndex.totalSteps,
+                      isLiveConnected &&
+                      !isPaused &&
+                      (!hasDetailedProgress || !isSystemStep),
                   },
                 )}
                 style={{
-                  width:
-                    hasDetailedProgress &&
-                    gamesIndex.currentStep &&
-                    gamesIndex.totalSteps
-                      ? gamesIndex.currentStep === gamesIndex.totalSteps
-                        ? "100%" // Use static 100% to avoid iOS animation glitch
-                        : `${((gamesIndex.currentStep / gamesIndex.totalSteps) * 100).toFixed(2)}%`
-                      : "100%",
+                  width: hasDetailedProgress
+                    ? currentStep === 0
+                      ? "0%"
+                      : currentStep >= totalSteps
+                        ? "100%"
+                        : `${((currentStep / totalSteps) * 100).toFixed(2)}%`
+                    : "100%",
                 }}
               />
             </div>
           </div>
           <Button
             label={
-              isCancelling ? t("cancelling") : t("settings.updateDb.cancel")
+              isPaused
+                ? isResuming
+                  ? t("resuming")
+                  : t("settings.updateDb.resume")
+                : isCancelling
+                  ? t("cancelling")
+                  : t("settings.updateDb.cancel")
             }
             variant="outline"
             className="w-full"
-            disabled={!connected || isCancelling}
-            onClick={handleCancelUpdate}
+            disabled={!connected || (isPaused ? isResuming : isCancelling)}
+            onClick={isPaused ? handleResumeUpdate : handleCancelUpdate}
           />
         </div>
       );
@@ -247,16 +284,13 @@ export function MediaDatabaseCard() {
   const getStatusText = (): string => {
     if (isOptimizing) return t("settings.updateDb.status.optimizing");
     if (isIndexing) {
-      const hasDetailedProgress =
-        gamesIndex.indexing &&
-        gamesIndex.totalSteps &&
-        gamesIndex.totalSteps > 0;
-      if (hasDetailedProgress && gamesIndex.currentStepDisplay) {
-        return gamesIndex.currentStep === gamesIndex.totalSteps
-          ? t("toast.writingDb")
-          : gamesIndex.currentStepDisplay;
+      if (isPaused) {
+        return `${stepText} — ${t("settings.updateDb.status.paused")}`;
       }
-      return t("toast.preparingDb");
+      if (!isLiveConnected) {
+        return `${stepText} — ${t("settings.updateDb.status.reconnecting")}`;
+      }
+      return stepText;
     }
     return "";
   };

--- a/src/components/MediaIndexingToast.tsx
+++ b/src/components/MediaIndexingToast.tsx
@@ -26,10 +26,8 @@ export const MediaIndexingToast = (props: {
       <div className="flex grow flex-col pr-3">
         <div className="font-semibold">{t("toast.updateDbHeading")}</div>
         <div className="text-sm">
-          {gamesIndex.currentStepDisplay
-            ? gamesIndex.currentStep === gamesIndex.totalSteps
-              ? t("toast.writingDb")
-              : gamesIndex.currentStepDisplay
+          {gamesIndex.currentStepDisplay && gamesIndex.currentStepDisplay !== ""
+            ? gamesIndex.currentStepDisplay
             : t("toast.preparingDb")}
         </div>
         <div

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -766,6 +766,19 @@ class CoreApi {
     });
   }
 
+  mediaGenerateResume(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.call(Method.MediaGenerateResume)
+        .then(() => {
+          resolve();
+        })
+        .catch((error) => {
+          logger.error("Media generate resume API call failed:", error);
+          reject(error);
+        });
+    });
+  }
+
   systems(): Promise<SystemsResponse> {
     return new Promise<SystemsResponse>((resolve, reject) => {
       this.call(Method.Systems)

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -7,6 +7,7 @@ export enum Method {
   MediaSearch = "media.search",
   MediaGenerate = "media.generate",
   MediaGenerateCancel = "media.generate.cancel",
+  MediaGenerateResume = "media.generate.resume",
   MediaActive = "media.active",
   MediaActiveUpdate = "media.active.update",
   MediaTags = "media.tags",
@@ -192,6 +193,7 @@ export interface IndexResponse {
   exists: boolean;
   indexing: boolean;
   optimizing?: boolean;
+  paused?: boolean;
   totalSteps?: number;
   currentStep?: number;
   currentStepDisplay?: string;

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -6,6 +6,7 @@
     "error": "Error: {{msg}}",
     "loading": "Loading...",
     "cancelling": "Cancelling...",
+    "resuming": "Resuming...",
     "shareFailed": "Failed to share",
     "errorBoundary": {
       "title": "Oops, something really bad happened!",
@@ -61,7 +62,6 @@
     "toast": {
       "updateDbHeading": "Updating media database",
       "preparingDb": "Preparing database",
-      "writingDb": "Writing database to disk",
       "hideLabel": "Hide",
       "updatedDb": "Media database updated",
       "filesFound": "{{count}} items scanned",
@@ -357,8 +357,11 @@
       "insertMode": "Hold",
       "updateDb": "Update media database",
       "updateDb.cancel": "Cancel",
+      "updateDb.resume": "Resume",
       "updateDb.status.ready": "Database is ready",
       "updateDb.status.optimizing": "Optimizing database (ready to use)",
+      "updateDb.status.paused": "Paused",
+      "updateDb.status.reconnecting": "Reconnecting...",
       "updateDb.status.mediaCount": "Database ready: {{formattedCount}} media titles",
       "updateDb.status.noConnection": "Not connected",
       "updateDb.status.checking": "Checking database status...",


### PR DESCRIPTION
- Add `media.generate.resume` API method and surface a `paused` flag on `IndexResponse`.
- `MediaDatabaseCard` now shows paused/reconnecting status text, swaps the Cancel button for Resume while paused, and pauses the progress animation when not actively indexing.
- `ConnectionProvider` invalidates the `["media"]` query and refetches media state on (re)connect, with one delayed retry to avoid racing the transport coming back up.
- Suppress media/tokens fetch error toasts unless the WS is actually `CONNECTED` — the connection-state UI already conveys reconnect/disconnect, so flapping shouldn't spam toasts.
- Drop the special-case "writing database to disk" string — Core now sends `currentStepDisplay` for every phase, including the final write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause/resume for media indexing with a visible "Resume" / "Resuming..." flow and reconnecting indicator.

* **Bug Fixes**
  * Suppresses error toasts unless fully connected and clears pending retries when connections change to avoid stale updates.
  * Progress/spinner behavior refined at phase boundaries to avoid misleading UI.

* **Tests**
  * Expanded tests for connection transitions, toast behavior, resume flow, and retry/cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->