### PR TITLE
Gate media tags by Core version

### DIFF
--- a/src/__tests__/integration/create-search.test.tsx
+++ b/src/__tests__/integration/create-search.test.tsx
@@ -310,6 +310,8 @@ describe("Create Search Integration", () => {
       ...useStatusStore.getInitialState(),
       connected: true,
       connectionState: ConnectionState.CONNECTED,
+      coreVersion: "2.7.0",
+      coreVersionPending: false,
       gamesIndex: {
         exists: true,
         indexing: false,
@@ -1020,6 +1022,16 @@ describe("Create Search Integration", () => {
           "platformer, action",
         );
       });
+    });
+
+    it("should hide tag selector when Core does not support media tags", () => {
+      useStatusStore.setState({ coreVersion: "2.6.2" });
+
+      render(<Search />);
+
+      expect(
+        screen.queryByTestId("tag-selector-trigger"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/unit/featureGates.test.ts
+++ b/src/__tests__/unit/featureGates.test.ts
@@ -57,4 +57,10 @@ describe("isCoreFeatureAvailable", () => {
     expect(isCoreFeatureAvailable("mediaCleanOrphans", "2.11.9")).toBe(false);
     expect(isCoreFeatureAvailable("mediaCleanOrphans", "2.12.0")).toBe(true);
   });
+
+  it("should gate media tags behind Core 2.7.0", () => {
+    expect(FEATURE_GATES.mediaTags?.since).toBe("2.7.0");
+    expect(isCoreFeatureAvailable("mediaTags", "2.6.2")).toBe(false);
+    expect(isCoreFeatureAvailable("mediaTags", "2.7.0")).toBe(true);
+  });
 });

--- a/src/__tests__/unit/routes/create.search.test.tsx
+++ b/src/__tests__/unit/routes/create.search.test.tsx
@@ -278,6 +278,8 @@ describe("Search Component", () => {
     useStatusStore.setState({
       ...useStatusStore.getInitialState(),
       connected: true,
+      coreVersion: "2.7.0",
+      coreVersionPending: false,
       gamesIndex: { exists: true, indexing: false },
     });
     usePreferencesStore.setState({
@@ -427,6 +429,26 @@ describe("Search Component", () => {
         tags: [],
       });
     });
+
+    it("should ignore selected tags when Core stops supporting media tags", () => {
+      render(<Search />);
+
+      fireEvent.click(screen.getByTestId("tag-selector-trigger"));
+      fireEvent.click(screen.getByRole("button", { name: "Select Action" }));
+      useStatusStore.setState({ coreVersion: "2.6.2" });
+      fireEvent.change(screen.getByLabelText("create.search.gameInput"), {
+        target: { value: "mario" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: "create.search.searchButton" }),
+      );
+
+      expect(mockAddRecentSearch).toHaveBeenCalledWith({
+        query: "mario",
+        system: "all",
+        tags: [],
+      });
+    });
   });
 
   describe("system selector", () => {
@@ -507,6 +529,16 @@ describe("Search Component", () => {
       expect(screen.getByTestId("tag-selector-trigger")).toHaveTextContent(
         "action",
       );
+    });
+
+    it("should hide tag selector when Core does not support media tags", () => {
+      useStatusStore.setState({ coreVersion: "2.6.2" });
+
+      render(<Search />);
+
+      expect(
+        screen.queryByTestId("tag-selector-trigger"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -26,6 +26,11 @@ export const FEATURE_GATES: Record<string, FeatureGate> = {
     marquee: false,
     labelKey: "features.mediaCleanOrphans",
   },
+  mediaTags: {
+    since: "2.7.0",
+    marquee: false,
+    labelKey: "features.mediaTags",
+  },
   remoteInput: {
     since: "2.10.0",
     marquee: true,

--- a/src/routes/-pages/Search.tsx
+++ b/src/routes/-pages/Search.tsx
@@ -1,7 +1,6 @@
 import { getRouteApi, useRouter } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 import { Preferences } from "@capacitor/preferences";
 import { Capacitor } from "@capacitor/core";
 import classNames from "classnames";
@@ -41,6 +40,7 @@ import { TagSelector, TagSelectorTrigger } from "@/components/TagSelector";
 import { useRecentSearches } from "@/hooks/useRecentSearches";
 import { RecentSearchesModal } from "@/components/RecentSearchesModal";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
+import { isCoreFeatureAvailable } from "@/lib/featureGates";
 
 export interface LoaderData {
   systemQuery: string;
@@ -58,6 +58,10 @@ export function Search() {
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
   const setGamesIndex = useStatusStore((state) => state.setGamesIndex);
   const connected = useStatusStore((state) => state.connected);
+  const coreVersion = useStatusStore((state) => state.coreVersion);
+  const coreVersionPending = useStatusStore(
+    (state) => state.coreVersionPending,
+  );
   const showFilenames = usePreferencesStore((s) => s.showFilenames);
 
   const [querySystem, setQuerySystem] = useState(loaderData.systemQuery);
@@ -76,6 +80,11 @@ export function Search() {
   const [isSearching, setIsSearching] = useState(false);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const mediaTagsAvailable =
+    connected &&
+    !coreVersionPending &&
+    isCoreFeatureAvailable("mediaTags", coreVersion);
+  const effectiveQueryTags = mediaTagsAvailable ? queryTags : [];
 
   // Recent searches hook
   const {
@@ -99,14 +108,14 @@ export function Search() {
     setSearchParams({
       query: query,
       system: querySystem,
-      tags: queryTags,
+      tags: effectiveQueryTags,
     });
 
     try {
       await addRecentSearch({
         query: query,
         system: querySystem,
-        tags: queryTags,
+        tags: effectiveQueryTags,
       });
     } catch (e) {
       logger.warn("Failed to record recent search", e, {
@@ -178,14 +187,11 @@ export function Search() {
     }
   }, [selectedResult]);
 
-  // Check if tags API is available for backwards compatibility
-  const { isError: tagsApiError } = useQuery({
-    queryKey: ["tagsAvailable"],
-    queryFn: () => CoreAPI.mediaTags([]),
-    retry: false,
-    staleTime: 60000, // Cache for 1 minute
-    enabled: connected, // Only check when connected
-  });
+  useEffect(() => {
+    if (!mediaTagsAvailable) {
+      setTagSelectorOpen(false);
+    }
+  }, [mediaTagsAvailable]);
 
   const router = useRouter();
   const goBack = () => router.history.back();
@@ -249,9 +255,10 @@ export function Search() {
   const handleRecentSearchSelect = async (
     recentSearch: (typeof recentSearches)[0],
   ) => {
+    const searchTags = mediaTagsAvailable ? recentSearch.tags : [];
     setQuery(recentSearch.query);
     setQuerySystem(recentSearch.system);
-    setQueryTags(recentSearch.tags);
+    setQueryTags(searchTags);
     setSelectedResult(null);
 
     // Save preferences to match the selected search
@@ -260,7 +267,7 @@ export function Search() {
         Preferences.set({ key: "searchSystem", value: recentSearch.system }),
         Preferences.set({
           key: "searchTags",
-          value: JSON.stringify(recentSearch.tags),
+          value: JSON.stringify(searchTags),
         }),
       ]);
     } catch (err) {
@@ -277,7 +284,7 @@ export function Search() {
       setSearchParams({
         query: recentSearch.query,
         system: recentSearch.system,
-        tags: recentSearch.tags,
+        tags: searchTags,
       });
     }
   };
@@ -351,21 +358,22 @@ export function Search() {
               />
             </div>
 
-            <div className="flex flex-col md:flex-1">
-              <label className="mb-1 text-white">
-                {t("create.search.tagsInput")}
-              </label>
-              <TagSelectorTrigger
-                selectedTags={queryTags}
-                placeholder={t("create.search.allTags")}
-                onClick={() => setTagSelectorOpen(true)}
-                disabled={tagsApiError}
-                className={classNames({
-                  "opacity-50":
-                    !connected || !gamesIndex.exists || gamesIndex.indexing,
-                })}
-              />
-            </div>
+            {mediaTagsAvailable && (
+              <div className="flex flex-col md:flex-1">
+                <label className="mb-1 text-white">
+                  {t("create.search.tagsInput")}
+                </label>
+                <TagSelectorTrigger
+                  selectedTags={queryTags}
+                  placeholder={t("create.search.allTags")}
+                  onClick={() => setTagSelectorOpen(true)}
+                  className={classNames({
+                    "opacity-50":
+                      !connected || !gamesIndex.exists || gamesIndex.indexing,
+                  })}
+                />
+              </div>
+            )}
           </div>
 
           <Button
@@ -691,14 +699,16 @@ export function Search() {
         includeAllOption={true}
         defaultSelection="all"
       />
-      <TagSelector
-        isOpen={tagSelectorOpen}
-        onClose={() => setTagSelectorOpen(false)}
-        onSelect={handleTagSelect}
-        selectedTags={queryTags}
-        systems={querySystem === "all" ? [] : [querySystem]}
-        title={t("create.search.selectTags")}
-      />
+      {mediaTagsAvailable && (
+        <TagSelector
+          isOpen={tagSelectorOpen}
+          onClose={() => setTagSelectorOpen(false)}
+          onSelect={handleTagSelect}
+          selectedTags={queryTags}
+          systems={querySystem === "all" ? [] : [querySystem]}
+          title={t("create.search.selectTags")}
+        />
+      )}
       <RecentSearchesModal
         isOpen={recentSearchesOpen}
         onClose={() => setRecentSearchesOpen(false)}

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -753,6 +753,7 @@
       "inbox": "Notifications",
       "mediaScrapers": "Scraper",
       "mediaCleanOrphans": "Clean missing media",
+      "mediaTags": "Media tags",
       "remoteInput": "Remote input"
     },
     "inbox": {


### PR DESCRIPTION
Summary:
- add a mediaTags Core feature gate for Core 2.7.0+
- hide Search tag filters when connected Core lacks media.tags support
- ignore selected/recent tag filters when unsupported

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media tags feature now requires Core version 2.7.0 or later

* **Bug Fixes**
  * Tag selector automatically hides for Core versions below 2.7.0
  * Search now safely ignores tags on unsupported Core versions

* **Tests**
  * Added version compatibility tests for media tags feature gate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->