### PR TITLE
Reduce auth monitoring noise

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { useLiveUpdate } from "./hooks/useLiveUpdate";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
 import { purchasesReady } from "./lib/purchasesSetup";
+import { isExpectedRevenueCatLogoutError } from "./lib/errors";
 import {
   A11yAnnouncerProvider,
   useAnnouncer,
@@ -289,9 +290,15 @@ export default function App() {
             }
           } else {
             // Revert to anonymous RevenueCat customer — only if not already anonymous
-            const { isAnonymous } = await Purchases.isAnonymous();
-            if (!isAnonymous) {
-              await Purchases.logOut();
+            try {
+              const { isAnonymous } = await Purchases.isAnonymous();
+              if (!isAnonymous) {
+                await Purchases.logOut();
+              }
+            } catch (e) {
+              if (!isExpectedRevenueCatLogoutError(e)) {
+                throw e;
+              }
             }
             const { customerInfo } = await Purchases.getCustomerInfo();
             const hasAccess =

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Purchases } from "@revenuecat/purchases-capacitor";
 import { ErrorComponent } from "@/components/ErrorComponent.tsx";
 import { InboxModal } from "@/components/InboxModal";
 import { StagedTokenModal } from "@/components/home/StagedTokenModal";
+import { isExpectedRevenueCatLogoutError } from "@/lib/errors";
 import { routeTree } from "./routeTree.gen";
 import { useStatusStore } from "./lib/store";
 import { DatabaseIcon, PlayIcon } from "./lib/images";
@@ -33,7 +34,6 @@ import { useLiveUpdate } from "./hooks/useLiveUpdate";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
 import { purchasesReady } from "./lib/purchasesSetup";
-import { isExpectedRevenueCatLogoutError } from "./lib/errors";
 import {
   A11yAnnouncerProvider,
   useAnnouncer,

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -661,6 +661,80 @@ describe("Firebase Auth Integration", () => {
       expect(mockPurchasesGetCustomerInfo).toHaveBeenCalled();
     });
 
+    it("should ignore expected RevenueCat logout state errors on sign out", async () => {
+      mockPlatform = "ios";
+      mockPurchasesLogOut.mockRejectedValueOnce(
+        new Error("Cannot log out anonymous app user"),
+      );
+      mockPurchasesGetCustomerInfo.mockResolvedValue({
+        customerInfo: { entitlements: { active: {} } },
+      });
+
+      let authCallback: ((change: { user: unknown }) => Promise<void>) | null =
+        null;
+      mockAddListener.mockImplementation(
+        (
+          _event: string,
+          callback: (change: { user: unknown }) => Promise<void>,
+        ) => {
+          authCallback = callback;
+          return Promise.resolve({ remove: mockRemove });
+        },
+      );
+
+      const App = (await import("@/App")).default;
+      render(<App />);
+
+      await waitFor(() => {
+        expect(authCallback).not.toBeNull();
+      });
+
+      await act(async () => {
+        await authCallback!({ user: null });
+      });
+
+      expect(mockPurchasesGetCustomerInfo).toHaveBeenCalled();
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it("should report unexpected RevenueCat logout errors on sign out", async () => {
+      mockPlatform = "ios";
+      const error = new Error("network connection lost");
+      mockPurchasesLogOut.mockRejectedValueOnce(error);
+
+      let authCallback: ((change: { user: unknown }) => Promise<void>) | null =
+        null;
+      mockAddListener.mockImplementation(
+        (
+          _event: string,
+          callback: (change: { user: unknown }) => Promise<void>,
+        ) => {
+          authCallback = callback;
+          return Promise.resolve({ remove: mockRemove });
+        },
+      );
+
+      const App = (await import("@/App")).default;
+      render(<App />);
+
+      await waitFor(() => {
+        expect(authCallback).not.toBeNull();
+      });
+
+      await act(async () => {
+        await authCallback!({ user: null });
+      });
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        "RevenueCat login sync failed:",
+        error,
+        expect.objectContaining({
+          category: "purchase",
+          action: "logOut",
+        }),
+      );
+    });
+
     it("should handle RevenueCat login failure gracefully", async () => {
       mockPlatform = "ios";
 

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -70,6 +70,7 @@ vi.mock("@/lib/logger", () => ({
 describe("RequirementsModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(window, "open").mockImplementation(() => null);
     // Reset the store state
     useRequirementsStore.setState({
       isOpen: false,
@@ -319,6 +320,79 @@ describe("RequirementsModal", () => {
     });
 
     expect(Purchases.logOut).not.toHaveBeenCalled();
+  });
+
+  it("should ignore expected RevenueCat logout state errors", async () => {
+    const { Purchases } = await import("@revenuecat/purchases-capacitor");
+    const { logger } = await import("@/lib/logger");
+    vi.mocked(Purchases.logOut).mockRejectedValueOnce(
+      new Error("Cannot log out anonymous app user"),
+    );
+
+    const requirements: PendingRequirement[] = [
+      {
+        type: "terms_acceptance",
+        description: "Accept terms",
+        endpoint: "/account/requirements",
+      },
+    ];
+
+    useRequirementsStore.setState({
+      isOpen: true,
+      pendingRequirements: requirements,
+    });
+
+    render(<RequirementsModal />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /requirements\.logout/i }),
+    );
+
+    const { FirebaseAuthentication } =
+      await import("@capacitor-firebase/authentication");
+    await waitFor(() => {
+      expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("should log unexpected RevenueCat logout errors", async () => {
+    const { Purchases } = await import("@revenuecat/purchases-capacitor");
+    const { logger } = await import("@/lib/logger");
+    const error = new Error("network connection lost");
+    vi.mocked(Purchases.logOut).mockRejectedValueOnce(error);
+
+    const requirements: PendingRequirement[] = [
+      {
+        type: "terms_acceptance",
+        description: "Accept terms",
+        endpoint: "/account/requirements",
+      },
+    ];
+
+    useRequirementsStore.setState({
+      isOpen: true,
+      pendingRequirements: requirements,
+    });
+
+    render(<RequirementsModal />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /requirements\.logout/i }),
+    );
+
+    const { FirebaseAuthentication } =
+      await import("@capacitor-firebase/authentication");
+    await waitFor(() => {
+      expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "RevenueCat logout failed:",
+      error,
+      expect.objectContaining({ action: "logOut" }),
+    );
   });
 
   it("should send verification email when button clicked", async () => {

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -344,7 +344,8 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    fireEvent.click(
+    const user = userEvent.setup();
+    await user.click(
       screen.getByRole("button", { name: /requirements\.logout/i }),
     );
 
@@ -378,7 +379,8 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    fireEvent.click(
+    const user = userEvent.setup();
+    await user.click(
       screen.getByRole("button", { name: /requirements\.logout/i }),
     );
 

--- a/src/__tests__/unit/lib/errors.test.ts
+++ b/src/__tests__/unit/lib/errors.test.ts
@@ -14,6 +14,8 @@ import {
   BarcodeScanCancelledError,
   PurchaseCancelledError,
   isCancellationError,
+  isExpectedEmailAuthError,
+  isExpectedRevenueCatLogoutError,
   isNfcError,
   wrapNfcError,
   wrapBarcodeScannerError,
@@ -257,6 +259,76 @@ describe("errors", () => {
       expect(isNfcError(null)).toBe(false);
       expect(isNfcError(undefined)).toBe(false);
       expect(isNfcError("error string")).toBe(false);
+    });
+  });
+
+  describe("isExpectedEmailAuthError", () => {
+    it("should return true for expected Firebase email auth message tokens", () => {
+      for (const token of [
+        "auth/invalid-credential",
+        "wrong-password",
+        "user-not-found",
+        "invalid-email",
+        "email-already-in-use",
+        "weak-password",
+      ]) {
+        expect(isExpectedEmailAuthError(new Error(`Firebase: ${token}`))).toBe(
+          true,
+        );
+      }
+    });
+
+    it("should return true for structured Firebase email auth codes", () => {
+      for (const code of [
+        "auth/invalid-credential",
+        "auth/wrong-password",
+        "auth/user-not-found",
+        "auth/invalid-email",
+        "auth/email-already-in-use",
+        "auth/weak-password",
+      ]) {
+        expect(isExpectedEmailAuthError({ code })).toBe(true);
+      }
+    });
+
+    it("should return false for unexpected auth failures", () => {
+      for (const error of [
+        new Error("network-request-failed"),
+        { code: "auth/internal-error" },
+        { code: "auth/too-many-requests" },
+        { message: "missing Firebase configuration" },
+        null,
+        undefined,
+      ]) {
+        expect(isExpectedEmailAuthError(error)).toBe(false);
+      }
+    });
+  });
+
+  describe("isExpectedRevenueCatLogoutError", () => {
+    it("should return true for expected anonymous-user logout states", () => {
+      for (const error of [
+        new Error("Cannot log out anonymous app user"),
+        new Error("Current user is already anonymous"),
+        { message: "No current user" },
+        { code: "credentials_unavailable" },
+        { userInfo: { readableErrorCode: "missing credentials" } },
+      ]) {
+        expect(isExpectedRevenueCatLogoutError(error)).toBe(true);
+      }
+    });
+
+    it("should return false for unexpected RevenueCat failures", () => {
+      for (const error of [
+        new Error("network connection lost"),
+        { code: "configuration_error" },
+        { message: "backend unavailable" },
+        { message: "failed to fetch customer info" },
+        null,
+        undefined,
+      ]) {
+        expect(isExpectedRevenueCatLogoutError(error)).toBe(false);
+      }
     });
   });
 

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -390,6 +390,47 @@ describe("Settings Online Route", () => {
       expect(mockPurchasesLogOut).not.toHaveBeenCalled();
     });
 
+    it("should ignore expected RevenueCat logout state errors on native platform", async () => {
+      const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
+      mockState.platform = "ios";
+      mockPurchasesLogOut.mockRejectedValueOnce(
+        new Error("Cannot log out anonymous app user"),
+      );
+
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "online.logout" }));
+
+      await waitFor(() => {
+        expect(mockFirebaseAuth.signOut).toHaveBeenCalled();
+      });
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("should log unexpected RevenueCat logout errors on native platform", async () => {
+      const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
+      mockState.platform = "ios";
+      const error = new Error("network connection lost");
+      mockPurchasesLogOut.mockRejectedValueOnce(error);
+
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "online.logout" }));
+
+      await waitFor(() => {
+        expect(mockFirebaseAuth.signOut).toHaveBeenCalled();
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "RevenueCat logout failed:",
+        error,
+        expect.objectContaining({ action: "logOut" }),
+      );
+    });
+
     it("should skip RevenueCat logout on web platform", async () => {
       const user = userEvent.setup();
       mockState.platform = "web";
@@ -604,10 +645,11 @@ describe("Settings Online Route", () => {
       });
     });
 
-    it("should show error toast on login failure", async () => {
+    it("should show error toast without logging expected login failure", async () => {
       const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
       mockFirebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(
-        new Error("Invalid credentials"),
+        new Error("auth/invalid-credential"),
       );
 
       renderComponent();
@@ -623,6 +665,7 @@ describe("Settings Online Route", () => {
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith("online.loginWrong");
       });
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("should signup with email and password when age confirmed", async () => {
@@ -701,8 +744,9 @@ describe("Settings Online Route", () => {
       ).not.toHaveBeenCalled();
     });
 
-    it("should show error on signup failure for email already in use", async () => {
+    it("should show error without logging expected signup failure for email already in use", async () => {
       const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
       mockFirebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(
         new Error("email-already-in-use"),
       );
@@ -723,10 +767,12 @@ describe("Settings Online Route", () => {
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith("online.emailExists");
       });
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
-    it("should show error on signup failure for weak password", async () => {
+    it("should show error without logging expected signup failure for weak password", async () => {
       const user = userEvent.setup();
+      const { logger } = await import("@/lib/logger");
       mockFirebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(
         new Error("weak-password"),
       );
@@ -747,6 +793,7 @@ describe("Settings Online Route", () => {
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith("online.weakPassword");
       });
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("should submit on Enter key press", async () => {

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -17,6 +17,7 @@ import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import { updateRequirements, getRequirements } from "@/lib/onlineApi";
 import { useStatusStore } from "@/lib/store";
 import { logger } from "@/lib/logger";
+import { isExpectedRevenueCatLogoutError } from "@/lib/errors";
 
 const TOS_URL = "https://zaparoo.com/terms";
 const PRIVACY_URL = "https://zaparoo.com/privacy";
@@ -117,11 +118,13 @@ export function RequirementsModal() {
           await Purchases.logOut();
         }
       } catch (e) {
-        logger.error("RevenueCat logout failed:", e, {
-          category: "purchase",
-          action: "logOut",
-          severity: "warning",
-        });
+        if (!isExpectedRevenueCatLogoutError(e)) {
+          logger.error("RevenueCat logout failed:", e, {
+            category: "purchase",
+            action: "logOut",
+            severity: "warning",
+          });
+        }
       }
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -86,6 +86,104 @@ export class PurchaseCancelledError extends ZaparooError {
 }
 
 // =============================================================================
+// Auth and RevenueCat State Errors
+// =============================================================================
+
+const EXPECTED_EMAIL_AUTH_TOKENS = [
+  "auth/invalid-credential",
+  "invalid-credential",
+  "auth/wrong-password",
+  "wrong-password",
+  "auth/user-not-found",
+  "user-not-found",
+  "auth/invalid-email",
+  "invalid-email",
+  "auth/email-already-in-use",
+  "email-already-in-use",
+  "auth/weak-password",
+  "weak-password",
+];
+
+const EXPECTED_REVENUECAT_LOGOUT_TOKENS = [
+  "already anonymous",
+  "current user is anonymous",
+  "anonymous app user",
+  "cannot log out anonymous",
+  "can't log out anonymous",
+  "cannot logout anonymous",
+  "can't logout anonymous",
+  "no current user",
+  "credentials unavailable",
+  "credentials_unavailable",
+  "credential unavailable",
+  "credential_unavailable",
+  "missing credentials",
+  "no credentials",
+];
+
+function collectErrorSearchStrings(error: unknown): string[] {
+  const strings: string[] = [];
+  const visited = new Set<unknown>();
+
+  const collect = (value: unknown): void => {
+    if (value == null || visited.has(value)) return;
+
+    if (typeof value === "string") {
+      strings.push(value.toLowerCase());
+      return;
+    }
+
+    if (typeof value !== "object") return;
+
+    visited.add(value);
+    if (value instanceof Error) {
+      strings.push(value.name.toLowerCase(), value.message.toLowerCase());
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const key of [
+      "code",
+      "name",
+      "message",
+      "readableErrorCode",
+      "underlyingErrorMessage",
+      "localizedDescription",
+      "domain",
+      "userInfo",
+      "error",
+    ]) {
+      collect(record[key]);
+    }
+  };
+
+  collect(error);
+  return strings;
+}
+
+function includesAnyToken(error: unknown, tokens: readonly string[]): boolean {
+  const searchStrings = collectErrorSearchStrings(error);
+  return tokens.some((token) =>
+    searchStrings.some((searchString) => searchString.includes(token)),
+  );
+}
+
+/**
+ * Check if Firebase email auth failed for expected user-facing reasons.
+ * These are login/signup states, not production monitoring events.
+ */
+export function isExpectedEmailAuthError(error: unknown): boolean {
+  return includesAnyToken(error, EXPECTED_EMAIL_AUTH_TOKENS);
+}
+
+/**
+ * Check if RevenueCat logout failed because auth state already moved anonymous.
+ * These races are expected during sign-out and should not report to monitoring.
+ */
+export function isExpectedRevenueCatLogoutError(error: unknown): boolean {
+  return includesAnyToken(error, EXPECTED_REVENUECAT_LOGOUT_TOKENS);
+}
+
+// =============================================================================
 // Type Guards
 // =============================================================================
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -121,7 +121,7 @@ const EXPECTED_REVENUECAT_LOGOUT_TOKENS = [
   "no credentials",
 ];
 
-function collectErrorSearchStrings(error: unknown): string[] {
+export function collectErrorSearchStrings(error: unknown): string[] {
   const strings: string[] = [];
   const visited = new Set<unknown>();
 

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -25,6 +25,7 @@ import { BackIcon, GoogleIcon, AppleIcon } from "@/lib/images";
 import { logger } from "@/lib/logger";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import {
+  collectErrorSearchStrings,
   isExpectedEmailAuthError,
   isExpectedRevenueCatLogoutError,
 } from "@/lib/errors";
@@ -64,39 +65,10 @@ const SIGNUP_EMAIL_AUTH_ERROR_TOKENS = [
   "auth/weak-password",
 ] as const;
 
-function collectEmailAuthErrorStrings(error: unknown): string[] {
-  const strings: string[] = [];
-  const visited = new Set<unknown>();
-
-  const collect = (value: unknown): void => {
-    if (value == null || visited.has(value)) return;
-
-    if (typeof value === "string") {
-      strings.push(value.toLowerCase());
-      return;
-    }
-
-    if (typeof value !== "object") return;
-
-    visited.add(value);
-    if (value instanceof Error) {
-      strings.push(value.name.toLowerCase(), value.message.toLowerCase());
-    }
-
-    const record = value as Record<string, unknown>;
-    for (const key of ["code", "readableErrorCode", "message", "error"]) {
-      collect(record[key]);
-    }
-  };
-
-  collect(error);
-  return strings;
-}
-
 function getExpectedSignupEmailAuthErrorToken(error: unknown): string | null {
   if (!isExpectedEmailAuthError(error)) return null;
 
-  const searchStrings = collectEmailAuthErrorStrings(error);
+  const searchStrings = collectErrorSearchStrings(error);
   return (
     SIGNUP_EMAIL_AUTH_ERROR_TOKENS.find((token) =>
       searchStrings.some((searchString) => searchString.includes(token)),

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -25,6 +25,10 @@ import { BackIcon, GoogleIcon, AppleIcon } from "@/lib/images";
 import { logger } from "@/lib/logger";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import {
+  isExpectedEmailAuthError,
+  isExpectedRevenueCatLogoutError,
+} from "@/lib/errors";
+import {
   updateRequirements,
   deleteAccount,
   cancelAccountDeletion,
@@ -165,11 +169,13 @@ function OnlinePage() {
         }
       } catch (e) {
         const error = e as Error;
-        logger.error("Firebase email signup failed:", error, {
-          category: "api",
-          action: "createUserWithEmailAndPassword",
-          severity: "warning",
-        });
+        if (!isExpectedEmailAuthError(e)) {
+          logger.error("Firebase email signup failed:", error, {
+            category: "api",
+            action: "createUserWithEmailAndPassword",
+            severity: "warning",
+          });
+        }
 
         // Handle specific error codes
         if (error.message.includes("email-already-in-use")) {
@@ -212,11 +218,13 @@ function OnlinePage() {
         }
       } catch (e) {
         const error = e as Error;
-        logger.error("Firebase email login failed:", error, {
-          category: "api",
-          action: "signInWithEmail",
-          severity: "warning",
-        });
+        if (!isExpectedEmailAuthError(e)) {
+          logger.error("Firebase email login failed:", error, {
+            category: "api",
+            action: "signInWithEmail",
+            severity: "warning",
+          });
+        }
         toast.error(t("online.loginWrong"));
       } finally {
         setIsLoading(false);
@@ -352,11 +360,13 @@ function OnlinePage() {
           await Purchases.logOut();
         }
       } catch (e) {
-        logger.error("RevenueCat logout failed:", e, {
-          category: "purchase",
-          action: "logOut",
-          severity: "warning",
-        });
+        if (!isExpectedRevenueCatLogoutError(e)) {
+          logger.error("RevenueCat logout failed:", e, {
+            category: "purchase",
+            action: "logOut",
+            severity: "warning",
+          });
+        }
       }
     }
 

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -57,6 +57,53 @@ function isOAuthAvailable(): boolean {
   return window.location.hostname === "zaparoo.app";
 }
 
+const SIGNUP_EMAIL_AUTH_ERROR_TOKENS = [
+  "email-already-in-use",
+  "auth/email-already-in-use",
+  "weak-password",
+  "auth/weak-password",
+] as const;
+
+function collectEmailAuthErrorStrings(error: unknown): string[] {
+  const strings: string[] = [];
+  const visited = new Set<unknown>();
+
+  const collect = (value: unknown): void => {
+    if (value == null || visited.has(value)) return;
+
+    if (typeof value === "string") {
+      strings.push(value.toLowerCase());
+      return;
+    }
+
+    if (typeof value !== "object") return;
+
+    visited.add(value);
+    if (value instanceof Error) {
+      strings.push(value.name.toLowerCase(), value.message.toLowerCase());
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const key of ["code", "readableErrorCode", "message", "error"]) {
+      collect(record[key]);
+    }
+  };
+
+  collect(error);
+  return strings;
+}
+
+function getExpectedSignupEmailAuthErrorToken(error: unknown): string | null {
+  if (!isExpectedEmailAuthError(error)) return null;
+
+  const searchStrings = collectEmailAuthErrorStrings(error);
+  return (
+    SIGNUP_EMAIL_AUTH_ERROR_TOKENS.find((token) =>
+      searchStrings.some((searchString) => searchString.includes(token)),
+    ) ?? null
+  );
+}
+
 /**
  * Get user's display initial for avatar
  */
@@ -168,19 +215,19 @@ function OnlinePage() {
           toast.error(t("online.signUpFail"));
         }
       } catch (e) {
-        const error = e as Error;
-        if (!isExpectedEmailAuthError(e)) {
-          logger.error("Firebase email signup failed:", error, {
+        const isExpectedEmailError = isExpectedEmailAuthError(e);
+        const emailAuthErrorToken = getExpectedSignupEmailAuthErrorToken(e);
+        if (!isExpectedEmailError) {
+          logger.error("Firebase email signup failed:", e, {
             category: "api",
             action: "createUserWithEmailAndPassword",
             severity: "warning",
           });
         }
 
-        // Handle specific error codes
-        if (error.message.includes("email-already-in-use")) {
+        if (emailAuthErrorToken?.includes("email-already-in-use")) {
           toast.error(t("online.emailExists"));
-        } else if (error.message.includes("weak-password")) {
+        } else if (emailAuthErrorToken?.includes("weak-password")) {
           toast.error(t("online.weakPassword"));
         } else {
           toast.error(t("online.signUpFail"));


### PR DESCRIPTION
## Summary
- suppress expected Firebase email credential/signup failures from monitoring while preserving user-facing toasts
- ignore expected RevenueCat logout anonymous/credential state races during sign-out
- add classifier coverage and auth flow regression tests

Verified: targeted auth/error tests, typecheck, and lint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppresses noisy error reports for known RevenueCat sign-out and Firebase email-auth failures, preventing unnecessary error logging.
  * Ensures sign-out proceeds reliably even when a known native logout error occurs.
  * Improves toast/feedback accuracy for email signup/login by detecting common validation cases and showing the appropriate message.

* **Tests**
  * Added and extended unit tests to verify expected-error suppression and proper reporting of unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->