### PR TITLE
Reduce NFC monitoring noise

### DIFF
--- a/src/__tests__/unit/hooks/useScanOperations.test.tsx
+++ b/src/__tests__/unit/hooks/useScanOperations.test.tsx
@@ -15,10 +15,21 @@ import {
   Nfc,
   __simulateTagScanned,
   __simulateScanCanceled,
+  __simulateScanError,
   __createMockNfcTag,
 } from "../../../../__mocks__/@capawesome-team/capacitor-nfc";
 
 // Helper to create mock barcode with all required properties
+const mockLogger = vi.hoisted(() => ({
+  log: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: mockLogger,
+}));
+
 const createMockBarcode = (rawValue: string): Barcode => ({
   rawValue,
   displayValue: rawValue,
@@ -587,6 +598,56 @@ describe("useScanOperations", () => {
 
       // Assert
       expect(result.current.scanStatus).toBe(ScanResult.Default);
+    });
+
+    it("should not log expected transient NFC scan failures as errors", async () => {
+      const { result } = renderHook(() => useScanOperations(defaultProps));
+
+      await act(async () => {
+        result.current.handleScanButton();
+        await vi.advanceTimersByTimeAsync(10);
+      });
+
+      await act(async () => {
+        __simulateScanError({ message: "Tag was lost." });
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.scanStatus).toBe(ScanResult.Error);
+      });
+      expect(result.current.scanSession).toBe(false);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Expected NFC scan failure",
+        expect.any(Error),
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("should log unexpected NFC scan failures as errors", async () => {
+      const { result } = renderHook(() => useScanOperations(defaultProps));
+
+      await act(async () => {
+        result.current.handleScanButton();
+        await vi.advanceTimersByTimeAsync(10);
+      });
+
+      await act(async () => {
+        __simulateScanError({ message: "NFC hardware error" });
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.scanStatus).toBe(ScanResult.Error);
+      });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "NFC scan failed",
+        expect.any(Error),
+        expect.objectContaining({
+          category: "nfc",
+          action: "doScan",
+        }),
+      );
     });
 
     it("should handle barcode scanner errors gracefully", async () => {

--- a/src/__tests__/unit/lib/errors.test.ts
+++ b/src/__tests__/unit/lib/errors.test.ts
@@ -9,12 +9,15 @@ import { describe, it, expect } from "vitest";
 import {
   ZaparooError,
   NfcCancelledError,
+  NfcTransientError,
   NfcUnformattedTagError,
   NfcFormatError,
   BarcodeScanCancelledError,
   PurchaseCancelledError,
   isCancellationError,
   isNfcError,
+  isExpectedNfcError,
+  isTransientNfcError,
   wrapNfcError,
   wrapBarcodeScannerError,
   wrapPurchaseError,
@@ -73,6 +76,34 @@ describe("errors", () => {
       const error = new NfcCancelledError();
 
       expect(error.name).toBe("NfcCancelledError");
+    });
+  });
+
+  describe("NfcTransientError", () => {
+    it("should extend ZaparooError", () => {
+      const error = new NfcTransientError();
+
+      expect(error).toBeInstanceOf(ZaparooError);
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it("should use default message when not provided", () => {
+      const error = new NfcTransientError();
+
+      expect(error.message).toBe("NFC tag was lost during operation");
+    });
+
+    it("should store original error", () => {
+      const originalError = new Error("Tag was lost");
+      const error = new NfcTransientError("Wrapped error", originalError);
+
+      expect(error.originalError).toBe(originalError);
+    });
+
+    it("should set correct name property", () => {
+      const error = new NfcTransientError();
+
+      expect(error.name).toBe("NfcTransientError");
     });
   });
 
@@ -235,6 +266,10 @@ describe("errors", () => {
       expect(isNfcError(new NfcCancelledError())).toBe(true);
     });
 
+    it("should return true for NfcTransientError", () => {
+      expect(isNfcError(new NfcTransientError())).toBe(true);
+    });
+
     it("should return true for NfcUnformattedTagError", () => {
       expect(isNfcError(new NfcUnformattedTagError())).toBe(true);
     });
@@ -257,6 +292,33 @@ describe("errors", () => {
       expect(isNfcError(null)).toBe(false);
       expect(isNfcError(undefined)).toBe(false);
       expect(isNfcError("error string")).toBe(false);
+    });
+  });
+
+  describe("isExpectedNfcError", () => {
+    it("should return true for expected NFC errors", () => {
+      expect(isExpectedNfcError(new NfcCancelledError())).toBe(true);
+      expect(isExpectedNfcError(new NfcTransientError())).toBe(true);
+      expect(isExpectedNfcError(new NfcUnformattedTagError())).toBe(true);
+      expect(isExpectedNfcError(new NfcFormatError())).toBe(true);
+    });
+
+    it("should wrap native expected NFC messages before checking", () => {
+      expect(isExpectedNfcError(new Error("Tag was lost."))).toBe(true);
+      expect(isExpectedNfcError({ message: "No NFC tag was detected." })).toBe(
+        true,
+      );
+    });
+
+    it("should return false for unexpected errors", () => {
+      expect(isExpectedNfcError(new Error("Permission denied"))).toBe(false);
+    });
+  });
+
+  describe("isTransientNfcError", () => {
+    it("should return true only for NfcTransientError", () => {
+      expect(isTransientNfcError(new NfcTransientError())).toBe(true);
+      expect(isTransientNfcError(new NfcFormatError())).toBe(false);
     });
   });
 
@@ -288,6 +350,34 @@ describe("errors", () => {
       const wrapped = wrapNfcError(originalError);
 
       expect(wrapped).toBeInstanceOf(NfcUnformattedTagError);
+    });
+
+    it("should wrap transient tag-loss errors", () => {
+      const messages = [
+        "No NFC tag was detected.",
+        "The tag is not connected.",
+        "Tag was lost.",
+        "android.nfc.TagLostException",
+        "Tag is out of date.",
+        "Stale tag handle",
+        "Could not connect to tag.",
+        "Session invalidated unexpectedly.",
+        "Reader session invalidated.",
+        "Connection lost.",
+      ];
+
+      for (const message of messages) {
+        expect(wrapNfcError(new Error(message))).toBeInstanceOf(
+          NfcTransientError,
+        );
+      }
+    });
+
+    it("should preserve message from plain plugin event objects", () => {
+      const wrapped = wrapNfcError({ message: "Tag was lost." });
+
+      expect(wrapped).toBeInstanceOf(NfcTransientError);
+      expect(wrapped.message).toBe("Tag was lost.");
     });
 
     it("should wrap format error with 'unknown error'", () => {

--- a/src/__tests__/unit/lib/nfc.test.ts
+++ b/src/__tests__/unit/lib/nfc.test.ts
@@ -113,10 +113,13 @@ vi.mock("@capacitor/core", () => ({
 vi.mock("../../../lib/logger", () => ({
   logger: {
     log: vi.fn(),
+    debug: vi.fn(),
     error: vi.fn(),
   },
 }));
 
+import { logger } from "../../../lib/logger";
+import { NfcTransientError } from "../../../lib/errors";
 import {
   int2hex,
   int2char,
@@ -151,6 +154,8 @@ describe("nfc", () => {
     mockClose.mockClear();
     mockIsSupported.mockClear();
     mockGetPlatform.mockClear();
+    vi.mocked(logger.debug).mockClear();
+    vi.mocked(logger.error).mockClear();
 
     // Reset mocks to default resolved values (important for tests that override them)
     mockWrite.mockResolvedValue(undefined);
@@ -377,6 +382,43 @@ describe("nfc", () => {
       });
     });
 
+    it("should not log expected scan session errors as errors", async () => {
+      const readPromise = readTag();
+
+      await vi.waitFor(() => {
+        expect(mockState.scanSessionErrorCallback).not.toBeNull();
+      });
+
+      mockState.scanSessionErrorCallback?.(new Error("Tag was lost."));
+
+      await expect(readPromise).rejects.toBeInstanceOf(NfcTransientError);
+      expect(logger.debug).toHaveBeenCalledWith(
+        "Expected NFC scan session failure:",
+        expect.any(NfcTransientError),
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("should log unexpected scan session errors as errors", async () => {
+      const readPromise = readTag();
+
+      await vi.waitFor(() => {
+        expect(mockState.scanSessionErrorCallback).not.toBeNull();
+      });
+
+      mockState.scanSessionErrorCallback?.(new Error("NFC hardware error"));
+
+      await expect(readPromise).rejects.toThrow("NFC hardware error");
+      expect(logger.error).toHaveBeenCalledWith(
+        "NFC scan session error:",
+        expect.any(Error),
+        expect.objectContaining({
+          category: "nfc",
+          action: "scanSessionError",
+        }),
+      );
+    });
+
     it("should stop scan session on successful scan", async () => {
       const readPromise = readTag();
 
@@ -508,6 +550,27 @@ describe("nfc", () => {
       expect(mockFormat).not.toHaveBeenCalled();
     });
 
+    it("should not log transient write errors as errors", async () => {
+      mockWrite.mockRejectedValueOnce(new Error("Tag was lost."));
+
+      const writePromise = writeTag("test content");
+
+      await vi.waitFor(() => {
+        expect(mockState.nfcTagScannedCallback).not.toBeNull();
+      });
+
+      mockState.nfcTagScannedCallback?.({
+        nfcTag: { id: [1, 2, 3, 4] },
+      } as NfcTagScannedEvent);
+
+      await expect(writePromise).rejects.toBeInstanceOf(NfcTransientError);
+      expect(logger.debug).toHaveBeenCalledWith(
+        "Expected NFC operation failure:",
+        expect.any(NfcTransientError),
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it("should propagate format errors after retries exhausted", async () => {
       mockWrite.mockRejectedValue(
         new Error("The NFC tag has not yet been formatted as NDEF."),
@@ -528,6 +591,39 @@ describe("nfc", () => {
       await expect(writePromise).rejects.toThrow("Format failed");
       // Verify all 3 retries were attempted
       expect(mockFormat).toHaveBeenCalledTimes(3);
+      expect(logger.error).toHaveBeenCalledWith(
+        "NFC format/write failed after retries",
+        expect.any(Error),
+        expect.objectContaining({
+          category: "nfc",
+          action: "writeTag",
+        }),
+      );
+    });
+
+    it("should not log transient format retry failures as errors", async () => {
+      mockWrite.mockRejectedValue(
+        new Error("The NFC tag has not yet been formatted as NDEF."),
+      );
+      mockFormat.mockRejectedValue(new Error("Tag was lost."));
+
+      const writePromise = writeTag("test content");
+
+      await vi.waitFor(() => {
+        expect(mockState.nfcTagScannedCallback).not.toBeNull();
+      });
+
+      mockState.nfcTagScannedCallback?.({
+        nfcTag: { id: [1, 2, 3, 4] },
+      } as NfcTagScannedEvent);
+
+      await expect(writePromise).rejects.toBeInstanceOf(NfcTransientError);
+      expect(mockFormat).toHaveBeenCalledTimes(3);
+      expect(logger.debug).toHaveBeenCalledWith(
+        "Expected NFC format/write failure:",
+        expect.any(NfcTransientError),
+      );
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("should retry on unknown error during format and succeed", async () => {

--- a/src/__tests__/unit/lib/writeNfcHook.test.tsx
+++ b/src/__tests__/unit/lib/writeNfcHook.test.tsx
@@ -25,6 +25,7 @@ const {
   mockFormatTag,
   mockEraseTag,
   mockMakeReadOnly,
+  mockIsFormatRelatedError,
   mockHasWriteCapableReader,
   mockIsConnected,
   mockWrite,
@@ -42,6 +43,7 @@ const {
   mockFormatTag: vi.fn(),
   mockEraseTag: vi.fn(),
   mockMakeReadOnly: vi.fn(),
+  mockIsFormatRelatedError: vi.fn().mockReturnValue(false),
   mockHasWriteCapableReader: vi.fn().mockResolvedValue(false),
   mockIsConnected: vi.fn().mockReturnValue(true),
   mockWrite: vi.fn().mockResolvedValue({}),
@@ -54,6 +56,7 @@ const {
   },
   mockLogger: {
     log: vi.fn(),
+    debug: vi.fn(),
     error: vi.fn(),
   },
 }));
@@ -81,6 +84,7 @@ vi.mock("../../../lib/nfc", () => ({
   formatTag: mockFormatTag,
   eraseTag: mockEraseTag,
   makeReadOnly: mockMakeReadOnly,
+  isFormatRelatedError: mockIsFormatRelatedError,
   Status: {
     Success: 0,
     Error: 1,
@@ -132,6 +136,7 @@ describe("useNfcWriter", () => {
     mockNfcIsAvailable.mockResolvedValue({ nfc: true });
     mockHasWriteCapableReader.mockResolvedValue(false);
     mockIsConnected.mockReturnValue(true);
+    mockIsFormatRelatedError.mockReturnValue(false);
 
     // Default successful operations
     mockReadRaw.mockResolvedValue({
@@ -388,6 +393,50 @@ describe("useNfcWriter", () => {
       });
 
       expect(mockToast.error).toHaveBeenCalled();
+    });
+
+    it("should not log expected transient write failures as errors", async () => {
+      mockWriteTag.mockRejectedValue(new Error("Tag was lost."));
+
+      const { result } = renderHook(() => useNfcWriter());
+
+      await act(async () => {
+        await result.current.write(WriteAction.Write, "content");
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(Status.Error);
+      });
+
+      expect(mockToast.error).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Expected NFC write operation failure",
+        expect.any(Error),
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("should log unexpected write failures as errors", async () => {
+      mockWriteTag.mockRejectedValue(new Error("Write failed"));
+
+      const { result } = renderHook(() => useNfcWriter());
+
+      await act(async () => {
+        await result.current.write(WriteAction.Write, "content");
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(Status.Error);
+      });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "NFC write operation failed",
+        expect.any(Error),
+        expect.objectContaining({
+          category: "nfc",
+          action: WriteAction.Write,
+        }),
+      );
     });
   });
 

--- a/src/hooks/useScanOperations.tsx
+++ b/src/hooks/useScanOperations.tsx
@@ -12,6 +12,7 @@ import { useAnnouncer } from "@/components/A11yAnnouncer";
 import { useHaptics } from "@/hooks/useHaptics";
 import {
   BarcodeScanCancelledError,
+  isExpectedNfcError,
   wrapBarcodeScannerError,
 } from "@/lib/errors";
 
@@ -97,10 +98,14 @@ export function useScanOperations({
       .catch((error) => {
         setScanStatus(ScanResult.Error);
         setScanSession(false);
-        logger.error("NFC scan failed", error, {
-          category: "nfc",
-          action: "doScan",
-        });
+        if (isExpectedNfcError(error)) {
+          logger.debug("Expected NFC scan failure", error);
+        } else {
+          logger.error("NFC scan failed", error, {
+            category: "nfc",
+            action: "doScan",
+          });
+        }
         toast.error(t("scan.scanError"));
         setTimeout(() => {
           setScanStatus(ScanResult.Default);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -33,6 +33,18 @@ export class NfcCancelledError extends ZaparooError {
 }
 
 /**
+ * Thrown when NFC tag/session loss is expected during normal tag interaction.
+ */
+export class NfcTransientError extends ZaparooError {
+  constructor(
+    message = "NFC tag was lost during operation",
+    public readonly originalError?: Error,
+  ) {
+    super(message);
+  }
+}
+
+/**
  * Thrown when NFC tag is not NDEF formatted.
  * Can be recovered by formatting the tag first.
  */
@@ -107,14 +119,52 @@ export function isCancellationError(error: unknown): boolean {
 export function isNfcError(error: unknown): boolean {
   return (
     error instanceof NfcCancelledError ||
+    error instanceof NfcTransientError ||
     error instanceof NfcUnformattedTagError ||
     error instanceof NfcFormatError
+  );
+}
+
+/**
+ * Check if error is an expected transient NFC failure.
+ */
+export function isTransientNfcError(error: unknown): boolean {
+  return error instanceof NfcTransientError;
+}
+
+/**
+ * Check if NFC error should surface user feedback without production reporting.
+ */
+export function isExpectedNfcError(error: unknown): boolean {
+  const wrappedError = wrapNfcError(error);
+  return (
+    wrappedError instanceof NfcCancelledError ||
+    wrappedError instanceof NfcTransientError ||
+    wrappedError instanceof NfcUnformattedTagError ||
+    wrappedError instanceof NfcFormatError
   );
 }
 
 // =============================================================================
 // Error Wrapping Utilities
 // =============================================================================
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return new Error(error.message);
+  }
+
+  return new Error(String(error));
+}
 
 /**
  * Wraps native NFC plugin errors into typed errors.
@@ -124,11 +174,18 @@ export function isNfcError(error: unknown): boolean {
  * @returns A typed error if recognized, otherwise the original error
  */
 export function wrapNfcError(error: unknown): Error {
-  if (!(error instanceof Error)) {
-    return error instanceof Error ? error : new Error(String(error));
+  const normalizedError = normalizeError(error);
+
+  if (
+    normalizedError instanceof NfcCancelledError ||
+    normalizedError instanceof NfcTransientError ||
+    normalizedError instanceof NfcUnformattedTagError ||
+    normalizedError instanceof NfcFormatError
+  ) {
+    return normalizedError;
   }
 
-  const msg = error.message.toLowerCase();
+  const msg = normalizedError.message.toLowerCase();
 
   // Check for unformatted tag errors
   if (
@@ -136,7 +193,23 @@ export function wrapNfcError(error: unknown): Error {
     msg.includes("tag is not ndef") ||
     msg.includes("not ndef formatted")
   ) {
-    return new NfcUnformattedTagError(error.message, error);
+    return new NfcUnformattedTagError(normalizedError.message, normalizedError);
+  }
+
+  // Check for transient tag/session loss during normal NFC operations
+  if (
+    msg.includes("no nfc tag was detected") ||
+    msg.includes("the tag is not connected") ||
+    msg.includes("tag was lost") ||
+    msg.includes("taglostexception") ||
+    msg.includes("tag is out of date") ||
+    msg.includes("stale tag") ||
+    msg.includes("could not connect to tag") ||
+    msg.includes("session invalidated unexpectedly") ||
+    msg.includes("reader session invalidated") ||
+    msg.includes("connection lost")
+  ) {
+    return new NfcTransientError(normalizedError.message, normalizedError);
   }
 
   // Check for format-related errors (used for user-friendly messages)
@@ -146,10 +219,10 @@ export function wrapNfcError(error: unknown): Error {
     msg.includes("only one tagtechnology") ||
     msg.includes("format")
   ) {
-    return new NfcFormatError(error.message, error);
+    return new NfcFormatError(normalizedError.message, normalizedError);
   }
 
-  return error;
+  return normalizedError;
 }
 
 /**

--- a/src/lib/nfc.ts
+++ b/src/lib/nfc.ts
@@ -12,6 +12,8 @@ import {
   NfcCancelledError,
   NfcUnformattedTagError,
   NfcFormatError,
+  NfcTransientError,
+  isExpectedNfcError,
   wrapNfcError,
 } from "./errors";
 
@@ -96,13 +98,21 @@ async function withNfcSession<T>(
               Nfc.stopScanSession();
               await handleSuccess(result);
             } catch (error) {
-              logger.error("NFC operation error:", error, {
-                category: "nfc",
-                action: "nfcTagScanned",
-                stack: error instanceof Error ? error.stack : undefined,
-              });
+              const wrappedError = wrapNfcError(error);
+              if (isExpectedNfcError(wrappedError)) {
+                logger.debug("Expected NFC operation failure:", wrappedError);
+              } else {
+                logger.error("NFC operation error:", wrappedError, {
+                  category: "nfc",
+                  action: "nfcTagScanned",
+                  stack:
+                    wrappedError instanceof Error
+                      ? wrappedError.stack
+                      : undefined,
+                });
+              }
               Nfc.stopScanSession();
-              await handleError(error);
+              await handleError(wrappedError);
             }
           },
         );
@@ -118,14 +128,22 @@ async function withNfcSession<T>(
         const scanErrorHandle = await Nfc.addListener(
           "scanSessionError",
           async (err) => {
-            logger.error("NFC scan session error:", err, {
-              category: "nfc",
-              action: "scanSessionError",
-              message: err.message,
-              stack: err instanceof Error ? err.stack : undefined,
-            });
+            const wrappedError = wrapNfcError(err);
+            if (isExpectedNfcError(wrappedError)) {
+              logger.debug("Expected NFC scan session failure:", wrappedError);
+            } else {
+              logger.error("NFC scan session error:", wrappedError, {
+                category: "nfc",
+                action: "scanSessionError",
+                message: wrappedError.message,
+                stack:
+                  wrappedError instanceof Error
+                    ? wrappedError.stack
+                    : undefined,
+              });
+            }
             Nfc.stopScanSession();
-            await handleError(err);
+            await handleError(wrappedError);
           },
         );
 
@@ -140,9 +158,10 @@ async function withNfcSession<T>(
         // Now it's safe to start the scan session
         await Nfc.startScanSession();
       } catch (setupError) {
+        const wrappedError = wrapNfcError(setupError);
         // If setup fails (e.g., NFC not enabled), clean up and reject
         await cleanup();
-        reject(setupError);
+        reject(wrappedError);
       }
     };
 
@@ -305,29 +324,35 @@ export async function writeTag(text: string): Promise<Result> {
                 },
               };
             } catch (formatError) {
-              lastFormatError = formatError;
+              const wrappedFormatError = wrapNfcError(formatError);
+              lastFormatError = wrappedFormatError;
               logger.log(
-                `Format attempt ${attempt} failed: ${formatError instanceof Error ? formatError.message : String(formatError)}`,
+                `Format attempt ${attempt} failed: ${wrappedFormatError.message}`,
               );
             }
           }
 
           // All retries exhausted - log technical error for debugging
-          logger.error(
-            "NFC format/write failed after retries",
-            lastFormatError,
-            {
-              category: "nfc",
-              action: "writeTag",
-              stack:
-                lastFormatError instanceof Error
-                  ? lastFormatError.stack
-                  : undefined,
-            },
-          );
-          throw lastFormatError;
+          const wrappedFormatError = wrapNfcError(lastFormatError);
+          if (wrappedFormatError instanceof NfcTransientError) {
+            logger.debug(
+              "Expected NFC format/write failure:",
+              wrappedFormatError,
+            );
+          } else {
+            logger.error(
+              "NFC format/write failed after retries",
+              wrappedFormatError,
+              {
+                category: "nfc",
+                action: "writeTag",
+                stack: wrappedFormatError.stack,
+              },
+            );
+          }
+          throw wrappedFormatError;
         }
-        throw writeError;
+        throw wrapNfcError(writeError);
       }
       return {
         status: Status.Success,

--- a/src/lib/writeNfcHook.tsx
+++ b/src/lib/writeNfcHook.tsx
@@ -17,7 +17,11 @@ import {
 } from "./nfc";
 import { CoreAPI } from "./coreApi.ts";
 import { logger } from "./logger";
-import { NfcCancelledError, isCancellationError } from "./errors";
+import {
+  NfcCancelledError,
+  isCancellationError,
+  isExpectedNfcError,
+} from "./errors";
 
 export interface WriteNfcHook {
   write: (action: WriteAction, text?: string) => Promise<void>;
@@ -286,11 +290,15 @@ export function useNfcWriter(
             setStatus(Status.Cancelled);
             return;
           }
-          logger.error("NFC write operation failed", e, {
-            category: "nfc",
-            action: action,
-            writeMethod: currentWriteMethod,
-          });
+          if (isExpectedNfcError(e)) {
+            logger.debug("Expected NFC write operation failure", e);
+          } else {
+            logger.error("NFC write operation failed", e, {
+              category: "nfc",
+              action: action,
+              writeMethod: currentWriteMethod,
+            });
+          }
           let showMs = 4000;
           if (Capacitor.getPlatform() === "ios") {
             showMs += 4000;


### PR DESCRIPTION
## Summary
- classify expected NFC tag-loss/session-loss failures separately from unexpected NFC errors
- downgrade expected scan/read/write NFC failures away from Rollbar while keeping user feedback
- keep exhausted format/write retry failures reported and covered by tests

Fixes #138

Validated with targeted tests, typecheck, lint, and format check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved NFC tag scanning and write operations to better handle transient errors like lost tags, treating them as expected temporary failures rather than critical issues
  * Enhanced error logging to distinguish between recoverable NFC problems and genuine errors

* **Tests**
  * Added comprehensive test coverage for NFC error handling scenarios across all operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->