### PR TITLE
Gate empty media searches by Core version

### DIFF
--- a/src/__tests__/integration/create-search.test.tsx
+++ b/src/__tests__/integration/create-search.test.tsx
@@ -310,7 +310,7 @@ describe("Create Search Integration", () => {
       ...useStatusStore.getInitialState(),
       connected: true,
       connectionState: ConnectionState.CONNECTED,
-      coreVersion: "2.7.0",
+      coreVersion: "2.10.0",
       coreVersionPending: false,
       gamesIndex: {
         exists: true,

--- a/src/__tests__/unit/featureGates.test.ts
+++ b/src/__tests__/unit/featureGates.test.ts
@@ -63,4 +63,10 @@ describe("isCoreFeatureAvailable", () => {
     expect(isCoreFeatureAvailable("mediaTags", "2.6.2")).toBe(false);
     expect(isCoreFeatureAvailable("mediaTags", "2.7.0")).toBe(true);
   });
+
+  it("should gate browse-all media search behind Core 2.10.0", () => {
+    expect(FEATURE_GATES.mediaBrowseAllSearch?.since).toBe("2.10.0");
+    expect(isCoreFeatureAvailable("mediaBrowseAllSearch", "2.9.1")).toBe(false);
+    expect(isCoreFeatureAvailable("mediaBrowseAllSearch", "2.10.0")).toBe(true);
+  });
 });

--- a/src/__tests__/unit/routes/create.search.test.tsx
+++ b/src/__tests__/unit/routes/create.search.test.tsx
@@ -278,7 +278,7 @@ describe("Search Component", () => {
     useStatusStore.setState({
       ...useStatusStore.getInitialState(),
       connected: true,
-      coreVersion: "2.7.0",
+      coreVersion: "2.10.0",
       coreVersionPending: false,
       gamesIndex: { exists: true, indexing: false },
     });
@@ -362,6 +362,56 @@ describe("Search Component", () => {
         name: "create.search.searchButton",
       });
       expect(searchButton).not.toBeDisabled();
+    });
+
+    it("should disable empty all-systems search when Core does not support browse-all", () => {
+      useStatusStore.setState({ coreVersion: "2.9.1" });
+      render(<Search />);
+
+      const searchButton = screen.getByRole("button", {
+        name: "create.search.searchButton",
+      });
+      expect(searchButton).toBeDisabled();
+    });
+
+    it("should allow query search when Core does not support browse-all", () => {
+      useStatusStore.setState({ coreVersion: "2.9.1" });
+      render(<Search />);
+
+      const input = screen.getByLabelText("create.search.gameInput");
+      fireEvent.change(input, { target: { value: "mario" } });
+
+      const searchButton = screen.getByRole("button", {
+        name: "create.search.searchButton",
+      });
+      expect(searchButton).not.toBeDisabled();
+      fireEvent.click(searchButton);
+
+      expect(mockAddRecentSearch).toHaveBeenCalledWith({
+        query: "mario",
+        system: "all",
+        tags: [],
+      });
+    });
+
+    it("should allow system-filtered empty search when Core does not support browse-all", () => {
+      useStatusStore.setState({ coreVersion: "2.9.1" });
+      render(<Search />);
+
+      fireEvent.click(screen.getByTestId("system-selector-trigger"));
+      fireEvent.click(screen.getByRole("button", { name: "Select SNES" }));
+
+      const searchButton = screen.getByRole("button", {
+        name: "create.search.searchButton",
+      });
+      expect(searchButton).not.toBeDisabled();
+      fireEvent.click(searchButton);
+
+      expect(mockAddRecentSearch).toHaveBeenCalledWith({
+        query: "",
+        system: "snes",
+        tags: [],
+      });
     });
 
     it("should disable search button when not connected", () => {

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -31,6 +31,11 @@ export const FEATURE_GATES: Record<string, FeatureGate> = {
     marquee: false,
     labelKey: "features.mediaTags",
   },
+  mediaBrowseAllSearch: {
+    since: "2.10.0",
+    marquee: false,
+    labelKey: "features.mediaBrowseAllSearch",
+  },
   remoteInput: {
     since: "2.10.0",
     marquee: true,

--- a/src/routes/-pages/Search.tsx
+++ b/src/routes/-pages/Search.tsx
@@ -85,6 +85,21 @@ export function Search() {
     !coreVersionPending &&
     isCoreFeatureAvailable("mediaTags", coreVersion);
   const effectiveQueryTags = mediaTagsAvailable ? queryTags : [];
+  const browseAllSearchAvailable =
+    connected &&
+    !coreVersionPending &&
+    isCoreFeatureAvailable("mediaBrowseAllSearch", coreVersion);
+  const hasSearchConstraint = (
+    searchQuery: string,
+    system: string,
+    tags: string[],
+  ) => searchQuery.trim().length > 0 || system !== "all" || tags.length > 0;
+  const baseSearchReady =
+    connected && gamesIndex.exists && !gamesIndex.indexing;
+  const canSearch =
+    baseSearchReady &&
+    (browseAllSearchAvailable ||
+      hasSearchConstraint(query, querySystem, effectiveQueryTags));
 
   // Recent searches hook
   const {
@@ -96,7 +111,7 @@ export function Search() {
 
   // Manual search function
   const performSearch = async () => {
-    if (!connected || !gamesIndex.exists || gamesIndex.indexing) {
+    if (!canSearch) {
       return;
     }
 
@@ -130,9 +145,6 @@ export function Search() {
     null,
   );
   const [writeMode, setWriteMode] = useState<"path" | "zapScript">("zapScript");
-
-  // Check if search has valid parameters
-  const canSearch = connected && gamesIndex.exists && !gamesIndex.indexing;
 
   const preferRemoteWriter = usePreferencesStore(
     (state) => state.preferRemoteWriter,
@@ -279,7 +291,15 @@ export function Search() {
     }
 
     // Automatically execute the search
-    if (connected && gamesIndex.exists && !gamesIndex.indexing) {
+    if (
+      baseSearchReady &&
+      (browseAllSearchAvailable ||
+        hasSearchConstraint(
+          recentSearch.query,
+          recentSearch.system,
+          searchTags,
+        ))
+    ) {
       setIsSearching(true);
       setSearchParams({
         query: recentSearch.query,

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -754,6 +754,7 @@
       "mediaScrapers": "Scraper",
       "mediaCleanOrphans": "Clean missing media",
       "mediaTags": "Media tags",
+      "mediaBrowseAllSearch": "Browse all media search",
       "remoteInput": "Remote input"
     },
     "inbox": {


### PR DESCRIPTION
## Summary
- Add a Core 2.10.0 feature gate for browse-all media search
- Disable unconstrained searches on unsupported Core while allowing query, system, or tag filters
- Cover gate behavior and Search route cases with tests

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Browse all media search" feature gate, available for core version 2.10.0 and later.
  * Enhanced search execution with capability-aware controls, enabling broader search operations and improved query handling across media catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->