### PR TITLE
fix: add AbortController polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@tanstack/react-router": "^1.139.12",
         "@tanstack/react-virtual": "^3.13.12",
         "@uidotdev/usehooks": "^2.4.1",
+        "abortcontroller-polyfill": "^1.7.8",
         "axios": "^1.15.0",
         "capacitor-plugin-safe-area": "^5.0.0",
         "capacitor-zeroconf": "^4.0.0",
@@ -7495,6 +7496,12 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
       "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
+      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
       "license": "MIT"
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@tanstack/react-router": "^1.139.12",
     "@tanstack/react-virtual": "^3.13.12",
     "@uidotdev/usehooks": "^2.4.1",
+    "abortcontroller-polyfill": "^1.7.8",
     "axios": "^1.15.0",
     "capacitor-plugin-safe-area": "^5.0.0",
     "capacitor-zeroconf": "^4.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,13 @@ export default defineConfig(({ command, mode }) => {
         "ios >= 11",
         "android >= 49",
       ],
-      additionalLegacyPolyfills: ["regenerator-runtime/runtime"],
+      additionalLegacyPolyfills: [
+        "regenerator-runtime/runtime",
+        "abortcontroller-polyfill/dist/polyfill-patch-fetch",
+      ],
+      additionalModernPolyfills: [
+        "abortcontroller-polyfill/dist/polyfill-patch-fetch",
+      ],
       modernPolyfills: true,
     }),
   ];


### PR DESCRIPTION
Adds the AbortController/fetch-signal polyfill to both Vite legacy and modern polyfill chunks so old Android WebViews can start and navigate without route error boundary crashes.

Also adds the runtime polyfill dependency and updates the lockfile.

Validation run: typecheck, lint, build:web, and built polyfill asset inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced browser compatibility by adding support for fetch request cancellation across a wider range of environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->