### PR TITLE
Downgrade invalid deep link logging

### DIFF
--- a/src/__tests__/unit/lib/deepLinks.test.tsx
+++ b/src/__tests__/unit/lib/deepLinks.test.tsx
@@ -16,6 +16,7 @@ const { mockAddListener, mockGetLaunchUrl, mockLogger, mockToast } = vi.hoisted(
     mockLogger: {
       log: vi.fn(),
       error: vi.fn(),
+      warn: vi.fn(),
     },
     mockToast: {
       error: vi.fn(),
@@ -300,15 +301,11 @@ describe("AppUrlListener", () => {
         url: "not-a-valid-url",
       });
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to parse deep link URL",
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Invalid deep link URL",
         expect.any(Error),
-        expect.objectContaining({
-          category: "general",
-          action: "parseDeepLink",
-          severity: "warning",
-        }),
       );
+      expect(mockLogger.error).not.toHaveBeenCalled();
 
       expect(mockToast.error).toHaveBeenCalledWith("deepLinks.invalidUrl");
     });
@@ -324,7 +321,11 @@ describe("AppUrlListener", () => {
         url: "",
       });
 
-      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Invalid deep link URL",
+        expect.any(Error),
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
       expect(mockToast.error).toHaveBeenCalledWith("deepLinks.invalidUrl");
     });
 

--- a/src/lib/deepLinks.tsx
+++ b/src/lib/deepLinks.tsx
@@ -60,11 +60,7 @@ const AppUrlListener: React.FC = () => {
           setWriteQueue(queryParams.v);
         }
       } catch (error) {
-        logger.error("Failed to parse deep link URL", error, {
-          category: "general",
-          action: "parseDeepLink",
-          severity: "warning",
-        });
+        logger.warn("Invalid deep link URL", error);
         toast.error(t("deepLinks.invalidUrl"));
       }
     },


### PR DESCRIPTION
## Summary
- Downgrade malformed external deep link parse failures from monitoring-visible errors to dev-only warnings.
- Keep invalid URL toast behavior for users.
- Update deep link tests to assert warnings and no error logging.

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted error logging for invalid deep links to use warning-level logging instead of error-level while maintaining error notifications to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->