### PR TITLE
Validate device addresses before connecting

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -91,12 +91,15 @@ vi.mock("../../../lib/coreApi", () => ({
       };
     }
 
+    const [host = address, portInput] = address.split(":");
+    const port = portInput ? Number(portInput) : 7497;
+
     return {
       ok: true,
       address,
-      host: address.split(":")[0] ?? address,
-      port: 7497,
-      wsUrl: `ws://${address}/api/v0.1`,
+      host,
+      port,
+      wsUrl: `ws://${host}:${port}/api/v0.1`,
     };
   }),
   isCancelled: vi.fn(() => false),

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -82,6 +82,23 @@ vi.mock("../../../lib/coreApi", () => ({
   },
   getDeviceAddress: vi.fn(() => "192.168.1.100:7497"),
   getWsUrl: vi.fn(() => "ws://192.168.1.100:7497"),
+  validateDeviceAddress: vi.fn((address: string) => {
+    if (address.includes("286")) {
+      return {
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+        message: "Invalid device address",
+      };
+    }
+
+    return {
+      ok: true,
+      address,
+      host: address.split(":")[0] ?? address,
+      port: 7497,
+      wsUrl: `ws://${address}/api/v0.1`,
+    };
+  }),
   isCancelled: vi.fn(() => false),
   isExpectedMediaDatabaseError: (error: unknown) => {
     if (!(error instanceof Error)) return false;
@@ -225,11 +242,33 @@ describe("ConnectionProvider", () => {
         expect.objectContaining({
           deviceId: "192.168.1.100:7497",
           type: "websocket",
-          address: "ws://192.168.1.100:7497",
+          address: "ws://192.168.1.100:7497/api/v0.1",
           encryption: expect.objectContaining({
             getCredentials: expect.any(Function),
           }),
         }),
+      );
+    });
+
+    it("should not create a transport for invalid target address", () => {
+      useStatusStore.setState({
+        ...useStatusStore.getInitialState(),
+        targetDeviceAddress: "192.168.1.286",
+      });
+
+      render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      expect(connectionManager.addDevice).not.toHaveBeenCalled();
+      expect(connectionManager.setActiveDevice).not.toHaveBeenCalled();
+      expect(useStatusStore.getState().connectionState).toBe(
+        ConnectionState.ERROR,
+      );
+      expect(useStatusStore.getState().connectionError).toBe(
+        "settings.deviceAddressInvalid",
       );
     });
 

--- a/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
+++ b/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
@@ -120,6 +120,20 @@ describe("DeviceConnectionCard", () => {
     expect(screen.getByText("scan.connectedHeading")).toBeInTheDocument();
   });
 
+  it("shows address validation error when provided", () => {
+    render(
+      <DeviceConnectionCard
+        {...defaultProps}
+        addressError="settings.deviceAddressInvalid"
+      />,
+    );
+
+    expect(
+      screen.getByText("settings.deviceAddressInvalid"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
   it("shows connection error when provided", () => {
     mockUseConnection.mockReturnValue({
       isConnected: false,

--- a/src/__tests__/unit/coreApi.internals.test.ts
+++ b/src/__tests__/unit/coreApi.internals.test.ts
@@ -87,19 +87,11 @@ describe("CoreAPI Internals", () => {
       expect(() => setDeviceAddress("test-address")).not.toThrow();
     });
 
-    it("should throw when getWsUrl encounters an error", () => {
-      // Mock String.prototype.lastIndexOf to throw an error during URL construction
-      const originalLastIndexOf = String.prototype.lastIndexOf;
-      String.prototype.lastIndexOf = vi.fn(() => {
-        throw new Error("String operation error");
-      });
+    it("should not throw for invalid saved device address", () => {
+      mockLocalStorage.getItem.mockReturnValue("192.168.1.286");
 
-      try {
-        expect(() => getWsUrl()).toThrow("String operation error");
-      } finally {
-        // Restore mock
-        String.prototype.lastIndexOf = originalLastIndexOf;
-      }
+      expect(() => getWsUrl()).not.toThrow();
+      expect(getWsUrl()).toBe("");
     });
   });
 

--- a/src/__tests__/unit/coreApi.write-operations.test.ts
+++ b/src/__tests__/unit/coreApi.write-operations.test.ts
@@ -393,13 +393,12 @@ describe("getWsUrl - Enhanced URL parsing", () => {
     expect(url).toBe("ws://[::1]:8080/api/v0.1");
   });
 
-  it("should strip invalid port and use default when port is out of range", () => {
-    localStorage.setItem("deviceAddress", "192.168.1.100:99999"); // Invalid port
+  it("should reject port that is out of range", () => {
+    localStorage.setItem("deviceAddress", "192.168.1.100:99999");
 
     const url = getWsUrl();
 
-    // Should strip invalid port and use default
-    expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+    expect(url).toBe("");
   });
 
   it("should reject malformed addresses with multiple colons that aren't valid IPv6", () => {
@@ -421,13 +420,12 @@ describe("getWsUrl - Enhanced URL parsing", () => {
     expect(url).toBe("");
   });
 
-  it("should handle trailing colon by stripping it", () => {
+  it("should reject trailing colon", () => {
     localStorage.setItem("deviceAddress", "192.168.1.100:");
 
     const url = getWsUrl();
 
-    // Trailing colon is stripped and default port is used
-    expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+    expect(url).toBe("");
   });
 
   it("should handle errors gracefully", () => {

--- a/src/__tests__/unit/hooks/useSelectDevice.test.tsx
+++ b/src/__tests__/unit/hooks/useSelectDevice.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, act } from "../../../test-utils";
 const {
   mockGetDeviceAddress,
   mockSetDeviceAddress,
+  mockValidateDeviceAddress,
   mockCoreReset,
   mockPreferencesRemove,
   mockResetConnectionState,
@@ -14,6 +15,13 @@ const {
 } = vi.hoisted(() => ({
   mockGetDeviceAddress: vi.fn(() => "192.168.1.10:7497"),
   mockSetDeviceAddress: vi.fn(),
+  mockValidateDeviceAddress: vi.fn((address: string): unknown => ({
+    ok: true,
+    address,
+    host: address.split(":")[0] ?? address,
+    port: 7497,
+    wsUrl: `ws://${address}/api/v0.1`,
+  })),
   mockCoreReset: vi.fn(),
   mockPreferencesRemove: vi.fn().mockResolvedValue(undefined),
   mockResetConnectionState: vi.fn(),
@@ -38,6 +46,7 @@ vi.mock("@/lib/coreApi", () => ({
   CoreAPI: { reset: mockCoreReset },
   getDeviceAddress: () => mockGetDeviceAddress(),
   setDeviceAddress: (v: string) => mockSetDeviceAddress(v),
+  validateDeviceAddress: (v: string) => mockValidateDeviceAddress(v),
 }));
 
 vi.mock("@/lib/store", () => ({
@@ -56,19 +65,33 @@ describe("useSelectDevice", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetDeviceAddress.mockReturnValue("192.168.1.10:7497");
+    mockValidateDeviceAddress.mockImplementation((address: string) => ({
+      ok: true,
+      address,
+      host: address.split(":")[0] ?? address,
+      port: 7497,
+      wsUrl: `ws://${address}/api/v0.1`,
+    }));
   });
 
   describe("selectDevice", () => {
     it("should short-circuit when the new address equals the current address", () => {
       const { result } = renderHook(() => useSelectDevice());
 
-      act(() => result.current.selectDevice("192.168.1.10:7497"));
+      let selectionResult: unknown;
+      act(() => {
+        selectionResult = result.current.selectDevice("192.168.1.10:7497");
+      });
 
       expect(mockSetDeviceAddress).not.toHaveBeenCalled();
       expect(mockResetConnectionState).not.toHaveBeenCalled();
       expect(mockSetTargetDeviceAddress).not.toHaveBeenCalled();
       expect(mockCoreReset).not.toHaveBeenCalled();
       expect(mockPreferencesRemove).not.toHaveBeenCalled();
+      expect(selectionResult).toMatchObject({
+        ok: true,
+        address: "192.168.1.10:7497",
+      });
     });
 
     it("should reset connection, target, API state, and search filters when switching devices", () => {
@@ -86,6 +109,46 @@ describe("useSelectDevice", () => {
       expect(mockPreferencesRemove).toHaveBeenCalledWith({
         key: "searchTags",
       });
+    });
+
+    it("should save normalized address when switching devices", () => {
+      mockValidateDeviceAddress.mockReturnValue({
+        ok: true,
+        address: "10.0.0.5:8080",
+        host: "10.0.0.5",
+        port: 8080,
+        wsUrl: "ws://10.0.0.5:8080/api/v0.1",
+      });
+      const { result } = renderHook(() => useSelectDevice());
+
+      act(() => result.current.selectDevice(" http://10.0.0.5:8080/api/v0.1 "));
+
+      expect(mockSetDeviceAddress).toHaveBeenCalledWith("10.0.0.5:8080");
+      expect(mockSetTargetDeviceAddress).toHaveBeenCalledWith("10.0.0.5:8080");
+    });
+
+    it("should not save or reconnect when address is invalid", () => {
+      mockValidateDeviceAddress.mockReturnValue({
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+        message: "Invalid device address",
+      });
+      const { result } = renderHook(() => useSelectDevice());
+
+      let selectionResult: unknown;
+      act(() => {
+        selectionResult = result.current.selectDevice("192.168.1.286");
+      });
+
+      expect(selectionResult).toMatchObject({
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+      });
+      expect(mockSetDeviceAddress).not.toHaveBeenCalled();
+      expect(mockResetConnectionState).not.toHaveBeenCalled();
+      expect(mockSetTargetDeviceAddress).not.toHaveBeenCalled();
+      expect(mockCoreReset).not.toHaveBeenCalled();
+      expect(mockPreferencesRemove).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/unit/hooks/useSelectDevice.test.tsx
+++ b/src/__tests__/unit/hooks/useSelectDevice.test.tsx
@@ -15,13 +15,18 @@ const {
 } = vi.hoisted(() => ({
   mockGetDeviceAddress: vi.fn(() => "192.168.1.10:7497"),
   mockSetDeviceAddress: vi.fn(),
-  mockValidateDeviceAddress: vi.fn((address: string): unknown => ({
-    ok: true,
-    address,
-    host: address.split(":")[0] ?? address,
-    port: 7497,
-    wsUrl: `ws://${address}/api/v0.1`,
-  })),
+  mockValidateDeviceAddress: vi.fn((address: string): unknown => {
+    const [host = address, portInput] = address.split(":");
+    const port = portInput ? Number(portInput) : 7497;
+
+    return {
+      ok: true,
+      address,
+      host,
+      port,
+      wsUrl: `ws://${host}:${port}/api/v0.1`,
+    };
+  }),
   mockCoreReset: vi.fn(),
   mockPreferencesRemove: vi.fn().mockResolvedValue(undefined),
   mockResetConnectionState: vi.fn(),
@@ -65,13 +70,18 @@ describe("useSelectDevice", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetDeviceAddress.mockReturnValue("192.168.1.10:7497");
-    mockValidateDeviceAddress.mockImplementation((address: string) => ({
-      ok: true,
-      address,
-      host: address.split(":")[0] ?? address,
-      port: 7497,
-      wsUrl: `ws://${address}/api/v0.1`,
-    }));
+    mockValidateDeviceAddress.mockImplementation((address: string) => {
+      const [host = address, portInput] = address.split(":");
+      const port = portInput ? Number(portInput) : 7497;
+
+      return {
+        ok: true,
+        address,
+        host,
+        port,
+        wsUrl: `ws://${host}:${port}/api/v0.1`,
+      };
+    });
   });
 
   describe("selectDevice", () => {
@@ -201,6 +211,34 @@ describe("useSelectDevice", () => {
           version: "1.0.0",
         },
       );
+    });
+
+    it("should not save or write history when scanned address is invalid", () => {
+      mockValidateDeviceAddress.mockReturnValue({
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+        message: "Invalid device address",
+      });
+      const { result } = renderHook(() => useSelectDevice());
+
+      let selectionResult: unknown;
+      act(() => {
+        selectionResult = result.current.selectScanDevice({
+          address: "192.168.1.286",
+        });
+      });
+
+      expect(selectionResult).toMatchObject({
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+      });
+      expect(mockSetDeviceAddress).not.toHaveBeenCalled();
+      expect(mockSetTargetDeviceAddress).not.toHaveBeenCalled();
+      expect(mockResetConnectionState).not.toHaveBeenCalled();
+      expect(mockCoreReset).not.toHaveBeenCalled();
+      expect(mockPreferencesRemove).not.toHaveBeenCalled();
+      expect(mockAddDeviceHistory).not.toHaveBeenCalled();
+      expect(mockUpdateDeviceHistoryMeta).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -327,25 +327,25 @@ describe("CoreAPI", () => {
       expect(wsUrl).toBe("ws://zaparoo.local:9090/api/v0.1");
     });
 
-    it("should strip invalid port and use default when port is non-numeric", () => {
+    it("should reject non-numeric port", () => {
       localStorageMock.getItem.mockReturnValue("192.168.1.100:abc");
 
       const wsUrl = getWsUrl();
-      expect(wsUrl).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(wsUrl).toBe("");
     });
 
-    it("should strip invalid port and use default when port is out of range", () => {
+    it("should reject port that is out of range", () => {
       localStorageMock.getItem.mockReturnValue("192.168.1.100:70000");
 
       const wsUrl = getWsUrl();
-      expect(wsUrl).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(wsUrl).toBe("");
     });
 
-    it("should strip invalid port and use default when port is zero", () => {
+    it("should reject zero port", () => {
       localStorageMock.getItem.mockReturnValue("192.168.1.100:0");
 
       const wsUrl = getWsUrl();
-      expect(wsUrl).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(wsUrl).toBe("");
     });
 
     it("should handle unbracketed IPv6 addresses by wrapping in brackets", () => {
@@ -364,11 +364,11 @@ describe("CoreAPI", () => {
       expect(wsUrl).toBe("ws://[fe80::1]:7497/api/v0.1");
     });
 
-    it("should handle trailing colon by stripping it and using default port", () => {
+    it("should reject trailing colon", () => {
       localStorageMock.getItem.mockReturnValue("192.168.1.100:");
 
       const wsUrl = getWsUrl();
-      expect(wsUrl).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(wsUrl).toBe("");
     });
 
     it("should use localhost with default port when no address is stored and on web", () => {

--- a/src/__tests__/unit/lib/coreApi.url.test.ts
+++ b/src/__tests__/unit/lib/coreApi.url.test.ts
@@ -93,6 +93,13 @@ describe("CoreAPI URL Functions", () => {
       expect(url).toBe("ws://mydevice.local:9000/api/v0.1");
     });
 
+    it("should use wss for secure stored URLs", () => {
+      localStorage.setItem("deviceAddress", "wss://mydevice.local:9000");
+
+      const url = getWsUrl();
+      expect(url).toBe("wss://mydevice.local:9000/api/v0.1");
+    });
+
     it("should reject invalid port number (out of range)", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:99999");
 
@@ -191,10 +198,23 @@ describe("CoreAPI URL Functions", () => {
       );
       expect(result).toEqual({
         ok: true,
-        address: "mydevice.local:9000",
+        address: "http://mydevice.local:9000",
         host: "mydevice.local",
         port: 9000,
         wsUrl: "ws://mydevice.local:9000/api/v0.1",
+      });
+    });
+
+    it("should preserve secure URL schemes", () => {
+      const result = validateDeviceAddress(
+        "https://mydevice.local:9000/api/v0.1",
+      );
+      expect(result).toEqual({
+        ok: true,
+        address: "https://mydevice.local:9000",
+        host: "mydevice.local",
+        port: 9000,
+        wsUrl: "wss://mydevice.local:9000/api/v0.1",
       });
     });
 

--- a/src/__tests__/unit/lib/coreApi.url.test.ts
+++ b/src/__tests__/unit/lib/coreApi.url.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { getWsUrl, getDeviceAddress, setDeviceAddress } from "@/lib/coreApi";
+import {
+  getWsUrl,
+  getDeviceAddress,
+  setDeviceAddress,
+  validateDeviceAddress,
+} from "@/lib/coreApi";
 
 describe("CoreAPI URL Functions", () => {
   beforeEach(() => {
@@ -88,37 +93,32 @@ describe("CoreAPI URL Functions", () => {
       expect(url).toBe("ws://mydevice.local:9000/api/v0.1");
     });
 
-    it("should use default port for invalid port number (out of range)", () => {
+    it("should reject invalid port number (out of range)", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:99999");
 
       const url = getWsUrl();
-      // Port 99999 is out of valid range (1-65535), should fall back to default
-      expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(url).toBe("");
     });
 
-    it("should use default port for zero port", () => {
+    it("should reject zero port", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:0");
 
       const url = getWsUrl();
-      // Port 0 is invalid, should fall back to default
-      expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(url).toBe("");
     });
 
-    it("should use default port for negative port", () => {
-      // This is an edge case - the regex won't match negative numbers
+    it("should reject negative port", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:-1");
 
       const url = getWsUrl();
-      // Non-numeric port after colon, strips it and uses default
-      expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(url).toBe("");
     });
 
-    it("should use default port for non-numeric port", () => {
+    it("should reject non-numeric port", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:abc");
 
       const url = getWsUrl();
-      // Non-numeric value after colon
-      expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(url).toBe("");
     });
 
     it("should handle unbracketed IPv6 by wrapping in brackets", () => {
@@ -154,10 +154,58 @@ describe("CoreAPI URL Functions", () => {
       expect(url).toBe("ws://192.168.1.100:1/api/v0.1");
     });
 
-    it("should handle trailing colon gracefully", () => {
+    it("should reject trailing colon", () => {
       localStorage.setItem("deviceAddress", "192.168.1.100:");
       const url = getWsUrl();
-      expect(url).toBe("ws://192.168.1.100:7497/api/v0.1");
+      expect(url).toBe("");
+    });
+
+    it("should reject invalid IPv4 octets before WebSocket construction", () => {
+      localStorage.setItem("deviceAddress", "192.168.1.286");
+      const url = getWsUrl();
+      expect(url).toBe("");
+    });
+
+    it("should reject addresses without a host", () => {
+      localStorage.setItem("deviceAddress", ":8080");
+      const url = getWsUrl();
+      expect(url).toBe("");
+    });
+  });
+
+  describe("validateDeviceAddress", () => {
+    it("should trim and normalize valid addresses", () => {
+      const result = validateDeviceAddress(" 192.168.1.100:8080 ");
+      expect(result).toEqual({
+        ok: true,
+        address: "192.168.1.100:8080",
+        host: "192.168.1.100",
+        port: 8080,
+        wsUrl: "ws://192.168.1.100:8080/api/v0.1",
+      });
+    });
+
+    it("should normalize pasted Core API URLs", () => {
+      const result = validateDeviceAddress(
+        "http://mydevice.local:9000/api/v0.1",
+      );
+      expect(result).toEqual({
+        ok: true,
+        address: "mydevice.local:9000",
+        host: "mydevice.local",
+        port: 9000,
+        wsUrl: "ws://mydevice.local:9000/api/v0.1",
+      });
+    });
+
+    it("should reject malformed IPv6", () => {
+      const result = validateDeviceAddress("2001:::1");
+      expect(result.ok).toBe(false);
+    });
+
+    it("should reject URL paths beyond the Core API endpoint", () => {
+      const result = validateDeviceAddress("http://mydevice.local/other");
+      expect(result.ok).toBe(false);
     });
   });
 });

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.test.ts
@@ -131,7 +131,8 @@ describe("WebSocketTransport", () => {
         // Should call onError with user-friendly message
         expect(onError).toHaveBeenCalledWith(
           expect.objectContaining({
-            message: "Invalid device address format",
+            message: "Invalid device address",
+            name: "InvalidDeviceAddressError",
           }),
         );
 

--- a/src/__tests__/unit/routes/settings.index.test.tsx
+++ b/src/__tests__/unit/routes/settings.index.test.tsx
@@ -15,6 +15,23 @@ vi.mock("@/lib/coreApi", () => ({
   },
   getDeviceAddress: vi.fn(() => "192.168.1.100"),
   setDeviceAddress: vi.fn(),
+  validateDeviceAddress: vi.fn((address: string) => {
+    if (address.includes("286")) {
+      return {
+        ok: false,
+        errorKey: "settings.deviceAddressInvalid",
+        message: "Invalid device address",
+      };
+    }
+
+    return {
+      ok: true,
+      address,
+      host: address.split(":")[0] ?? address,
+      port: 7497,
+      wsUrl: `ws://${address}/api/v0.1`,
+    };
+  }),
 }));
 
 // Mock stores
@@ -100,16 +117,22 @@ vi.mock("@/components/MediaDatabaseCard", () => ({
 
 vi.mock("@/components/DeviceConnectionCard", () => ({
   DeviceConnectionCard: ({
+    address,
+    setAddress,
     onScanClick,
     onAddressChange,
+    addressError,
   }: {
     address: string;
     setAddress: (address: string) => void;
     onAddressChange: (address: string) => void;
     connectionError: string;
+    addressError?: string;
     onScanClick: () => void;
   }) => (
     <div data-testid="device-connection-card">
+      <span data-testid="address-value">{address}</span>
+      {addressError && <span role="alert">{addressError}</span>}
       <button onClick={onScanClick} data-testid="scan-button">
         Scan
       </button>
@@ -118,6 +141,21 @@ vi.mock("@/components/DeviceConnectionCard", () => ({
         data-testid="change-address"
       >
         Change Address
+      </button>
+      <button
+        onClick={() => onAddressChange("192.168.1.286")}
+        data-testid="invalid-address"
+      >
+        Invalid Address
+      </button>
+      <button
+        onClick={() => {
+          setAddress("192.168.1.201");
+          onAddressChange("192.168.1.201");
+        }}
+        data-testid="valid-address"
+      >
+        Valid Address
       </button>
     </div>
   ),
@@ -344,6 +382,49 @@ describe("Settings Index Route", () => {
       await waitFor(() => {
         expect(invalidateQueriesSpy).toHaveBeenCalled();
       });
+    });
+
+    it("should show validation message and not select invalid address", async () => {
+      const mockResetConnectionState = vi.fn();
+      const mockSetTargetDeviceAddress = vi.fn();
+
+      mockUseStatusStore.mockImplementation((selector) =>
+        selector({
+          ...defaultStoreState,
+          resetConnectionState: mockResetConnectionState,
+          setTargetDeviceAddress: mockSetTargetDeviceAddress,
+        }),
+      );
+
+      renderComponent();
+
+      fireEvent.click(screen.getByTestId("invalid-address"));
+
+      expect(
+        await screen.findByText("settings.deviceAddressInvalid"),
+      ).toBeInTheDocument();
+      expect(mockResetConnectionState).not.toHaveBeenCalled();
+      expect(mockSetTargetDeviceAddress).not.toHaveBeenCalled();
+    });
+
+    it("should clear validation message after a valid address", async () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByTestId("invalid-address"));
+      expect(
+        await screen.findByText("settings.deviceAddressInvalid"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("valid-address"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("settings.deviceAddressInvalid"),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("address-value")).toHaveTextContent(
+        "192.168.1.201",
+      );
     });
   });
 

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -49,9 +49,9 @@ import { isCoreFeatureAvailable } from "@/lib/featureGates";
 import {
   CoreAPI,
   getDeviceAddress,
-  getWsUrl,
   isCancelled,
   isExpectedMediaDatabaseError,
+  validateDeviceAddress,
   type NotificationRequest,
 } from "@/lib/coreApi";
 import {
@@ -719,22 +719,18 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       return;
     }
 
-    let wsUrl: string;
-    try {
-      wsUrl = getWsUrl();
-    } catch (e) {
-      logger.error("Failed to construct WebSocket URL:", e);
-      setConnectionState(ConnectionState.ERROR);
-      setConnectionError(
-        e instanceof Error ? e.message : "Invalid configuration",
+    const addressResult = validateDeviceAddress(targetDeviceAddress);
+    if (!addressResult.ok) {
+      logger.warn(
+        `[ConnectionProvider] Invalid device address: ${targetDeviceAddress}`,
       );
-      return;
-    }
-    if (!wsUrl) {
       setConnectionState(ConnectionState.ERROR);
-      setConnectionError("Invalid WebSocket URL");
+      setConnectionError(tRef.current(addressResult.errorKey));
       return;
     }
+
+    const wsUrl = addressResult.wsUrl;
+    const deviceAddress = addressResult.address;
 
     // Generate unique ID for this connection session to prevent stale events
     // Use crypto.randomUUID if available, fallback for older Android WebViews
@@ -748,7 +744,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     CoreAPI.reset();
 
     logger.log(
-      `[ConnectionProvider] Setting up connection to: ${targetDeviceAddress} (id: ${connectionId.slice(0, 8)})`,
+      `[ConnectionProvider] Setting up connection to: ${deviceAddress} (id: ${connectionId.slice(0, 8)})`,
     );
 
     // Setup connection manager event handlers
@@ -849,7 +845,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       onCredentialsRevoked: () => {
         // Server rejected our stored credentials — clear them and prompt
         // the user to pair again.
-        const deviceKey = normalizeDeviceKey(targetDeviceAddress);
+        const deviceKey = normalizeDeviceKey(deviceAddress);
         credentialStore.delete(deviceKey).catch((err) => {
           logger.error("Failed to delete revoked credentials", err, {
             category: "storage",
@@ -859,7 +855,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         const updated = useStatusStore
           .getState()
           .deviceHistory.map((entry) =>
-            entry.address === targetDeviceAddress
+            entry.address === deviceAddress
               ? { ...entry, paired: undefined }
               : entry,
           );
@@ -875,16 +871,16 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
 
     // Add device and set as active
     const transport = connectionManager.addDevice({
-      deviceId: targetDeviceAddress,
+      deviceId: deviceAddress,
       type: "websocket",
       address: wsUrl,
       encryption: {
         getCredentials: () =>
-          credentialStore.get(normalizeDeviceKey(targetDeviceAddress)),
+          credentialStore.get(normalizeDeviceKey(deviceAddress)),
       },
     });
 
-    connectionManager.setActiveDevice(targetDeviceAddress);
+    connectionManager.setActiveDevice(deviceAddress);
 
     // Create a compatibility wrapper for CoreAPI
     const transportWrapper = {
@@ -919,7 +915,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       }
       // Reset CoreAPI to clear any pending requests for this connection
       CoreAPI.reset();
-      connectionManager.removeDevice(targetDeviceAddress);
+      connectionManager.removeDevice(deviceAddress);
       setConnectionState(ConnectionState.DISCONNECTED);
     };
   }, [

--- a/src/components/DeviceConnectionCard.tsx
+++ b/src/components/DeviceConnectionCard.tsx
@@ -16,6 +16,7 @@ interface DeviceConnectionCardProps {
   setAddress: (address: string) => void;
   onAddressChange: (address: string) => void;
   connectionError: string;
+  addressError?: string;
   onScanClick?: () => void;
 }
 
@@ -24,6 +25,7 @@ export function DeviceConnectionCard({
   setAddress,
   onAddressChange,
   connectionError,
+  addressError,
   onScanClick,
 }: DeviceConnectionCardProps) {
   const { t } = useTranslation();
@@ -66,6 +68,7 @@ export function DeviceConnectionCard({
             saveValue={onAddressChange}
             saveDisabled={address === savedAddress}
             autoComplete="off"
+            error={addressError}
             onKeyUp={(e) => {
               if (e.key === "Enter" && address !== savedAddress) {
                 onAddressChange(address);

--- a/src/hooks/useSelectDevice.ts
+++ b/src/hooks/useSelectDevice.ts
@@ -1,7 +1,13 @@
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Preferences } from "@capacitor/preferences";
-import { CoreAPI, getDeviceAddress, setDeviceAddress } from "@/lib/coreApi";
+import {
+  CoreAPI,
+  getDeviceAddress,
+  setDeviceAddress,
+  validateDeviceAddress,
+  type DeviceAddressValidationResult,
+} from "@/lib/coreApi";
 import { useStatusStore } from "@/lib/store";
 
 export interface ScanDeviceSelection {
@@ -23,12 +29,15 @@ export function useSelectDevice() {
   );
 
   const selectDevice = useCallback(
-    (newAddress: string) => {
-      if (newAddress === getDeviceAddress()) return;
+    (newAddress: string): DeviceAddressValidationResult => {
+      const result = validateDeviceAddress(newAddress);
+      if (!result.ok) return result;
 
-      setDeviceAddress(newAddress);
+      if (result.address === getDeviceAddress()) return result;
+
+      setDeviceAddress(result.address);
       resetConnectionState();
-      setTargetDeviceAddress(newAddress);
+      setTargetDeviceAddress(result.address);
       CoreAPI.reset();
       queryClient.invalidateQueries();
 
@@ -36,22 +45,28 @@ export function useSelectDevice() {
       // don't fire requests against unknown systems/tags on first load.
       Preferences.remove({ key: "searchSystem" }).catch(() => {});
       Preferences.remove({ key: "searchTags" }).catch(() => {});
+
+      return result;
     },
     [queryClient, resetConnectionState, setTargetDeviceAddress],
   );
 
   const selectScanDevice = useCallback(
     (device: ScanDeviceSelection) => {
-      selectDevice(device.address);
+      const result = selectDevice(device.address);
+      if (!result.ok) return result;
+
       // Capture metadata immediately. The version() RPC populates these fields
       // post-connect, but if the user disconnects first we still want a
       // populated row to show in the device list.
-      addDeviceHistory(device.address);
-      updateDeviceHistoryMeta(device.address, {
+      addDeviceHistory(result.address);
+      updateDeviceHistoryMeta(result.address, {
         name: device.name,
         platform: device.platform,
         version: device.version,
       });
+
+      return result;
     },
     [addDeviceHistory, selectDevice, updateDeviceHistoryMeta],
   );

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -1687,29 +1687,45 @@ function validateHost(host: string): boolean {
   return false;
 }
 
-function formatDeviceAddress(host: string, port: number): string {
+type DeviceAddressScheme = "http" | "https" | "ws" | "wss";
+
+type WebSocketScheme = "ws" | "wss";
+
+function formatDeviceAddress(
+  host: string,
+  port: number,
+  scheme?: DeviceAddressScheme,
+): string {
   const hostPart = host.includes(":") ? `[${host}]` : host;
-  return port === DEFAULT_DEVICE_PORT ? hostPart : `${hostPart}:${port}`;
+  const address =
+    port === DEFAULT_DEVICE_PORT ? hostPart : `${hostPart}:${port}`;
+  return scheme ? `${scheme}://${address}` : address;
 }
 
-function formatWsUrl(host: string, port: number): string {
+function formatWsUrl(
+  host: string,
+  port: number,
+  scheme: WebSocketScheme = "ws",
+): string {
   const hostPart = host.includes(":") ? `[${host}]` : host;
-  return `ws://${hostPart}:${port}/api/v0.1`;
+  return `${scheme}://${hostPart}:${port}/api/v0.1`;
 }
 
 function validateHostAndPort(
   host: string,
   port: number | null,
+  addressScheme?: DeviceAddressScheme,
+  wsScheme?: WebSocketScheme,
 ): DeviceAddressValidationResult {
   if (port === null) return invalidDeviceAddress();
   if (!validateHost(host)) return invalidDeviceAddress();
 
   return {
     ok: true,
-    address: formatDeviceAddress(host, port),
+    address: formatDeviceAddress(host, port, addressScheme),
     host,
     port,
-    wsUrl: formatWsUrl(host, port),
+    wsUrl: formatWsUrl(host, port, wsScheme),
   };
 }
 
@@ -1735,20 +1751,24 @@ function normalizeUrlInput(
     return invalidDeviceAddress();
   }
 
+  const addressScheme = url.protocol.slice(0, -1) as DeviceAddressScheme;
+  const wsScheme: WebSocketScheme = ["https:", "wss:"].includes(url.protocol)
+    ? "wss"
+    : "ws";
   const host = url.hostname.replace(/^\[|\]$/g, "");
   const port = parsePort(url.port || undefined);
   if (host.includes(":")) {
     if (port === null || !isValidIPv6(host)) return invalidDeviceAddress();
     return {
       ok: true,
-      address: formatDeviceAddress(host, port),
+      address: formatDeviceAddress(host, port, addressScheme),
       host,
       port,
-      wsUrl: formatWsUrl(host, port),
+      wsUrl: formatWsUrl(host, port, wsScheme),
     };
   }
 
-  return validateHostAndPort(host, port);
+  return validateHostAndPort(host, port, addressScheme, wsScheme);
 }
 
 export function validateDeviceAddress(

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -1593,6 +1593,221 @@ class CoreApi {
 export const CoreAPI = new CoreApi();
 
 const addrKey = "deviceAddress";
+const DEFAULT_DEVICE_PORT = 7497;
+const INVALID_DEVICE_ADDRESS_MESSAGE = "Invalid device address";
+
+export class InvalidDeviceAddressError extends Error {
+  constructor(message = INVALID_DEVICE_ADDRESS_MESSAGE) {
+    super(message);
+    this.name = "InvalidDeviceAddressError";
+  }
+}
+
+export interface ValidDeviceAddress {
+  ok: true;
+  address: string;
+  host: string;
+  port: number;
+  wsUrl: string;
+}
+
+export interface InvalidDeviceAddress {
+  ok: false;
+  errorKey: "settings.deviceAddressRequired" | "settings.deviceAddressInvalid";
+  message: string;
+}
+
+export type DeviceAddressValidationResult =
+  | ValidDeviceAddress
+  | InvalidDeviceAddress;
+
+function invalidDeviceAddress(
+  errorKey: InvalidDeviceAddress["errorKey"] = "settings.deviceAddressInvalid",
+): InvalidDeviceAddress {
+  return {
+    ok: false,
+    errorKey,
+    message:
+      errorKey === "settings.deviceAddressRequired"
+        ? "Enter a device address"
+        : INVALID_DEVICE_ADDRESS_MESSAGE,
+  };
+}
+
+function parsePort(port: string | undefined): number | null {
+  if (port === undefined) return DEFAULT_DEVICE_PORT;
+  if (!/^\d+$/.test(port)) return null;
+
+  const parsed = Number(port);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) return null;
+  return parsed;
+}
+
+function isValidIPv4(host: string): boolean {
+  const octets = host.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => {
+      if (!/^\d+$/.test(octet)) return false;
+      if (octet.length > 1 && octet.startsWith("0")) return false;
+      const parsed = Number(octet);
+      return parsed >= 0 && parsed <= 255;
+    })
+  );
+}
+
+function isValidIPv6(host: string): boolean {
+  try {
+    new URL(`ws://[${host}]`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidHostname(host: string): boolean {
+  if (host.length === 0 || host.length > 253) return false;
+  if (/^[0-9.]+$/.test(host)) return false;
+
+  const labels = host.split(".");
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      label.length <= 63 &&
+      /^[a-zA-Z0-9-]+$/.test(label) &&
+      !label.startsWith("-") &&
+      !label.endsWith("-"),
+  );
+}
+
+function validateHost(host: string): boolean {
+  if (isValidIPv4(host) || isValidHostname(host)) return true;
+
+  if (/^[0-9.]+$/.test(host)) return false;
+  return false;
+}
+
+function formatDeviceAddress(host: string, port: number): string {
+  const hostPart = host.includes(":") ? `[${host}]` : host;
+  return port === DEFAULT_DEVICE_PORT ? hostPart : `${hostPart}:${port}`;
+}
+
+function formatWsUrl(host: string, port: number): string {
+  const hostPart = host.includes(":") ? `[${host}]` : host;
+  return `ws://${hostPart}:${port}/api/v0.1`;
+}
+
+function validateHostAndPort(
+  host: string,
+  port: number | null,
+): DeviceAddressValidationResult {
+  if (port === null) return invalidDeviceAddress();
+  if (!validateHost(host)) return invalidDeviceAddress();
+
+  return {
+    ok: true,
+    address: formatDeviceAddress(host, port),
+    host,
+    port,
+    wsUrl: formatWsUrl(host, port),
+  };
+}
+
+function normalizeUrlInput(
+  input: string,
+): DeviceAddressValidationResult | null {
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(input)) return null;
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return invalidDeviceAddress();
+  }
+
+  if (!["ws:", "wss:", "http:", "https:"].includes(url.protocol)) {
+    return invalidDeviceAddress();
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    return invalidDeviceAddress();
+  }
+  if (!["", "/", "/api/v0.1"].includes(url.pathname)) {
+    return invalidDeviceAddress();
+  }
+
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+  const port = parsePort(url.port || undefined);
+  if (host.includes(":")) {
+    if (port === null || !isValidIPv6(host)) return invalidDeviceAddress();
+    return {
+      ok: true,
+      address: formatDeviceAddress(host, port),
+      host,
+      port,
+      wsUrl: formatWsUrl(host, port),
+    };
+  }
+
+  return validateHostAndPort(host, port);
+}
+
+export function validateDeviceAddress(
+  input: string,
+): DeviceAddressValidationResult {
+  const address = input.trim();
+  if (!address) return invalidDeviceAddress("settings.deviceAddressRequired");
+
+  const urlResult = normalizeUrlInput(address);
+  if (urlResult) return urlResult;
+
+  if (/\s/.test(address)) return invalidDeviceAddress();
+
+  if (address.startsWith("[")) {
+    const match = /^\[([^\]]+)](?::([^:]+))?$/.exec(address);
+    if (!match) return invalidDeviceAddress();
+
+    const [, host, portInput] = match;
+    if (!host || !isValidIPv6(host)) return invalidDeviceAddress();
+
+    const port = parsePort(portInput);
+    if (port === null) return invalidDeviceAddress();
+
+    return {
+      ok: true,
+      address: formatDeviceAddress(host, port),
+      host,
+      port,
+      wsUrl: formatWsUrl(host, port),
+    };
+  }
+
+  const colonCount = (address.match(/:/g) || []).length;
+  if (colonCount > 1) {
+    if (!isValidIPv6(address)) return invalidDeviceAddress();
+    return {
+      ok: true,
+      address: formatDeviceAddress(address, DEFAULT_DEVICE_PORT),
+      host: address,
+      port: DEFAULT_DEVICE_PORT,
+      wsUrl: formatWsUrl(address, DEFAULT_DEVICE_PORT),
+    };
+  }
+
+  if (colonCount === 1) {
+    const [host, portInput] = address.split(":");
+    if (!host || !portInput) return invalidDeviceAddress();
+    return validateHostAndPort(host, parsePort(portInput));
+  }
+
+  return validateHostAndPort(address, DEFAULT_DEVICE_PORT);
+}
+
+export function isInvalidDeviceAddressError(error: unknown): boolean {
+  return (
+    error instanceof InvalidDeviceAddressError ||
+    (error instanceof Error && error.message === INVALID_DEVICE_ADDRESS_MESSAGE)
+  );
+}
 
 export function getDeviceAddress() {
   const addr = localStorage.getItem(addrKey) || "";
@@ -1618,74 +1833,20 @@ export function parseDeviceAddress(address: string): {
   host: string;
   port: number;
 } {
-  const DEFAULT_PORT = 7497;
-  if (!address) return { host: "", port: DEFAULT_PORT };
-
-  // Bracketed IPv6: [::1] or [::1]:8080
-  if (address.startsWith("[")) {
-    const closeBracket = address.indexOf("]");
-    if (closeBracket > 0) {
-      const host = address.substring(0, closeBracket + 1);
-      const afterBracket = address.substring(closeBracket + 1);
-      if (afterBracket.startsWith(":") && afterBracket.length > 1) {
-        const portNum = parseInt(afterBracket.substring(1), 10);
-        if (portNum > 0 && portNum <= 65535) return { host, port: portNum };
-      }
-      return { host, port: DEFAULT_PORT };
-    }
-  }
-
-  // Unbracketed IPv6 (multiple colons, no port)
-  const colonCount = (address.match(/:/g) || []).length;
-  if (colonCount > 1) return { host: address, port: DEFAULT_PORT };
-
-  // IPv4 or hostname with optional port
-  const lastColon = address.lastIndexOf(":");
-  if (lastColon > 0) {
-    const potentialPort = address.substring(lastColon + 1);
-    if (/^\d+$/.test(potentialPort)) {
-      const portNum = parseInt(potentialPort, 10);
-      if (portNum > 0 && portNum <= 65535) {
-        return { host: address.substring(0, lastColon), port: portNum };
-      }
-    }
-    return { host: address.substring(0, lastColon), port: DEFAULT_PORT };
-  }
-
-  return { host: address, port: DEFAULT_PORT };
+  const result = validateDeviceAddress(address);
+  if (result.ok) return { host: result.host, port: result.port };
+  return { host: "", port: DEFAULT_DEVICE_PORT };
 }
 
 export function getWsUrl() {
   const address = getDeviceAddress();
   if (!address) return "";
 
-  // ":8080" — leading colon means no host, can't build a URL. "::1" and other
-  // compressed-IPv6 forms start with "::" and are still valid.
-  if (address.startsWith(":") && !address.startsWith("::")) {
+  const result = validateDeviceAddress(address);
+  if (!result.ok) {
     logger.warn(`Invalid device address format: ${address}`);
     return "";
   }
 
-  // Reject obviously-broken unbracketed IPv6 (multiple colons but a non-hex
-  // segment) before letting parseDeviceAddress treat it as a bare hostname.
-  if (!address.startsWith("[")) {
-    const colonCount = (address.match(/:/g) || []).length;
-    if (colonCount > 1) {
-      const segments = address.split(":");
-      const isValidIPv6 = segments.every(
-        (seg) => seg === "" || /^[0-9a-fA-F]{1,4}$/.test(seg),
-      );
-      if (!isValidIPv6) {
-        logger.warn(`Invalid address format (not valid IPv6): ${address}`);
-        return "";
-      }
-    }
-  }
-
-  const { host, port } = parseDeviceAddress(address);
-
-  // Bracket unbracketed IPv6 hosts so the URL is well-formed.
-  const urlHost =
-    host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
-  return `ws://${urlHost}:${port}/api/v0.1`;
+  return result.wsUrl;
 }

--- a/src/lib/transport/ConnectionManager.ts
+++ b/src/lib/transport/ConnectionManager.ts
@@ -5,7 +5,7 @@
  * Routes messages to the active transport and handles lifecycle events.
  */
 
-import { isInvalidDeviceAddressError } from "../coreApi";
+import { isInvalidDeviceAddressError } from "@/lib/coreApi";
 import { logger } from "../logger";
 import type {
   Transport,
@@ -89,11 +89,23 @@ export class ConnectionManager {
           logger.warn(
             `[ConnectionManager] Device ${config.deviceId} invalid address`,
             error,
+            {
+              category: "connection",
+              action: "device-connect",
+              severity: "warning",
+              deviceId: config.deviceId,
+            },
           );
         } else {
           logger.error(
             `[ConnectionManager] Device ${config.deviceId} error:`,
             error,
+            {
+              category: "connection",
+              action: "device-connect",
+              severity: "error",
+              deviceId: config.deviceId,
+            },
           );
         }
         this.handlers.onError?.(config.deviceId, error);

--- a/src/lib/transport/ConnectionManager.ts
+++ b/src/lib/transport/ConnectionManager.ts
@@ -5,6 +5,7 @@
  * Routes messages to the active transport and handles lifecycle events.
  */
 
+import { isInvalidDeviceAddressError } from "../coreApi";
 import { logger } from "../logger";
 import type {
   Transport,
@@ -84,10 +85,17 @@ export class ConnectionManager {
         // State will be updated by onStateChange
       },
       onError: (error) => {
-        logger.error(
-          `[ConnectionManager] Device ${config.deviceId} error:`,
-          error,
-        );
+        if (isInvalidDeviceAddressError(error)) {
+          logger.warn(
+            `[ConnectionManager] Device ${config.deviceId} invalid address`,
+            error,
+          );
+        } else {
+          logger.error(
+            `[ConnectionManager] Device ${config.deviceId} error:`,
+            error,
+          );
+        }
         this.handlers.onError?.(config.deviceId, error);
       },
       onMessage: (event) => {

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -5,6 +5,7 @@
  * Message queuing is handled at the CoreAPI level, not here.
  */
 
+import { InvalidDeviceAddressError } from "../coreApi";
 import { logger } from "../logger";
 import { EncryptedSession } from "../crypto/session";
 import type {
@@ -320,8 +321,7 @@ export class WebSocketTransport implements Transport {
         logger.warn(
           `[Transport:${this.deviceId}] Invalid device address format`,
         );
-        // Provide a user-friendly error message
-        this.handlers.onError?.(new Error("Invalid device address format"));
+        this.handlers.onError?.(new InvalidDeviceAddressError());
       } else {
         logger.error(
           `[Transport:${this.deviceId}] Failed to create WebSocket:`,

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -5,7 +5,7 @@
  * Message queuing is handled at the CoreAPI level, not here.
  */
 
-import { InvalidDeviceAddressError } from "../coreApi";
+import { InvalidDeviceAddressError } from "@/lib/coreApi";
 import { logger } from "../logger";
 import { EncryptedSession } from "../crypto/session";
 import type {

--- a/src/routes/settings.index.tsx
+++ b/src/routes/settings.index.tsx
@@ -49,6 +49,7 @@ function Settings() {
     isCoreFeatureAvailable("mediaScrapers", coreVersion);
 
   const [address, setAddress] = useState(getDeviceAddress());
+  const [addressError, setAddressError] = useState("");
   const [scanOpen, setScanOpen] = useState(false);
 
   const { selectDevice, selectScanDevice } = useSelectDevice();
@@ -61,14 +62,31 @@ function Settings() {
     });
   }, [setDeviceHistory]);
 
-  const handleDeviceAddressChange = (newAddress: string) => {
-    selectDevice(newAddress);
+  const handleAddressInputChange = (newAddress: string) => {
     setAddress(newAddress);
+    if (addressError) setAddressError("");
+  };
+
+  const handleDeviceAddressChange = (newAddress: string) => {
+    const result = selectDevice(newAddress);
+    if (!result.ok) {
+      setAddressError(t(result.errorKey));
+      return;
+    }
+
+    setAddress(result.address);
+    setAddressError("");
   };
 
   const handleScanDeviceSelect = (device: ScanDeviceSelection) => {
-    selectScanDevice(device);
-    setAddress(device.address);
+    const result = selectScanDevice(device);
+    if (!result.ok) {
+      setAddressError(t(result.errorKey));
+      return;
+    }
+
+    setAddress(result.address);
+    setAddressError("");
   };
 
   return (
@@ -89,9 +107,10 @@ function Settings() {
           <div data-tour="device-address">
             <DeviceConnectionCard
               address={address}
-              setAddress={setAddress}
+              setAddress={handleAddressInputChange}
               onAddressChange={handleDeviceAddressChange}
               connectionError={connectionError}
+              addressError={addressError}
               onScanClick={() => setScanOpen(true)}
             />
           </div>

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -416,6 +416,8 @@
       "title": "Settings",
       "moreSettings": "More settings",
       "device": "Device address",
+      "deviceAddressRequired": "Enter a device address",
+      "deviceAddressInvalid": "Enter a valid hostname, IP address, or host:port.",
       "modeLabel": "Scan mode",
       "tapMode": "Tap",
       "insertMode": "Hold",


### PR DESCRIPTION
Summary:
- validate and normalize device addresses before saving or opening WebSocket connections
- show settings validation messages for invalid address input
- downgrade expected invalid-address transport logging to warnings
- update URL, settings, selection, and transport tests

Closes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized device-address validation with user-facing error messages and UI wiring to surface them.
  * Address validation results are returned from device-selection flows so callers can react.

* **Bug Fixes**
  * Connection setup now rejects malformed addresses and moves to an error state instead of attempting fallback parsing.
  * Transport error reporting distinguishes invalid-address failures.

* **Tests**
  * Expanded tests covering validation, UI error display, connection behavior, and storage edge cases.

* **Localization**
  * Added device-address validation strings for settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->