### PR TITLE
fix: handle malformed Core JSON responses

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -370,6 +370,29 @@ describe("notification processing", () => {
     });
   });
 
+  describe("message error handling", () => {
+    it("should show recoverable toast when message processing fails", async () => {
+      const { resetToastRateLimiter } = await import("@/lib/toastUtils");
+      resetToastRateLimiter();
+      vi.mocked(CoreAPI.processReceived).mockRejectedValueOnce(
+        new Error("Malformed Core JSON response: Unexpected end of JSON input"),
+      );
+
+      render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      expect(capturedEventHandlers.onMessage).toBeDefined();
+      await capturedEventHandlers.onMessage!("test-device", {});
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("error");
+      });
+    });
+  });
+
   describe("media.stopped", () => {
     it("should clear playing state and staged token when media stops", async () => {
       useStatusStore.setState({

--- a/src/__tests__/unit/components/TagSelector.test.tsx
+++ b/src/__tests__/unit/components/TagSelector.test.tsx
@@ -16,7 +16,7 @@ import { render, screen, waitFor, act } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import { TagSelector, TagSelectorTrigger } from "@/components/TagSelector";
 import { useStatusStore } from "@/lib/store";
-import { CoreAPI } from "@/lib/coreApi";
+import { CoreAPI, MalformedCoreResponseError } from "@/lib/coreApi";
 import { TagInfo } from "@/lib/models";
 
 // Mock CoreAPI
@@ -24,6 +24,17 @@ vi.mock("@/lib/coreApi", () => ({
   CoreAPI: {
     mediaTags: vi.fn(),
     reset: vi.fn(),
+  },
+  MalformedCoreResponseError: class MalformedCoreResponseError extends Error {
+    constructor(
+      public readonly parseMessage: string,
+      public readonly requestId: string | null,
+      public readonly dataLength: number,
+      public readonly dataPreview: string,
+    ) {
+      super(`Malformed Core JSON response: ${parseMessage}`);
+      this.name = "MalformedCoreResponseError";
+    }
   },
 }));
 
@@ -115,6 +126,26 @@ describe("TagSelector", () => {
     it("should render error state when tags API fails", async () => {
       // Arrange
       vi.mocked(CoreAPI.mediaTags).mockRejectedValue(new Error("API Error"));
+
+      // Act
+      render(<TagSelector {...defaultProps} />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("tagSelector.unavailable")).toBeInTheDocument();
+      });
+    });
+
+    it("should render error state when tags response is malformed", async () => {
+      // Arrange
+      vi.mocked(CoreAPI.mediaTags).mockRejectedValue(
+        new MalformedCoreResponseError(
+          "Unexpected end of JSON input",
+          null,
+          42,
+          "{",
+        ),
+      );
 
       // Act
       render(<TagSelector {...defaultProps} />);

--- a/src/__tests__/unit/coreApi.api-contract.test.ts
+++ b/src/__tests__/unit/coreApi.api-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { CoreAPI } from "../../lib/coreApi";
+import { CoreAPI, MalformedCoreResponseError } from "../../lib/coreApi";
 import { logger } from "../../lib/logger";
 import {
   HistoryResponseEntry,
@@ -139,6 +139,28 @@ describe("CoreAPI API Contract", () => {
           action: "mediaTags",
           severity: "warning",
         },
+      );
+    });
+
+    it("mediaTags should report malformed Core responses as recoverable warnings", async () => {
+      const warnSpy = vi.spyOn(logger, "warn");
+      const promise = CoreAPI.mediaTags();
+      const request = JSON.parse(mockSend.mock.calls[0]![0]);
+
+      await CoreAPI.processReceived({
+        data: `{"jsonrpc":"2.0","id":"${request.id}","result":{"tags":[`,
+      } as MessageEvent);
+
+      await expect(promise).rejects.toBeInstanceOf(MalformedCoreResponseError);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Media tags API call failed:",
+        expect.any(MalformedCoreResponseError),
+        expect.objectContaining({
+          category: "api",
+          action: "mediaTags",
+          severity: "warning",
+          requestId: request.id,
+        }),
       );
     });
 

--- a/src/__tests__/unit/coreApi.internals.test.ts
+++ b/src/__tests__/unit/coreApi.internals.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   CoreAPI,
+  MalformedCoreResponseError,
   getDeviceAddress,
   setDeviceAddress,
   getWsUrl,
@@ -132,6 +133,16 @@ describe("CoreAPI Internals", () => {
       await expect(CoreAPI.processReceived(messageEvent)).rejects.toThrow(
         "Not a valid JSON-RPC payload.",
       );
+    });
+
+    it("should classify malformed JSON as a recoverable Core response error", async () => {
+      const messageEvent = new MessageEvent("message", {
+        data: '{"jsonrpc":"2.0","result":',
+      });
+
+      await expect(
+        CoreAPI.processReceived(messageEvent),
+      ).rejects.toBeInstanceOf(MalformedCoreResponseError);
     });
 
     it("should process notifications and return method/params", async () => {

--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   CoreAPI,
   CoreApiError,
+  MalformedCoreResponseError,
   getDeviceAddress,
   getWsUrl,
   isExpectedMediaDatabaseError,
@@ -167,11 +168,25 @@ describe("CoreAPI", () => {
     expect(result).toBeNull();
   });
 
-  it("should handle invalid JSON in processReceived", async () => {
+  it("should reject unknown malformed JSON in processReceived", async () => {
     const invalidJsonEvent = { data: "invalid json" } as MessageEvent;
-    await expect(CoreAPI.processReceived(invalidJsonEvent)).rejects.toThrow(
-      "Error parsing JSON response",
-    );
+
+    await expect(
+      CoreAPI.processReceived(invalidJsonEvent),
+    ).rejects.toBeInstanceOf(MalformedCoreResponseError);
+  });
+
+  it("should reject matching pending requests for malformed JSON responses", async () => {
+    const promise = CoreAPI.version();
+    const sentData = JSON.parse(mockSend.mock.calls[0][0]);
+
+    await expect(
+      CoreAPI.processReceived({
+        data: `{"jsonrpc":"2.0","id":"${sentData.id}","result":{"version":`,
+      } as MessageEvent),
+    ).resolves.toBeNull();
+
+    await expect(promise).rejects.toBeInstanceOf(MalformedCoreResponseError);
   });
 
   it.each([

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -69,6 +69,47 @@ export class CoreApiError extends Error {
   }
 }
 
+export class MalformedCoreResponseError extends Error {
+  constructor(
+    public readonly parseMessage: string,
+    public readonly requestId: string | null,
+    public readonly dataLength: number,
+    public readonly dataPreview: string,
+  ) {
+    super(`Malformed Core JSON response: ${parseMessage}`);
+    this.name = "MalformedCoreResponseError";
+  }
+}
+
+export function isMalformedCoreResponseError(
+  error: unknown,
+): error is MalformedCoreResponseError {
+  return error instanceof MalformedCoreResponseError;
+}
+
+function normalizeMessageData(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  return String(data);
+}
+
+function createSanitizedDataPreview(data: string): string {
+  return Array.from(data)
+    .map((char) => {
+      const codePoint = char.codePointAt(0) ?? 0;
+      return codePoint <= 31 || codePoint === 127 ? " " : char;
+    })
+    .join("")
+    .slice(0, 200);
+}
+
+function extractJsonRpcIdFromMalformedData(data: string): string | null {
+  const match = data.match(/"id"\s*:\s*"([^"\\\r\n]{1,128})"/);
+  return match?.[1] ?? null;
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
@@ -104,6 +145,18 @@ function logMediaApiFailure(
   error: unknown,
   severity: "error" | "warning" = "error",
 ): void {
+  if (isMalformedCoreResponseError(error)) {
+    logger.warn(`${label}:`, error, {
+      category: "api",
+      action,
+      severity: "warning",
+      requestId: error.requestId,
+      dataLength: error.dataLength,
+      dataPreview: error.dataPreview,
+    });
+    return;
+  }
+
   if (isExpectedMediaDatabaseError(error)) {
     logger.warn(`${label}:`, error, {
       category: "api",
@@ -592,21 +645,45 @@ class CoreApi {
           return;
         }
 
+        const rawData = normalizeMessageData(msg.data);
         let res: ApiResponse;
         try {
-          res = JSON.parse(msg.data);
+          res = JSON.parse(rawData);
         } catch (e) {
-          logger.error("Could not parse JSON:", msg.data, e, {
+          const parseMessage = e instanceof Error ? e.message : String(e);
+          const requestId = extractJsonRpcIdFromMalformedData(rawData);
+          const error = new MalformedCoreResponseError(
+            parseMessage,
+            requestId,
+            rawData.length,
+            createSanitizedDataPreview(rawData),
+          );
+          logger.error("Malformed Core JSON response:", error, {
             category: "api",
             action: "parseJSON",
-            severity: "critical",
-            dataPreview: String(msg.data).slice(0, 100),
+            severity: "warning",
+            requestId,
+            dataLength: error.dataLength,
+            dataPreview: error.dataPreview,
           });
-          reject(
-            new Error(
-              `Error parsing JSON response: ${e instanceof Error ? e.message : String(e)}`,
-            ),
-          );
+
+          if (requestId) {
+            const pendingResponse = this.responsePool[requestId];
+            if (pendingResponse) {
+              if (pendingResponse.timeoutId) {
+                clearTimeout(pendingResponse.timeoutId);
+              }
+              pendingResponse.reject(error);
+              delete this.responsePool[requestId];
+              if (requestId === this.pendingWriteId) {
+                this.pendingWriteId = null;
+              }
+              resolve(null);
+              return;
+            }
+          }
+
+          reject(error);
           return;
         }
 

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -96,13 +96,18 @@ function normalizeMessageData(data: unknown): string {
 }
 
 function createSanitizedDataPreview(data: string): string {
-  return Array.from(data)
-    .map((char) => {
-      const codePoint = char.codePointAt(0) ?? 0;
-      return codePoint <= 31 || codePoint === 127 ? " " : char;
-    })
-    .join("")
-    .slice(0, 200);
+  let preview = "";
+
+  for (let index = 0; index < data.length && preview.length < 200; ) {
+    const codePoint = data.codePointAt(index) ?? 0;
+    const charLength = codePoint > 0xffff ? 2 : 1;
+    const char = data.slice(index, index + charLength);
+
+    preview += codePoint <= 31 || codePoint === 127 ? " " : char;
+    index += charLength;
+  }
+
+  return preview;
 }
 
 function extractJsonRpcIdFromMalformedData(data: string): string | null {
@@ -658,15 +663,6 @@ class CoreApi {
             rawData.length,
             createSanitizedDataPreview(rawData),
           );
-          logger.error("Malformed Core JSON response:", error, {
-            category: "api",
-            action: "parseJSON",
-            severity: "warning",
-            requestId,
-            dataLength: error.dataLength,
-            dataPreview: error.dataPreview,
-          });
-
           if (requestId) {
             const pendingResponse = this.responsePool[requestId];
             if (pendingResponse) {


### PR DESCRIPTION
Closes #147

## Summary
- add a typed malformed Core response error with sanitized parse-failure context
- reject matching pending JSON-RPC requests immediately when malformed frames include an id
- keep media tags and message handling on recoverable UI error paths

Validated with focused CoreAPI, TagSelector, and ConnectionProvider tests plus typecheck and lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for malformed API responses, including notification handling and tag-loading error states.

* **Bug Fixes**
  * Improved handling of malformed API responses: clearer user-facing error notifications, tag selector shows an "unavailable" state for malformed data, and recoverable malformed responses are logged as warnings to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->