### PR TITLE
Fix Android startup bridge hardening

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -16,9 +16,11 @@ const config: CapacitorConfig = {
         : undefined,
     androidScheme: "http",
     cleartext: true,
+    errorPath: "unsupported-webview.html",
   },
   android: {
     allowMixedContent: true,
+    minWebViewVersion: 60,
   },
   plugins: {
     CapacitorHttp: {

--- a/public/unsupported-webview.html
+++ b/public/unsupported-webview.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Unsupported Android WebView</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        background: #111928;
+        color: #f9fafb;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+
+      main {
+        max-width: 520px;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+        line-height: 1.2;
+        margin: 0 0 16px;
+      }
+
+      p {
+        color: #d1d5db;
+        line-height: 1.5;
+        margin: 0 0 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Android WebView update required</h1>
+      <p>
+        Zaparoo requires a newer Android System WebView or Chrome before it can
+        start safely.
+      </p>
+      <p>
+        Update Android System WebView or Chrome from Google Play, then restart
+        Zaparoo. If updates are unavailable, update device firmware.
+      </p>
+    </main>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import toast, { Toaster, useToasterStore } from "react-hot-toast";
-import { Capacitor } from "@capacitor/core";
 import { StatusBar, Style } from "@capacitor/status-bar";
 import { usePrevious } from "@uidotdev/usehooks";
 import { useTranslation } from "react-i18next";
@@ -34,6 +33,10 @@ import { useLiveUpdate } from "./hooks/useLiveUpdate";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
 import { purchasesReady } from "./lib/purchasesSetup";
+import {
+  isNativePluginAvailable,
+  isPluginAvailable,
+} from "./lib/capacitorBridge";
 import {
   A11yAnnouncerProvider,
   useAnnouncer,
@@ -211,9 +214,13 @@ export default function App() {
     initDeviceInfo();
 
     // Show status bar and configure style
-    if (Capacitor.isNativePlatform()) {
-      StatusBar.show();
-      StatusBar.setStyle({ style: Style.Dark });
+    if (isNativePluginAvailable("StatusBar")) {
+      Promise.all([
+        StatusBar.show(),
+        StatusBar.setStyle({ style: Style.Dark }),
+      ]).catch((e) => {
+        logger.warn("StatusBar setup failed:", e);
+      });
     }
   }, []);
 
@@ -236,6 +243,10 @@ export default function App() {
   useEffect(() => {
     let cleanup: (() => void) | undefined;
 
+    if (!isPluginAvailable("FirebaseAuthentication")) {
+      return undefined;
+    }
+
     FirebaseAuthentication.addListener("authStateChange", async (change) => {
       // Refresh user data and token to get latest claims (e.g., email_verified)
       // This must happen before any API calls that depend on token claims
@@ -251,8 +262,8 @@ export default function App() {
 
       setLoggedInUser(change.user);
 
-      // Sync RevenueCat identity with Firebase user (skip on web)
-      if (Capacitor.getPlatform() !== "web") {
+      // Sync RevenueCat identity with Firebase user (skip on web or missing bridge)
+      if (isNativePluginAvailable("Purchases")) {
         await purchasesReady;
         try {
           if (change.user) {
@@ -313,9 +324,13 @@ export default function App() {
           });
         }
       }
-    }).then((handle) => {
-      cleanup = () => handle.remove();
-    });
+    })
+      .then((handle) => {
+        cleanup = () => handle.remove();
+      })
+      .catch((e) => {
+        logger.warn("Firebase auth listener setup failed:", e);
+      });
 
     return () => {
       cleanup?.();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,10 @@ import { Purchases } from "@revenuecat/purchases-capacitor";
 import { ErrorComponent } from "@/components/ErrorComponent.tsx";
 import { InboxModal } from "@/components/InboxModal";
 import { StagedTokenModal } from "@/components/home/StagedTokenModal";
+import {
+  isNativePluginAvailable,
+  isPluginAvailable,
+} from "@/lib/capacitorBridge";
 import { isExpectedRevenueCatLogoutError } from "@/lib/errors";
 import { routeTree } from "./routeTree.gen";
 import { useStatusStore } from "./lib/store";
@@ -33,10 +37,6 @@ import { useLiveUpdate } from "./hooks/useLiveUpdate";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
 import { purchasesReady } from "./lib/purchasesSetup";
-import {
-  isNativePluginAvailable,
-  isPluginAvailable,
-} from "./lib/capacitorBridge";
 import {
   A11yAnnouncerProvider,
   useAnnouncer,

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -2,6 +2,10 @@ import { render, waitFor, act } from "../../test-utils";
 import { vi, beforeEach, describe, it, expect } from "vitest";
 import React from "react";
 
+const { mockIsPluginAvailable } = vi.hoisted(() => ({
+  mockIsPluginAvailable: vi.fn<(pluginName: string) => boolean>(() => true),
+}));
+
 // Store mock functions
 const mockSetLoggedInUser = vi.fn();
 const mockSetLauncherAccess = vi.fn();
@@ -49,12 +53,19 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: vi.fn(() => mockPlatform !== "web"),
     getPlatform: vi.fn(() => mockPlatform),
+    isPluginAvailable: mockIsPluginAvailable,
   },
   registerPlugin: vi.fn(),
 }));
 
 vi.mock("@uidotdev/usehooks", () => ({
   usePrevious: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/capacitorBridge", () => ({
+  isPluginAvailable: (pluginName: string) => mockIsPluginAvailable(pluginName),
+  isNativePluginAvailable: (pluginName: string) =>
+    mockPlatform !== "web" && mockIsPluginAvailable(pluginName),
 }));
 
 vi.mock("@capacitor/status-bar", () => ({
@@ -249,6 +260,7 @@ describe("Firebase Auth Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPlatform = "web"; // Default to web platform
+    mockIsPluginAvailable.mockReturnValue(true);
     mockAddListener.mockImplementation(() =>
       Promise.resolve({ remove: mockRemove }),
     );
@@ -277,6 +289,19 @@ describe("Firebase Auth Integration", () => {
         "authStateChange",
         expect.any(Function),
       );
+    });
+  });
+
+  it("should skip auth listener setup when FirebaseAuthentication is unavailable", async () => {
+    mockIsPluginAvailable.mockImplementation(
+      (pluginName: string) => pluginName !== "FirebaseAuthentication",
+    );
+
+    const App = (await import("@/App")).default;
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockAddListener).not.toHaveBeenCalled();
     });
   });
 
@@ -474,6 +499,42 @@ describe("Firebase Auth Integration", () => {
       // RevenueCat should NOT be called on web
       expect(mockPurchasesLogIn).not.toHaveBeenCalled();
       expect(mockPurchasesLogOut).not.toHaveBeenCalled();
+    });
+
+    it("should skip RevenueCat sync when Purchases plugin is unavailable", async () => {
+      mockPlatform = "ios";
+      mockIsPluginAvailable.mockImplementation(
+        (pluginName: string) => pluginName !== "Purchases",
+      );
+
+      let authCallback: ((change: { user: unknown }) => Promise<void>) | null =
+        null;
+      mockAddListener.mockImplementation(
+        (
+          _event: string,
+          callback: (change: { user: unknown }) => Promise<void>,
+        ) => {
+          authCallback = callback;
+          return Promise.resolve({ remove: mockRemove });
+        },
+      );
+
+      const App = (await import("@/App")).default;
+      render(<App />);
+
+      await waitFor(() => {
+        expect(authCallback).not.toBeNull();
+      });
+
+      const mockUser = { uid: "user-123", email: "test@example.com" };
+      await act(async () => {
+        await authCallback!({ user: mockUser });
+      });
+
+      expect(mockSetLoggedInUser).toHaveBeenCalledWith(mockUser);
+      expect(mockPurchasesLogIn).not.toHaveBeenCalled();
+      expect(mockPurchasesLogOut).not.toHaveBeenCalled();
+      expect(mockPurchasesGetCustomerInfo).not.toHaveBeenCalled();
     });
 
     it("should call Purchases.logIn when user authenticates on native platform", async () => {

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "../../test-utils";
+import { render, screen, waitFor } from "../../test-utils";
 import { vi, beforeEach, describe, it, expect } from "vitest";
 import App from "@/App";
 import { isNativePluginAvailable } from "@/lib/capacitorBridge";
+import { logger } from "@/lib/logger";
 
 // Mock window.location for i18n
 Object.defineProperty(window, "location", {
@@ -277,5 +278,23 @@ describe("App Integration", () => {
 
     expect(StatusBar.show).not.toHaveBeenCalled();
     expect(StatusBar.setStyle).not.toHaveBeenCalled();
+  });
+
+  it("should log non-critical StatusBar setup failures", async () => {
+    const { Capacitor } = await import("@capacitor/core");
+    const { StatusBar } = await import("@capacitor/status-bar");
+    const error = new Error("StatusBar unavailable");
+
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(StatusBar.show).mockRejectedValueOnce(error);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        "StatusBar setup failed:",
+        error,
+      );
+    });
   });
 });

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "../../test-utils";
 import { vi, beforeEach, describe, it, expect } from "vitest";
 import App from "@/App";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
 
 // Mock window.location for i18n
 Object.defineProperty(window, "location", {
@@ -50,6 +51,11 @@ vi.mock("@capacitor/core", () => ({
 
 vi.mock("@uidotdev/usehooks", () => ({
   usePrevious: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/capacitorBridge", () => ({
+  isNativePluginAvailable: vi.fn(() => true),
+  isPluginAvailable: vi.fn(() => true),
 }));
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -222,6 +228,7 @@ vi.mock("@/lib/purchasesSetup", () => ({ purchasesReady: Promise.resolve() }));
 describe("App Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isNativePluginAvailable).mockReturnValue(true);
   });
 
   it("should render App component with all providers", () => {
@@ -262,7 +269,7 @@ describe("App Integration", () => {
     const { StatusBar } = await import("@capacitor/status-bar");
 
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
-    vi.mocked(Capacitor.isPluginAvailable).mockImplementation(
+    vi.mocked(isNativePluginAvailable).mockImplementation(
       (pluginName: string) => pluginName !== "StatusBar",
     );
 

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: vi.fn(() => false),
     getPlatform: vi.fn(() => "web"),
+    isPluginAvailable: vi.fn(() => true),
   },
   registerPlugin: vi.fn(),
 }));
@@ -212,7 +213,10 @@ vi.mock("@/hooks/useWriteQueueProcessor", () => ({
   useWriteQueueProcessor: vi.fn(),
 }));
 vi.mock("@/hooks/useShakeDetection", () => ({ useShakeDetection: vi.fn() }));
-vi.mock("@/lib/logger", () => ({ initDeviceInfo: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  initDeviceInfo: vi.fn(),
+  logger: { warn: vi.fn(), debug: vi.fn(), log: vi.fn(), error: vi.fn() },
+}));
 vi.mock("@/lib/purchasesSetup", () => ({ purchasesReady: Promise.resolve() }));
 
 describe("App Integration", () => {
@@ -251,5 +255,20 @@ describe("App Integration", () => {
 
     // Verify ConnectionProvider is rendered
     expect(screen.getByTestId("connection-provider")).toBeInTheDocument();
+  });
+
+  it("should skip StatusBar setup when native plugin is unavailable", async () => {
+    const { Capacitor } = await import("@capacitor/core");
+    const { StatusBar } = await import("@capacitor/status-bar");
+
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.isPluginAvailable).mockImplementation(
+      (pluginName: string) => pluginName !== "StatusBar",
+    );
+
+    render(<App />);
+
+    expect(StatusBar.show).not.toHaveBeenCalled();
+    expect(StatusBar.setStyle).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -129,6 +129,7 @@ vi.mock("@capacitor/app", () => ({
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: vi.fn(() => false),
+    isPluginAvailable: vi.fn(() => true),
   },
 }));
 
@@ -136,6 +137,11 @@ vi.mock("@capacitor/network", () => ({
   Network: {
     addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
   },
+}));
+
+vi.mock("@/lib/capacitorBridge", () => ({
+  isPluginAvailable: vi.fn(() => true),
+  isNativePluginAvailable: vi.fn(() => true),
 }));
 
 // Use vi.hoisted for toast mock

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -201,9 +201,13 @@ function resetStore() {
 }
 
 describe("ConnectionProvider", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     resetStore();
+
+    const bridge = await import("@/lib/capacitorBridge");
+    vi.mocked(bridge.isPluginAvailable).mockReturnValue(true);
+    vi.mocked(bridge.isNativePluginAvailable).mockReturnValue(true);
   });
 
   describe("rendering", () => {
@@ -226,6 +230,48 @@ describe("ConnectionProvider", () => {
 
       expect(screen.getByTestId("isConnected")).toBeInTheDocument();
       expect(screen.getByTestId("hasData")).toBeInTheDocument();
+    });
+
+    it("should skip startup plugin calls when bridge plugins are unavailable", async () => {
+      const { App } = await import("@capacitor/app");
+      const { Capacitor } = await import("@capacitor/core");
+      const { Network } = await import("@capacitor/network");
+      const bridge = await import("@/lib/capacitorBridge");
+
+      vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+      vi.mocked(bridge.isPluginAvailable).mockImplementation(
+        (pluginName: string) => pluginName !== "Preferences",
+      );
+      vi.mocked(bridge.isNativePluginAvailable).mockImplementation(
+        (pluginName: string) => !["App", "Network"].includes(pluginName),
+      );
+      vi.mocked(connectionManager.getActiveDeviceId).mockReturnValue(
+        "192.168.1.100:7497",
+      );
+
+      render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(connectionManager.setEventHandlers).toHaveBeenCalled();
+      });
+
+      capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+        state: "connected",
+        hasData: false,
+        hasConnectedBefore: false,
+      });
+
+      await waitFor(() => {
+        expect(CoreAPI.version).toHaveBeenCalled();
+      });
+
+      expect(Preferences.get).not.toHaveBeenCalled();
+      expect(App.addListener).not.toHaveBeenCalled();
+      expect(Network.addListener).not.toHaveBeenCalled();
     });
   });
 
@@ -1857,9 +1903,12 @@ describe("app lifecycle handling", () => {
 });
 
 describe("browser visibility handling (web platform)", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     resetStore();
+
+    const { Capacitor } = await import("@capacitor/core");
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
   });
 
   it("should call connectionManager.resumeAll when tab becomes visible", async () => {

--- a/src/__tests__/unit/components/ProPurchase.test.tsx
+++ b/src/__tests__/unit/components/ProPurchase.test.tsx
@@ -24,7 +24,7 @@ import {
 // Mock external modules
 vi.mock("@capacitor/preferences", () => ({
   Preferences: {
-    get: vi.fn(),
+    get: vi.fn().mockResolvedValue({ value: null }),
     set: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
     clear: vi.fn().mockResolvedValue(undefined),
@@ -35,6 +35,7 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: vi.fn().mockReturnValue("ios"),
     isNativePlatform: vi.fn().mockReturnValue(true),
+    isPluginAvailable: vi.fn().mockReturnValue(true),
   },
 }));
 
@@ -214,6 +215,11 @@ describe("RestorePuchasesButton", () => {
 
     render(<RestorePuchasesButton />);
 
+    const { usePreferencesStore } = await import("@/lib/preferencesStore");
+    await waitFor(() => {
+      expect(usePreferencesStore.getState()._hasHydrated).toBe(true);
+    });
+
     const button = screen.getByRole("button", {
       name: "settings.app.restorePurchases",
     });
@@ -224,13 +230,9 @@ describe("RestorePuchasesButton", () => {
       expect(Purchases.getCustomerInfo).toHaveBeenCalled();
     });
 
-    const { Preferences } = await import("@capacitor/preferences");
-    // Preferences.set is now called with app-preferences key and full state
-    expect(Preferences.set).toHaveBeenCalled();
-    const setCall = vi.mocked(Preferences.set).mock.calls[0]![0];
-    expect(setCall.key).toBe("app-preferences");
-    const state = JSON.parse(setCall.value);
-    expect(state.state.launcherAccess).toBe(true);
+    await waitFor(() => {
+      expect(usePreferencesStore.getState().launcherAccess).toBe(true);
+    });
 
     // No longer reloads the page - state updates reactively
     expect(window.location.reload).not.toHaveBeenCalled();

--- a/src/__tests__/unit/hooks/useAvailabilityChecks.test.ts
+++ b/src/__tests__/unit/hooks/useAvailabilityChecks.test.ts
@@ -9,6 +9,12 @@ import { useNfcAvailabilityCheck } from "@/hooks/useNfcAvailabilityCheck";
 import { useCameraAvailabilityCheck } from "@/hooks/useCameraAvailabilityCheck";
 import { useAccelerometerAvailabilityCheck } from "@/hooks/useAccelerometerAvailabilityCheck";
 
+vi.mock("@/lib/capacitorBridge", () => ({
+  isCapacitorPluginUnavailableError: vi.fn(() => false),
+  isNativePluginAvailable: vi.fn(() => true),
+  isPluginAvailable: vi.fn(() => true),
+}));
+
 describe("Availability Check Hooks", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/__tests__/unit/hooks/useLiveUpdate.test.ts
+++ b/src/__tests__/unit/hooks/useLiveUpdate.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+vi.mock("@/lib/capacitorBridge", () => ({
+  isNativePluginAvailable: vi.fn(() => true),
+}));
+
 describe("useLiveUpdate", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/__tests__/unit/hooks/useProAccessCheck.test.ts
+++ b/src/__tests__/unit/hooks/useProAccessCheck.test.ts
@@ -12,8 +12,16 @@ import { renderHook, waitFor } from "../../../test-utils";
 import { useProAccessCheck } from "../../../hooks/useProAccessCheck";
 
 // Create hoisted mocks
-const { mockGetPlatform, mockGetCustomerInfo, mockLogger } = vi.hoisted(() => ({
+const {
+  mockGetPlatform,
+  mockIsNativePlatform,
+  mockIsPluginAvailable,
+  mockGetCustomerInfo,
+  mockLogger,
+} = vi.hoisted(() => ({
   mockGetPlatform: vi.fn().mockReturnValue("ios"),
+  mockIsNativePlatform: vi.fn().mockReturnValue(true),
+  mockIsPluginAvailable: vi.fn().mockReturnValue(true),
   mockGetCustomerInfo: vi.fn(),
   mockLogger: {
     log: vi.fn(),
@@ -25,7 +33,14 @@ const { mockGetPlatform, mockGetCustomerInfo, mockLogger } = vi.hoisted(() => ({
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: mockGetPlatform,
+    isNativePlatform: mockIsNativePlatform,
+    isPluginAvailable: mockIsPluginAvailable,
   },
+}));
+
+vi.mock("@/lib/capacitorBridge", () => ({
+  isNativePluginAvailable: (pluginName: string) =>
+    mockIsNativePlatform() && mockIsPluginAvailable(pluginName),
 }));
 
 // Mock RevenueCat
@@ -65,6 +80,8 @@ describe("useProAccessCheck", () => {
 
     // Default to iOS platform
     mockGetPlatform.mockReturnValue("ios");
+    mockIsNativePlatform.mockReturnValue(true);
+    mockIsPluginAvailable.mockReturnValue(true);
 
     // Default to successful response with no entitlement
     mockGetCustomerInfo.mockResolvedValue({
@@ -170,6 +187,21 @@ describe("useProAccessCheck", () => {
   });
 
   describe("error handling", () => {
+    it("should mark as hydrated when Purchases plugin is unavailable", async () => {
+      mockGetPlatform.mockReturnValue("ios");
+      mockIsPluginAvailable.mockReturnValue(false);
+
+      renderHook(() => useProAccessCheck());
+
+      await waitFor(() => {
+        expect(mockSetProAccessHydrated).toHaveBeenCalledWith(true);
+      });
+
+      expect(mockGetCustomerInfo).not.toHaveBeenCalled();
+      expect(mockSetLauncherAccess).not.toHaveBeenCalled();
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
     it("should mark as hydrated on RevenueCat error", async () => {
       mockGetPlatform.mockReturnValue("ios");
       mockGetCustomerInfo.mockRejectedValue(new Error("Network error"));
@@ -289,7 +321,11 @@ describe("useProAccessCheck", () => {
         purchasesReady: deferredReady,
       }));
       vi.doMock("@capacitor/core", () => ({
-        Capacitor: { getPlatform: vi.fn().mockReturnValue("ios") },
+        Capacitor: {
+          getPlatform: vi.fn().mockReturnValue("ios"),
+          isNativePlatform: vi.fn().mockReturnValue(true),
+          isPluginAvailable: vi.fn().mockReturnValue(true),
+        },
       }));
       vi.doMock("@revenuecat/purchases-capacitor", () => ({
         Purchases: { getCustomerInfo: mockGetCustomerInfoDeferred },

--- a/src/__tests__/unit/lib/capacitorBridge.test.ts
+++ b/src/__tests__/unit/lib/capacitorBridge.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Capacitor } from "@capacitor/core";
+import {
+  isCapacitorPluginUnavailableError,
+  isNativePluginAvailable,
+  isPluginAvailable,
+} from "@/lib/capacitorBridge";
+
+describe("capacitorBridge", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should report plugin availability safely", () => {
+    vi.spyOn(Capacitor, "isPluginAvailable").mockReturnValue(true);
+
+    expect(isPluginAvailable("Preferences")).toBe(true);
+
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(false);
+
+    expect(isPluginAvailable("Preferences")).toBe(false);
+  });
+
+  it("should return false when availability check throws", () => {
+    vi.spyOn(Capacitor, "isPluginAvailable").mockImplementation(() => {
+      throw new Error("bridge missing");
+    });
+
+    expect(isPluginAvailable("Preferences")).toBe(false);
+  });
+
+  it("should require native platform for native plugin availability", () => {
+    vi.spyOn(Capacitor, "isNativePlatform").mockReturnValue(false);
+    vi.spyOn(Capacitor, "isPluginAvailable").mockReturnValue(true);
+    vi.clearAllMocks();
+
+    expect(isNativePluginAvailable("StatusBar")).toBe(false);
+    expect(Capacitor.isPluginAvailable).not.toHaveBeenCalled();
+  });
+
+  it("should detect expected unavailable plugin errors", () => {
+    expect(
+      isCapacitorPluginUnavailableError(
+        new Error('"Purchases" plugin is not implemented on android'),
+      ),
+    ).toBe(true);
+    expect(isCapacitorPluginUnavailableError("plugin missing")).toBe(true);
+    expect(isCapacitorPluginUnavailableError(new Error("network failed"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/__tests__/unit/lib/capacitorBridge.test.ts
+++ b/src/__tests__/unit/lib/capacitorBridge.test.ts
@@ -38,6 +38,14 @@ describe("capacitorBridge", () => {
     expect(Capacitor.isPluginAvailable).not.toHaveBeenCalled();
   });
 
+  it("should return false when native platform check throws", () => {
+    vi.spyOn(Capacitor, "isNativePlatform").mockImplementation(() => {
+      throw new Error("bridge unavailable");
+    });
+
+    expect(isNativePluginAvailable("StatusBar")).toBe(false);
+  });
+
   it("should detect expected unavailable plugin errors", () => {
     expect(
       isCapacitorPluginUnavailableError(

--- a/src/__tests__/unit/lib/logger.test.ts
+++ b/src/__tests__/unit/lib/logger.test.ts
@@ -44,6 +44,10 @@ vi.mock("@capacitor/device", () => ({
   },
 }));
 
+vi.mock("../../../lib/capacitorBridge", () => ({
+  isPluginAvailable: vi.fn(() => true),
+}));
+
 // Mock import.meta.env for production mode with token
 vi.stubEnv("PROD", true);
 vi.stubEnv("VITE_ROLLBAR_ACCESS_TOKEN", "test-token");
@@ -74,6 +78,18 @@ describe("Logger Rate Limiting", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("should skip device info lookup when Device plugin is unavailable", async () => {
+    const { Device } = await import("@capacitor/device");
+    const { isPluginAvailable } = await import("../../../lib/capacitorBridge");
+    const { initDeviceInfo } = await import("../../../lib/logger");
+
+    vi.mocked(isPluginAvailable).mockReturnValueOnce(false);
+
+    await initDeviceInfo();
+
+    expect(Device.getInfo).not.toHaveBeenCalled();
   });
 
   it("should report the first error", () => {

--- a/src/__tests__/unit/lib/preferencesStore.test.ts
+++ b/src/__tests__/unit/lib/preferencesStore.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Preferences } from "@capacitor/preferences";
 import { usePreferencesStore } from "../../../lib/preferencesStore";
-import { act, renderHook } from "../../../test-utils";
+import { act, renderHook, waitFor } from "../../../test-utils";
+import { isPluginAvailable } from "../../../lib/capacitorBridge";
 
 // Mock Capacitor Preferences
 vi.mock("@capacitor/preferences", () => ({
@@ -9,6 +11,14 @@ vi.mock("@capacitor/preferences", () => ({
     set: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
   },
+}));
+
+vi.mock("../../../lib/capacitorBridge", () => ({
+  isCapacitorPluginUnavailableError: vi.fn((error: unknown) =>
+    error instanceof Error ? error.message.includes("not implemented") : false,
+  ),
+  isNativePluginAvailable: vi.fn(() => true),
+  isPluginAvailable: vi.fn(() => true),
 }));
 
 // Mock sessionManager
@@ -22,6 +32,7 @@ vi.mock("../../../lib/nfc", () => ({
 describe("usePreferencesStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isPluginAvailable).mockReturnValue(true);
     // Reset store state between tests
     usePreferencesStore.setState({
       restartScan: false,
@@ -37,6 +48,35 @@ describe("usePreferencesStore", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("Capacitor Preferences bridge guards", () => {
+    it("should hydrate with defaults without reading storage when Preferences is unavailable", async () => {
+      vi.mocked(isPluginAvailable).mockReturnValue(false);
+
+      await usePreferencesStore.persist.rehydrate();
+
+      expect(Preferences.get).not.toHaveBeenCalled();
+      expect(usePreferencesStore.getState()._hasHydrated).toBe(true);
+    });
+
+    it("should skip persistence writes when Preferences is unavailable", async () => {
+      vi.mocked(isPluginAvailable).mockImplementation(
+        (pluginName: string) => pluginName !== "Preferences",
+      );
+      vi.mocked(Preferences.set).mockClear();
+
+      const { result } = renderHook(() => usePreferencesStore());
+
+      act(() => {
+        result.current.setShowFilenames(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.showFilenames).toBe(true);
+      });
+      expect(Preferences.set).not.toHaveBeenCalled();
+    });
   });
 
   describe("shake mode business logic", () => {

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -946,7 +946,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       null;
 
     const setupListeners = async () => {
-      if (!isPluginAvailable("App")) return;
+      if (!isNativePluginAvailable("App")) return;
 
       resumeListener = await App.addListener("resume", () => {
         logger.log("[ConnectionProvider] App resumed");

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -60,6 +60,10 @@ import {
   ConnectionState,
 } from "@/lib/store";
 import { credentialStore, normalizeDeviceKey } from "@/lib/crypto/credentials";
+import {
+  isNativePluginAvailable,
+  isPluginAvailable,
+} from "@/lib/capacitorBridge";
 import { formatDurationDisplay, formatDurationAccessible } from "@/lib/utils";
 import {
   ConnectionContext,
@@ -466,7 +470,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     // late setDeviceHistory(stored) would wholesale overwrite the
     // freshly-merged metadata from updateDeviceHistoryMeta().
     setCoreVersionPending(true);
-    Preferences.get({ key: "deviceHistory" })
+    const deviceHistory = isPluginAvailable("Preferences")
+      ? Preferences.get({ key: "deviceHistory" })
+      : Promise.resolve({ value: null });
+
+    deviceHistory
       .then((v) => {
         try {
           if (v.value) {
@@ -938,6 +946,8 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       null;
 
     const setupListeners = async () => {
+      if (!isPluginAvailable("App")) return;
+
       resumeListener = await App.addListener("resume", () => {
         logger.log("[ConnectionProvider] App resumed");
         connectionManager.resumeAll();
@@ -949,7 +959,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       });
     };
 
-    setupListeners();
+    setupListeners().catch((e) => {
+      logger.warn("[ConnectionProvider] Failed to setup app listeners:", e);
+    });
 
     return () => {
       resumeListener?.remove();
@@ -979,7 +991,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   // Network change detection (native platforms only)
   // Triggers immediate reconnect when network is restored (e.g., WiFi reconnects)
   useEffect(() => {
-    if (!Capacitor.isNativePlatform()) return;
+    if (!Capacitor.isNativePlatform() || !isNativePluginAvailable("Network")) {
+      return;
+    }
 
     let networkListener: PluginListenerHandle | null = null;
 

--- a/src/hooks/useAccelerometerAvailabilityCheck.ts
+++ b/src/hooks/useAccelerometerAvailabilityCheck.ts
@@ -3,6 +3,10 @@ import { Capacitor } from "@capacitor/core";
 import { CapacitorShake } from "@capgo/capacitor-shake";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { logger } from "@/lib/logger";
+import {
+  isCapacitorPluginUnavailableError,
+  isNativePluginAvailable,
+} from "@/lib/capacitorBridge";
 
 /**
  * Hook to check accelerometer/shake detection availability once at app startup.
@@ -18,8 +22,11 @@ export function useAccelerometerAvailabilityCheck() {
   );
 
   useEffect(() => {
-    // Skip on web platform
-    if (!Capacitor.isNativePlatform()) {
+    // Skip on web platform or when the native plugin bridge is unavailable
+    if (
+      !Capacitor.isNativePlatform() ||
+      !isNativePluginAvailable("CapacitorShake")
+    ) {
       setAccelerometerAvailable(false);
       setAccelerometerAvailabilityHydrated(true);
       return;
@@ -39,11 +46,13 @@ export function useAccelerometerAvailabilityCheck() {
         // Clean up test listener
         await listener.remove();
       } catch (e) {
-        logger.error("Failed to check accelerometer availability:", e, {
-          category: "accelerometer",
-          action: "availabilityCheck",
-          severity: "warning",
-        });
+        if (!isCapacitorPluginUnavailableError(e)) {
+          logger.error("Failed to check accelerometer availability:", e, {
+            category: "accelerometer",
+            action: "availabilityCheck",
+            severity: "warning",
+          });
+        }
         // On error, assume accelerometer not available
         setAccelerometerAvailable(false);
         setAccelerometerAvailabilityHydrated(true);

--- a/src/hooks/useCameraAvailabilityCheck.ts
+++ b/src/hooks/useCameraAvailabilityCheck.ts
@@ -3,6 +3,7 @@ import { Capacitor } from "@capacitor/core";
 import { BarcodeScanner } from "@capacitor-mlkit/barcode-scanning";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { logger } from "@/lib/logger";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
 
 /**
  * Hook to check camera/barcode scanner availability once at app startup.
@@ -18,8 +19,11 @@ export function useCameraAvailabilityCheck() {
   );
 
   useEffect(() => {
-    // Skip on web platform
-    if (!Capacitor.isNativePlatform()) {
+    // Skip on web platform or when the native plugin bridge is unavailable
+    if (
+      !Capacitor.isNativePlatform() ||
+      !isNativePluginAvailable("BarcodeScanner")
+    ) {
       setCameraAvailable(false);
       setCameraAvailabilityHydrated(true);
       return;

--- a/src/hooks/useLiveUpdate.ts
+++ b/src/hooks/useLiveUpdate.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { Capacitor } from "@capacitor/core";
 import { LiveUpdate } from "@capawesome/capacitor-live-update";
 import { logger } from "@/lib/logger";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
 
 /**
  * Hook to handle Capawesome Live Update lifecycle.
@@ -16,7 +17,11 @@ export function useLiveUpdate() {
   const initialized = useRef(false);
 
   useEffect(() => {
-    if (!Capacitor.isNativePlatform() || initialized.current) {
+    if (
+      !Capacitor.isNativePlatform() ||
+      !isNativePluginAvailable("LiveUpdate") ||
+      initialized.current
+    ) {
       return;
     }
 

--- a/src/hooks/useNfcAvailabilityCheck.ts
+++ b/src/hooks/useNfcAvailabilityCheck.ts
@@ -3,6 +3,10 @@ import { Capacitor } from "@capacitor/core";
 import { Nfc } from "@capawesome-team/capacitor-nfc";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { logger } from "@/lib/logger";
+import {
+  isCapacitorPluginUnavailableError,
+  isNativePluginAvailable,
+} from "@/lib/capacitorBridge";
 
 /**
  * Hook to check NFC availability once at app startup.
@@ -16,8 +20,8 @@ export function useNfcAvailabilityCheck() {
   );
 
   useEffect(() => {
-    // Skip on web platform
-    if (!Capacitor.isNativePlatform()) {
+    // Skip on web platform or when the native plugin bridge is unavailable
+    if (!Capacitor.isNativePlatform() || !isNativePluginAvailable("Nfc")) {
       setNfcAvailable(false);
       setNfcAvailabilityHydrated(true);
       return;
@@ -30,11 +34,13 @@ export function useNfcAvailabilityCheck() {
         setNfcAvailabilityHydrated(true);
       })
       .catch((e) => {
-        logger.error("Failed to check NFC availability:", e, {
-          category: "nfc",
-          action: "availabilityCheck",
-          severity: "warning",
-        });
+        if (!isCapacitorPluginUnavailableError(e)) {
+          logger.error("Failed to check NFC availability:", e, {
+            category: "nfc",
+            action: "availabilityCheck",
+            severity: "warning",
+          });
+        }
         // On error, assume NFC not available
         setNfcAvailable(false);
         setNfcAvailabilityHydrated(true);

--- a/src/hooks/useProAccessCheck.ts
+++ b/src/hooks/useProAccessCheck.ts
@@ -4,6 +4,7 @@ import { Purchases } from "@revenuecat/purchases-capacitor";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { logger } from "@/lib/logger";
 import { purchasesReady } from "@/lib/purchasesSetup";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
 
 /**
  * Hook to check Pro access status from RevenueCat on app startup.
@@ -19,9 +20,14 @@ export function useProAccessCheck() {
   );
 
   useEffect(() => {
-    // Skip on web platform
+    // Skip on web platform or when the native purchases bridge is unavailable
     if (Capacitor.getPlatform() === "web") {
       logger.log("Web platform, skipping Pro access check");
+      setProAccessHydrated(true);
+      return;
+    }
+
+    if (!isNativePluginAvailable("Purchases")) {
       setProAccessHydrated(true);
       return;
     }

--- a/src/lib/capacitorBridge.ts
+++ b/src/lib/capacitorBridge.ts
@@ -1,0 +1,30 @@
+import { Capacitor } from "@capacitor/core";
+
+export function isPluginAvailable(pluginName: string): boolean {
+  try {
+    return Capacitor.isPluginAvailable(pluginName);
+  } catch {
+    return false;
+  }
+}
+
+export function isNativePluginAvailable(pluginName: string): boolean {
+  try {
+    return Capacitor.isNativePlatform() && isPluginAvailable(pluginName);
+  } catch {
+    return false;
+  }
+}
+
+export function isCapacitorPluginUnavailableError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+
+  return /not implemented|not available|plugin.*missing|plugin.*not.*found|plugin.*not.*implemented/i.test(
+    message,
+  );
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -7,6 +7,7 @@
 import { Capacitor } from "@capacitor/core";
 import { Device } from "@capacitor/device";
 import { useStatusStore } from "./store";
+import { isPluginAvailable } from "./capacitorBridge";
 
 // Check if Rollbar should be enabled (native + production + token present)
 const isNative = Capacitor.isNativePlatform();
@@ -78,6 +79,8 @@ let cachedDeviceInfo: {
  */
 export async function initDeviceInfo(): Promise<void> {
   if (cachedDeviceInfo) return;
+
+  if (!isPluginAvailable("Device")) return;
 
   try {
     const info = await Device.getInfo();

--- a/src/lib/preferencesStore.ts
+++ b/src/lib/preferencesStore.ts
@@ -1,9 +1,13 @@
 import { create } from "zustand";
 import { persist, createJSONStorage, StateStorage } from "zustand/middleware";
 import { Preferences } from "@capacitor/preferences";
-import { Capacitor } from "@capacitor/core";
 import { TextZoom } from "@capacitor/text-zoom";
 import { sessionManager } from "./nfc";
+import {
+  isCapacitorPluginUnavailableError,
+  isNativePluginAvailable,
+  isPluginAvailable,
+} from "./capacitorBridge";
 
 /**
  * Preferences Store
@@ -24,15 +28,33 @@ let _storageWritesEnabled = false;
 // Custom storage adapter for Capacitor Preferences
 const capacitorPreferencesStorage: StateStorage = {
   getItem: async (name: string): Promise<string | null> => {
-    const result = await Preferences.get({ key: name });
-    return result.value;
+    if (!isPluginAvailable("Preferences")) return null;
+
+    try {
+      const result = await Preferences.get({ key: name });
+      return result.value;
+    } catch (e) {
+      if (isCapacitorPluginUnavailableError(e)) return null;
+      throw e;
+    }
   },
   setItem: async (name: string, value: string): Promise<void> => {
-    if (!_storageWritesEnabled) return;
-    await Preferences.set({ key: name, value });
+    if (!_storageWritesEnabled || !isPluginAvailable("Preferences")) return;
+
+    try {
+      await Preferences.set({ key: name, value });
+    } catch (e) {
+      if (!isCapacitorPluginUnavailableError(e)) throw e;
+    }
   },
   removeItem: async (name: string): Promise<void> => {
-    await Preferences.remove({ key: name });
+    if (!isPluginAvailable("Preferences")) return;
+
+    try {
+      await Preferences.remove({ key: name });
+    } catch (e) {
+      if (!isCapacitorPluginUnavailableError(e)) throw e;
+    }
   },
 };
 
@@ -258,7 +280,10 @@ export const usePreferencesStore = create<PreferencesStore>()(
           sessionManager.setLaunchOnScan(state.launchOnScan);
 
           // Apply text zoom on native platforms
-          if (Capacitor.isNativePlatform() && state.textZoomLevel !== 1.0) {
+          if (
+            isNativePluginAvailable("TextZoom") &&
+            state.textZoomLevel !== 1.0
+          ) {
             TextZoom.set({ value: state.textZoomLevel }).catch(() => {
               // Silently ignore - text zoom may not be available
             });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider } from "./components/theme-provider";
 import { ErrorComponent } from "./components/ErrorComponent";
 import { logger } from "./lib/logger";
 import { resolvePurchasesReady } from "./lib/purchasesSetup";
+import { isPluginAvailable } from "./lib/capacitorBridge";
 
 // Firebase config is optional - auth features will be disabled without it
 const firebaseConfigs = import.meta.glob<Record<string, string>>(
@@ -34,25 +35,37 @@ const queryClient = new QueryClient({
   },
 });
 
-Preferences.get({ key: "apiUrl" })
-  .then((res) => {
-    if (res.value && localStorage.getItem("apiUrl") === null) {
-      localStorage.setItem("apiUrl", res.value);
-      window.location.reload();
-    }
-  })
-  .catch(() => {
-    // Silently ignore - migration from Preferences to localStorage is optional
-  });
-
-const onDeviceReady = async () => {
-  if (import.meta.env.MODE === "development") {
-    await Purchases.setLogLevel({
-      level: LOG_LEVEL.DEBUG,
+if (isPluginAvailable("Preferences")) {
+  Preferences.get({ key: "apiUrl" })
+    .then((res) => {
+      if (res.value && localStorage.getItem("apiUrl") === null) {
+        localStorage.setItem("apiUrl", res.value);
+        window.location.reload();
+      }
+    })
+    .catch(() => {
+      // Silently ignore - migration from Preferences to localStorage is optional
     });
+}
+
+let purchasesInitializationStarted = false;
+
+const initializePurchasesOnce = async () => {
+  if (purchasesInitializationStarted) return;
+  purchasesInitializationStarted = true;
+
+  if (!Capacitor.isNativePlatform() || !isPluginAvailable("Purchases")) {
+    resolvePurchasesReady();
+    return;
   }
 
   try {
+    if (import.meta.env.MODE === "development") {
+      await Purchases.setLogLevel({
+        level: LOG_LEVEL.DEBUG,
+      });
+    }
+
     if (Capacitor.getPlatform() === "ios") {
       await Purchases.configure({
         apiKey: import.meta.env.VITE_APPLE_STORE_API,
@@ -73,12 +86,14 @@ const onDeviceReady = async () => {
   }
 };
 
-// Web platform skips RC entirely — resolve immediately so awaits don't hang
-if (!Capacitor.isNativePlatform()) {
-  resolvePurchasesReady();
+if (!Capacitor.isNativePlatform() || !isPluginAvailable("Purchases")) {
+  initializePurchasesOnce();
+} else {
+  document.addEventListener("deviceready", initializePurchasesOnce, false);
+  window.setTimeout(() => {
+    initializePurchasesOnce();
+  }, 1500);
 }
-
-document.addEventListener("deviceready", onDeviceReady, false);
 
 // App content wrapped in theme and query providers
 const AppContent = (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,12 @@ import { LOG_LEVEL, Purchases } from "@revenuecat/purchases-capacitor";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
 import { initializeApp } from "firebase/app";
+import { isPluginAvailable } from "@/lib/capacitorBridge";
 import App from "./App";
 import { ThemeProvider } from "./components/theme-provider";
 import { ErrorComponent } from "./components/ErrorComponent";
 import { logger } from "./lib/logger";
 import { resolvePurchasesReady } from "./lib/purchasesSetup";
-import { isPluginAvailable } from "./lib/capacitorBridge";
 
 // Firebase config is optional - auth features will be disabled without it
 const firebaseConfigs = import.meta.glob<Record<string, string>>(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,11 +37,11 @@ export default defineConfig(({ command, mode }) => {
     react(),
     legacy({
       targets: [
-        "chrome >= 49",
+        "chrome >= 60",
         "safari >= 11",
         "firefox >= 52",
         "ios >= 11",
-        "android >= 49",
+        "android >= 60",
       ],
       additionalLegacyPolyfills: [
         "regenerator-runtime/runtime",


### PR DESCRIPTION
Closes #141

Summary:
- add guarded Capacitor plugin availability checks around startup native calls
- block unsupported Android WebViews with a static fallback page and WebView >= 60 floor
- align Vite legacy Chrome/Android targets with Capacitor Android WebView support
- initialize RevenueCat via deviceready with a fallback for missing event dispatch

Verified:
- npm run typecheck
- npm run lint
- npm run test -- --run --reporter dot
- npm run build:web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “unsupported WebView” error page guiding Android users to update WebView/Chrome before restarting the app.

* **Bug Fixes**
  * App now more gracefully disables native-dependent features (camera, NFC, accelerometer, purchases, live updates, status bar) when device support is missing, reducing errors and crashes.
  * Raised minimum Android WebView requirement to improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->