### PR TITLE
Fix deep link startup handling

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# CodeRabbit configuration
+# ESLint is already enforced by CI. Disable CodeRabbit's sandboxed ESLint
+# because its dependency install cannot authenticate against private registries.
+reviews:
+  tools:
+    eslint:
+      enabled: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,13 @@ import {
   isNativePluginAvailable,
   isPluginAvailable,
 } from "@/lib/capacitorBridge";
+import { useDeepLinks } from "@/lib/deepLinks";
 import { isExpectedRevenueCatLogoutError } from "@/lib/errors";
 import { routeTree } from "./routeTree.gen";
 import { useStatusStore } from "./lib/store";
 import { DatabaseIcon, PlayIcon } from "./lib/images";
 import { ConnectionProvider } from "./components/ConnectionProvider";
 import { ReconnectingIndicator } from "./components/ReconnectingIndicator";
-import { useDeepLinks } from "./lib/deepLinks.tsx";
 import { MediaFinishedToast } from "./components/MediaFinishedToast.tsx";
 import { useDataCache } from "./hooks/useDataCache";
 import { SlideModalProvider } from "./components/SlideModalProvider";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useStatusStore } from "./lib/store";
 import { DatabaseIcon, PlayIcon } from "./lib/images";
 import { ConnectionProvider } from "./components/ConnectionProvider";
 import { ReconnectingIndicator } from "./components/ReconnectingIndicator";
-import AppUrlListener from "./lib/deepLinks.tsx";
+import { useDeepLinks } from "./lib/deepLinks.tsx";
 import { MediaFinishedToast } from "./components/MediaFinishedToast.tsx";
 import { useDataCache } from "./hooks/useDataCache";
 import { SlideModalProvider } from "./components/SlideModalProvider";
@@ -190,6 +190,8 @@ declare module "@tanstack/react-router" {
 }
 
 export default function App() {
+  useDeepLinks();
+
   // Wait for preferences to hydrate before rendering to prevent layout shifts
   const hasHydrated = usePreferencesStore((state) => state._hasHydrated);
   const proAccessHydrated = usePreferencesStore(
@@ -335,7 +337,6 @@ export default function App() {
 
   return (
     <>
-      <AppUrlListener />
       <QueueProcessors />
       <Toaster
         position="top-center"

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -195,6 +195,7 @@ vi.mock("@/components/ReconnectingIndicator", () => ({
 }));
 
 vi.mock("@/lib/deepLinks", () => ({
+  useDeepLinks: vi.fn(),
   default: () => <div data-testid="deep-links" />,
 }));
 

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -2,6 +2,27 @@ import { render, screen } from "../../test-utils";
 import { vi, beforeEach, describe, it, expect } from "vitest";
 import App from "@/App";
 
+const {
+  mockUseDeepLinks,
+  mockUseRunQueueProcessor,
+  mockUseWriteQueueProcessor,
+  mockPreferencesState,
+} = vi.hoisted(() => ({
+  mockUseDeepLinks: vi.fn(),
+  mockUseRunQueueProcessor: vi.fn(),
+  mockUseWriteQueueProcessor: vi.fn(),
+  mockPreferencesState: {
+    _hasHydrated: true,
+    _proAccessHydrated: true,
+    _nfcAvailabilityHydrated: true,
+    _cameraAvailabilityHydrated: true,
+    _accelerometerAvailabilityHydrated: true,
+    showFilenames: false,
+    shakeEnabled: false,
+    launcherAccess: false,
+  },
+}));
+
 // Mock window.location for i18n
 Object.defineProperty(window, "location", {
   value: {
@@ -136,6 +157,7 @@ vi.mock("@/components/ReconnectingIndicator", () => ({
 }));
 
 vi.mock("@/lib/deepLinks", () => ({
+  useDeepLinks: mockUseDeepLinks,
   default: () => <div data-testid="deep-links" />,
 }));
 
@@ -169,20 +191,10 @@ vi.mock("@capacitor/status-bar", () => ({
 
 vi.mock("@/lib/preferencesStore", () => {
   const usePreferencesStore: any = vi.fn((selector) => {
-    const state = {
-      _hasHydrated: true,
-      _proAccessHydrated: true,
-      _nfcAvailabilityHydrated: true,
-      _cameraAvailabilityHydrated: true,
-      _accelerometerAvailabilityHydrated: true,
-      showFilenames: false,
-      shakeEnabled: false,
-      launcherAccess: false,
-    };
     if (typeof selector === "function") {
-      return selector(state);
+      return selector(mockPreferencesState);
     }
-    return state;
+    return mockPreferencesState;
   });
 
   return { usePreferencesStore };
@@ -206,10 +218,10 @@ vi.mock("@/hooks/useAccelerometerAvailabilityCheck", () => ({
   useAccelerometerAvailabilityCheck: vi.fn(),
 }));
 vi.mock("@/hooks/useRunQueueProcessor", () => ({
-  useRunQueueProcessor: vi.fn(),
+  useRunQueueProcessor: mockUseRunQueueProcessor,
 }));
 vi.mock("@/hooks/useWriteQueueProcessor", () => ({
-  useWriteQueueProcessor: vi.fn(),
+  useWriteQueueProcessor: mockUseWriteQueueProcessor,
 }));
 vi.mock("@/hooks/useShakeDetection", () => ({ useShakeDetection: vi.fn() }));
 vi.mock("@/lib/logger", () => ({ initDeviceInfo: vi.fn() }));
@@ -218,6 +230,16 @@ vi.mock("@/lib/purchasesSetup", () => ({ purchasesReady: Promise.resolve() }));
 describe("App Integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.assign(mockPreferencesState, {
+      _hasHydrated: true,
+      _proAccessHydrated: true,
+      _nfcAvailabilityHydrated: true,
+      _cameraAvailabilityHydrated: true,
+      _accelerometerAvailabilityHydrated: true,
+      showFilenames: false,
+      shakeEnabled: false,
+      launcherAccess: false,
+    });
   });
 
   it("should render App component with all providers", () => {
@@ -235,7 +257,7 @@ describe("App Integration", () => {
 
     // Verify ConnectionProvider is rendered
     expect(screen.getByTestId("connection-provider")).toBeInTheDocument();
-    expect(screen.getByTestId("deep-links")).toBeInTheDocument();
+    expect(mockUseDeepLinks).toHaveBeenCalled();
     expect(screen.getByTestId("staged-token-modal")).toBeInTheDocument();
   });
 
@@ -251,5 +273,16 @@ describe("App Integration", () => {
 
     // Verify ConnectionProvider is rendered
     expect(screen.getByTestId("connection-provider")).toBeInTheDocument();
+  });
+
+  it("should initialize deep links before hydration completes", () => {
+    mockPreferencesState._hasHydrated = false;
+
+    const { container } = render(<App />);
+
+    expect(mockUseDeepLinks).toHaveBeenCalled();
+    expect(mockUseRunQueueProcessor).not.toHaveBeenCalled();
+    expect(mockUseWriteQueueProcessor).not.toHaveBeenCalled();
+    expect(container.textContent).toBe("");
   });
 });

--- a/src/__tests__/unit/lib/deepLinks.test.tsx
+++ b/src/__tests__/unit/lib/deepLinks.test.tsx
@@ -50,7 +50,7 @@ vi.mock("@capacitor/app", () => ({
 }));
 
 // Mock logger
-vi.mock("../../../lib/logger", () => ({
+vi.mock("@/lib/logger", () => ({
   logger: mockLogger,
 }));
 
@@ -63,7 +63,7 @@ vi.mock("react-hot-toast", () => ({
 const mockSetRunQueue = vi.fn();
 const mockSetWriteQueue = vi.fn();
 
-vi.mock("../../../lib/store", () => ({
+vi.mock("@/lib/store", () => ({
   useStatusStore: vi.fn((selector: (state: unknown) => unknown) => {
     const state = {
       setRunQueue: mockSetRunQueue,
@@ -73,7 +73,7 @@ vi.mock("../../../lib/store", () => ({
   }),
 }));
 
-import AppUrlListener, { parseDeepLink } from "../../../lib/deepLinks";
+import AppUrlListener, { parseDeepLink } from "@/lib/deepLinks";
 
 describe("AppUrlListener", () => {
   beforeEach(() => {
@@ -152,10 +152,9 @@ describe("AppUrlListener", () => {
       });
     });
 
-    it("should parse custom scheme host paths", () => {
+    it("should reject custom scheme links with unexpected hosts", () => {
       expect(parseDeepLink("zaparoo://write?v=test-write")).toEqual({
-        type: "write",
-        value: "test-write",
+        type: "unsupported",
       });
     });
 
@@ -362,11 +361,16 @@ describe("AppUrlListener", () => {
         url: "not-a-valid-url",
       });
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         "Invalid deep link URL",
         expect.any(Error),
+        {
+          category: "general",
+          action: "deepLinkParse",
+          severity: "error",
+        },
       );
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.warn).not.toHaveBeenCalled();
 
       expect(mockToast.error).toHaveBeenCalledWith("deepLinks.invalidUrl");
     });
@@ -382,11 +386,16 @@ describe("AppUrlListener", () => {
         url: "",
       });
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         "Invalid deep link URL",
         expect.any(Error),
+        {
+          category: "general",
+          action: "deepLinkParse",
+          severity: "error",
+        },
       );
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.warn).not.toHaveBeenCalled();
       expect(mockToast.error).toHaveBeenCalledWith("deepLinks.invalidUrl");
     });
 

--- a/src/__tests__/unit/lib/deepLinks.test.tsx
+++ b/src/__tests__/unit/lib/deepLinks.test.tsx
@@ -73,7 +73,7 @@ vi.mock("../../../lib/store", () => ({
   }),
 }));
 
-import AppUrlListener from "../../../lib/deepLinks";
+import AppUrlListener, { parseDeepLink } from "../../../lib/deepLinks";
 
 describe("AppUrlListener", () => {
   beforeEach(() => {
@@ -102,6 +102,67 @@ describe("AppUrlListener", () => {
 
     await waitFor(() => {
       expect(listenerRemoveFn).toHaveBeenCalled();
+    });
+  });
+
+  it("should cleanup listener if handle resolves after unmount", async () => {
+    let resolveHandle: (value: {
+      remove: typeof listenerRemoveFn;
+    }) => void = () => {};
+    mockAddListener.mockImplementationOnce(
+      (eventName: string, callback: (event: URLOpenListenerEvent) => void) => {
+        if (eventName === "appUrlOpen") {
+          urlOpenCallback = callback;
+        }
+        return new Promise((resolve) => {
+          resolveHandle = resolve;
+        });
+      },
+    );
+
+    const { unmount } = render(<AppUrlListener />);
+
+    unmount();
+    resolveHandle({ remove: listenerRemoveFn });
+
+    await waitFor(() => {
+      expect(listenerRemoveFn).toHaveBeenCalled();
+    });
+  });
+
+  describe("parseDeepLink", () => {
+    it("should parse HTTPS run links", () => {
+      expect(parseDeepLink("https://zaparoo.app/run?v=test-token")).toEqual({
+        type: "run",
+        value: "test-token",
+      });
+    });
+
+    it("should parse HTTPS write links", () => {
+      expect(parseDeepLink("https://zaparoo.app/write?v=test-write")).toEqual({
+        type: "write",
+        value: "test-write",
+      });
+    });
+
+    it("should parse custom scheme app paths", () => {
+      expect(parseDeepLink("zaparoo://app/run?v=test-token")).toEqual({
+        type: "run",
+        value: "test-token",
+      });
+    });
+
+    it("should parse custom scheme host paths", () => {
+      expect(parseDeepLink("zaparoo://write?v=test-write")).toEqual({
+        type: "write",
+        value: "test-write",
+      });
+    });
+
+    it("should reject other HTTPS hosts", () => {
+      expect(parseDeepLink("https://example.com/run?v=test-token")).toEqual({
+        type: "unsupported",
+      });
     });
   });
 
@@ -375,7 +436,8 @@ describe("AppUrlListener", () => {
       expect(mockLogger.log).toHaveBeenCalledWith(
         "App URL opened:",
         expect.objectContaining({
-          path: "/unknown",
+          url: "zaparoo://app/unknown",
+          parsed: { type: "unsupported" },
         }),
       );
     });

--- a/src/__tests__/unit/lib/deepLinks.test.tsx
+++ b/src/__tests__/unit/lib/deepLinks.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "../../../test-utils";
+import { render, waitFor } from "@/test-utils";
 import type { URLOpenListenerEvent } from "@capacitor/app";
 
 // Create hoisted mocks
@@ -73,11 +73,13 @@ vi.mock("@/lib/store", () => ({
   }),
 }));
 
+import { CoreAPI } from "@/lib/coreApi";
 import AppUrlListener, { parseDeepLink } from "@/lib/deepLinks";
 
 describe("AppUrlListener", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    CoreAPI.reset();
     urlOpenCallback = null;
     mockGetLaunchUrl.mockResolvedValue({ url: undefined });
   });

--- a/src/lib/deepLinks.tsx
+++ b/src/lib/deepLinks.tsx
@@ -5,31 +5,59 @@ import toast from "react-hot-toast";
 import { useStatusStore } from "./store";
 import { logger } from "./logger";
 
-// Deduplication window in milliseconds - prevents double-processing when both
-// getLaunchUrl() and appUrlOpen fire for the same URL on cold start
 const DEDUPE_WINDOW_MS = 1000;
+const DEEP_LINK_HOST = "zaparoo.app";
 
-const AppUrlListener: React.FC = () => {
+type ParsedDeepLink =
+  | { type: "run"; value: string }
+  | { type: "write"; value: string }
+  | { type: "unsupported" }
+  | { type: "invalid" };
+
+export function parseDeepLink(urlString: string): ParsedDeepLink {
+  try {
+    const url = new URL(urlString);
+    const scheme = url.protocol.replace(":", "");
+
+    if (scheme === "https" && url.host !== DEEP_LINK_HOST) {
+      return { type: "unsupported" };
+    }
+
+    if (scheme !== "https" && scheme !== "zaparoo") {
+      return { type: "unsupported" };
+    }
+
+    const path = url.pathname || (scheme === "zaparoo" ? `/${url.host}` : "");
+    const value = url.searchParams.get("v");
+
+    if (!value) {
+      return { type: "unsupported" };
+    }
+
+    if (path === "/run") {
+      return { type: "run", value };
+    }
+
+    if (path === "/write") {
+      return { type: "write", value };
+    }
+
+    return { type: "unsupported" };
+  } catch {
+    return { type: "invalid" };
+  }
+}
+
+export function useDeepLinks() {
   const { t } = useTranslation();
   const setRunQueue = useStatusStore((state) => state.setRunQueue);
   const setWriteQueue = useStatusStore((state) => state.setWriteQueue);
-
-  // Track last processed URL with timestamp for time-based deduplication
   const lastProcessedRef = useRef<{ url: string; time: number } | null>(null);
 
-  /**
-   * Process a deep link URL and dispatch to appropriate queue.
-   * Handles both /run and /write paths with a 'v' query parameter.
-   * Uses time-based deduplication to prevent double-processing on cold start
-   * while still allowing intentional repeat clicks.
-   */
   const processUrl = useCallback(
     (urlString: string) => {
       const now = Date.now();
 
-      // Skip if same URL was processed within deduplication window
-      // This catches cold-start duplicates (getLaunchUrl + appUrlOpen)
-      // but allows intentional repeat clicks after the window expires
       if (
         lastProcessedRef.current &&
         lastProcessedRef.current.url === urlString &&
@@ -40,59 +68,77 @@ const AppUrlListener: React.FC = () => {
       }
 
       lastProcessedRef.current = { url: urlString, time: now };
+      const parsed = parseDeepLink(urlString);
+      logger.log("App URL opened:", { url: urlString, parsed });
 
       try {
-        const url = new URL(urlString);
-        const path = url.pathname;
-        const params = new URLSearchParams(url.search);
-        const queryParams = Object.fromEntries(params.entries());
-        const data = {
-          path,
-          queryParams,
-        };
-        logger.log("App URL opened:", data);
-
-        if (path === "/run" && queryParams.v) {
-          logger.log("Run queue:", queryParams.v);
-          setRunQueue({ value: queryParams.v, unsafe: true });
-        } else if (path === "/write" && queryParams.v) {
-          logger.log("Write queue:", queryParams.v);
-          setWriteQueue(queryParams.v);
+        if (parsed.type === "run") {
+          logger.log("Run queue:", parsed.value);
+          setRunQueue({ value: parsed.value, unsafe: true });
+        } else if (parsed.type === "write") {
+          logger.log("Write queue:", parsed.value);
+          setWriteQueue(parsed.value);
+        } else if (parsed.type === "invalid") {
+          logger.warn("Invalid deep link URL", new Error("Invalid URL"));
+          toast.error(t("deepLinks.invalidUrl"));
         }
       } catch (error) {
-        logger.warn("Invalid deep link URL", error);
-        toast.error(t("deepLinks.invalidUrl"));
+        logger.error("Deep link dispatch failed", error, {
+          category: "general",
+          action: "deepLinkDispatch",
+        });
       }
     },
     [setRunQueue, setWriteQueue, t],
   );
 
   useEffect(() => {
-    // Check for launch URL on cold start - this catches deep links that
-    // arrived before the listener was registered (app was not running)
-    App.getLaunchUrl().then((result) => {
-      if (result?.url) {
-        logger.log("App launched with URL:", result.url);
-        processUrl(result.url);
-      }
-    });
-
-    // Register listener for deep links while app is running
+    let disposed = false;
     let listenerHandle: Awaited<ReturnType<typeof App.addListener>> | null =
       null;
 
     App.addListener("appUrlOpen", (event: URLOpenListenerEvent) => {
       processUrl(event.url);
-    }).then((handle) => {
-      listenerHandle = handle;
-    });
+    })
+      .then((handle) => {
+        if (disposed) {
+          void handle.remove();
+          return;
+        }
+        listenerHandle = handle;
+      })
+      .catch((error) => {
+        logger.error("Failed to register deep link listener", error, {
+          category: "lifecycle",
+          action: "deepLinkListener",
+          severity: "warning",
+        });
+      });
 
-    // Cleanup listener on unmount to prevent memory leaks
+    App.getLaunchUrl()
+      .then((result) => {
+        if (!disposed && result?.url) {
+          logger.log("App launched with URL:", result.url);
+          processUrl(result.url);
+        }
+      })
+      .catch((error) => {
+        logger.error("Failed to read launch URL", error, {
+          category: "lifecycle",
+          action: "getLaunchUrl",
+          severity: "warning",
+        });
+      });
+
     return () => {
-      listenerHandle?.remove();
+      disposed = true;
+      void listenerHandle?.remove();
     };
   }, [processUrl]);
+}
 
+const AppUrlListener: React.FC = () => {
+  useDeepLinks();
   return null;
 };
 

--- a/src/lib/deepLinks.tsx
+++ b/src/lib/deepLinks.tsx
@@ -2,17 +2,18 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { App, URLOpenListenerEvent } from "@capacitor/app";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
-import { useStatusStore } from "./store";
-import { logger } from "./logger";
+import { useStatusStore } from "@/lib/store";
+import { logger } from "@/lib/logger";
 
 const DEDUPE_WINDOW_MS = 1000;
 const DEEP_LINK_HOST = "zaparoo.app";
+const CUSTOM_SCHEME_HOSTS = new Set(["", "app"]);
 
 type ParsedDeepLink =
   | { type: "run"; value: string }
   | { type: "write"; value: string }
   | { type: "unsupported" }
-  | { type: "invalid" };
+  | { type: "invalid"; error: Error };
 
 export function parseDeepLink(urlString: string): ParsedDeepLink {
   try {
@@ -27,7 +28,11 @@ export function parseDeepLink(urlString: string): ParsedDeepLink {
       return { type: "unsupported" };
     }
 
-    const path = url.pathname || (scheme === "zaparoo" ? `/${url.host}` : "");
+    if (scheme === "zaparoo" && !CUSTOM_SCHEME_HOSTS.has(url.host)) {
+      return { type: "unsupported" };
+    }
+
+    const path = url.pathname;
     const value = url.searchParams.get("v");
 
     if (!value) {
@@ -43,8 +48,11 @@ export function parseDeepLink(urlString: string): ParsedDeepLink {
     }
 
     return { type: "unsupported" };
-  } catch {
-    return { type: "invalid" };
+  } catch (error) {
+    return {
+      type: "invalid",
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
   }
 }
 
@@ -79,13 +87,18 @@ export function useDeepLinks() {
           logger.log("Write queue:", parsed.value);
           setWriteQueue(parsed.value);
         } else if (parsed.type === "invalid") {
-          logger.warn("Invalid deep link URL", new Error("Invalid URL"));
+          logger.error("Invalid deep link URL", parsed.error, {
+            category: "general",
+            action: "deepLinkParse",
+            severity: "error",
+          });
           toast.error(t("deepLinks.invalidUrl"));
         }
       } catch (error) {
         logger.error("Deep link dispatch failed", error, {
           category: "general",
           action: "deepLinkDispatch",
+          severity: "error",
         });
       }
     },


### PR DESCRIPTION
Summary:
- Initialize deep link capture before app hydration gates so cold-start URLs are not missed.
- Add explicit deep link parsing and safer listener cleanup/deduping.
- Cover early startup, parser, duplicate URL, and cleanup behavior in tests.

Validation:
- npm run typecheck
- npm run lint
- npm run test -- --run src/__tests__/unit/lib/deepLinks.test.tsx src/__tests__/unit/App.integration.test.tsx src/__tests__/unit/hooks/useRunQueueProcessor.test.tsx src/__tests__/unit/hooks/useWriteQueueProcessor.test.tsx

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deep-link handling now initializes earlier so links are processed before app hydration.
  * More robust deep-link parsing with clearer error reporting and user-facing error toasts for malformed/unsupported links.
  * Deduplication prevents repeated processing of the same link.

* **Bug Fixes**
  * Prevented deep-link side effects from running after relevant components have unmounted; improved listener cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->