### PR TITLE
Add app update polish

### DIFF
--- a/__mocks__/@capawesome/capacitor-live-update.ts
+++ b/__mocks__/@capawesome/capacitor-live-update.ts
@@ -12,6 +12,8 @@ export const LiveUpdate = {
   sync: vi.fn().mockResolvedValue({ nextBundleId: null }),
   getCurrentBundle: vi.fn().mockResolvedValue({ bundleId: null }),
   getNextBundle: vi.fn().mockResolvedValue({ bundleId: null }),
+  getVersionName: vi.fn().mockResolvedValue({ versionName: "1.0.0" }),
+  getVersionCode: vi.fn().mockResolvedValue({ versionCode: "1" }),
   setNextBundle: vi.fn().mockResolvedValue(undefined),
   deleteBundle: vi.fn().mockResolvedValue(undefined),
   reset: vi.fn().mockResolvedValue(undefined),
@@ -25,6 +27,8 @@ export function __resetLiveUpdateMock(): void {
   vi.mocked(LiveUpdate.sync).mockClear();
   vi.mocked(LiveUpdate.getCurrentBundle).mockClear();
   vi.mocked(LiveUpdate.getNextBundle).mockClear();
+  vi.mocked(LiveUpdate.getVersionName).mockClear();
+  vi.mocked(LiveUpdate.getVersionCode).mockClear();
   vi.mocked(LiveUpdate.setNextBundle).mockClear();
   vi.mocked(LiveUpdate.deleteBundle).mockClear();
   vi.mocked(LiveUpdate.reset).mockClear();

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,14 +39,15 @@ If a bad update crashes the app before `ready()` is called, the plugin automatic
 ### Pushing a Live Update
 
 ```bash
-npm run live-update
+VITE_RELEASE_KEY="live:1.10.2-ota.1" npm run live-update
 ```
 
 This command:
 
-1. Builds the web assets (`npm run build:web`)
-2. Signs the bundle with `live-update-private.pem`
-3. Uploads to Capawesome Cloud
+1. Requires `VITE_RELEASE_KEY` so the app can identify the applied web bundle for the “What’s new” dialog
+2. Builds the web assets (`npm run build:web`)
+3. Signs the bundle with `live-update-private.pem`
+4. Uploads to Capawesome Cloud with `releaseKey` as a custom property
 
 ### Listing Deployed Updates
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sync": "npx cap sync",
     "build:server": "tsc --noEmit -p tsconfig.build.json && vite build && cross-env NODE_ENV=development cap sync",
     "build:analyze": "tsc --noEmit -p tsconfig.build.json && vite build --mode analyze",
-    "live-update": "npm run build:web && npx capawesome apps:liveupdates:upload --app-id e96c260c-3271-4895-bff0-de9f8ca4d05a --path dist --private-key live-update-private.pem --channel production",
+    "live-update": "sh -c 'test -n \"$VITE_RELEASE_KEY\" || { echo \"VITE_RELEASE_KEY is required for live updates\"; exit 1; }; npm run build:web && npx capawesome apps:liveupdates:upload --app-id e96c260c-3271-4895-bff0-de9f8ca4d05a --path dist --private-key live-update-private.pem --channel production --custom-property releaseKey=$VITE_RELEASE_KEY'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { useRunQueueProcessor } from "./hooks/useRunQueueProcessor";
 import { useWriteQueueProcessor } from "./hooks/useWriteQueueProcessor";
 import { usePassiveNfcListener } from "./hooks/usePassiveNfcListener";
 import { useLiveUpdate } from "./hooks/useLiveUpdate";
+import { WhatsNewInitializer } from "./components/WhatsNewInitializer";
 import { initDeviceInfo, logger } from "./lib/logger";
 import { getSubscriptionStatus } from "./lib/onlineApi";
 import { purchasesReady } from "./lib/purchasesSetup";
@@ -393,6 +394,7 @@ export default function App() {
             <RequirementsModal />
             <InboxModal />
             <StagedTokenModal />
+            <WhatsNewInitializer />
           </ConnectionProvider>
         </SlideModalProvider>
       </A11yAnnouncerProvider>

--- a/src/__tests__/integration/create-mappings.test.tsx
+++ b/src/__tests__/integration/create-mappings.test.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, waitFor } from "../../test-utils";
 import userEvent from "@testing-library/user-event";
+import type { MappingResponse } from "@/lib/models";
 
 const {
   componentRef,
@@ -35,7 +36,9 @@ const {
   mockMappingsReload: vi.fn(),
   mockRefetch: vi.fn(),
   mockMappingsData: {
-    current: { mappings: [] as any[] } as { mappings: any[] } | undefined,
+    current: { mappings: [] as MappingResponse[] } as
+      | { mappings: MappingResponse[] }
+      | undefined,
   },
   mockIsLoading: { current: false },
 }));
@@ -117,7 +120,9 @@ vi.mock("react-hot-toast", () => ({
 
 import "@/routes/create.mappings";
 
-const buildMapping = (overrides: Partial<any> = {}) => ({
+const buildMapping = (
+  overrides: Partial<MappingResponse> = {},
+): MappingResponse => ({
   id: "1",
   added: new Date().toISOString(),
   label: "",

--- a/src/__tests__/integration/create-mappings.test.tsx
+++ b/src/__tests__/integration/create-mappings.test.tsx
@@ -34,7 +34,9 @@ const {
   mockToastError: vi.fn(),
   mockMappingsReload: vi.fn(),
   mockRefetch: vi.fn(),
-  mockMappingsData: { current: { mappings: [] as any[] } },
+  mockMappingsData: {
+    current: { mappings: [] as any[] } as { mappings: any[] } | undefined,
+  },
   mockIsLoading: { current: false },
 }));
 
@@ -178,6 +180,28 @@ describe("Create Mappings List Route", () => {
           name: "create.mappings.list.newMapping",
         }),
       ).toBeInTheDocument();
+    });
+
+    it("should render blank content while mappings are initially loading", () => {
+      mockMappingsData.current = undefined;
+      mockIsLoading.current = true;
+
+      renderList();
+
+      expect(
+        screen.getByRole("heading", { name: "create.mappings.title" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", {
+          name: "create.mappings.list.newMapping",
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("create.mappings.list.empty"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("create.mappings.list.searchEmpty"),
+      ).not.toBeInTheDocument();
     });
 
     it("should render the empty state when there are no mappings", () => {

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -157,6 +157,12 @@ vi.mock("@/lib/preferencesStore", () => {
       showFilenames: false,
       shakeEnabled: false,
       launcherAccess: false,
+      whatsNewInitialized: true,
+      lastWhatsNewRuntimeKey: "native:1.0.0+1",
+      seenWhatsNewAnnouncementIds: [],
+      initializeWhatsNew: vi.fn(),
+      setLastWhatsNewRuntimeKey: vi.fn(),
+      markWhatsNewSeen: vi.fn(),
       setLauncherAccess: mockSetLauncherAccess,
     };
     if (typeof selector === "function") {

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -22,6 +22,12 @@ const {
     showFilenames: false,
     shakeEnabled: false,
     launcherAccess: false,
+    whatsNewInitialized: true,
+    lastWhatsNewRuntimeKey: "native:1.0.0+1",
+    seenWhatsNewAnnouncementIds: [],
+    initializeWhatsNew: vi.fn(),
+    setLastWhatsNewRuntimeKey: vi.fn(),
+    markWhatsNewSeen: vi.fn(),
   },
 }));
 

--- a/src/__tests__/unit/components/RemoteKeyboardModal.test.tsx
+++ b/src/__tests__/unit/components/RemoteKeyboardModal.test.tsx
@@ -7,6 +7,7 @@ import { CoreAPI } from "@/lib/coreApi";
 import { Capacitor } from "@capacitor/core";
 import { Directory, Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
+import { Haptics, ImpactStyle } from "@capacitor/haptics";
 import toast from "react-hot-toast";
 
 interface KeyboardMockProps {
@@ -105,6 +106,17 @@ describe("RemoteKeyboardModal", () => {
     await waitFor(() => {
       expect(CoreAPI.inputKeyboard).toHaveBeenCalledWith({ keys: "{enter}" });
     });
+  });
+
+  it("should trigger light haptics for remote pad actions on native platforms", async () => {
+    const user = userEvent.setup();
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+
+    render(<RemoteKeyboardModal isOpen close={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "remoteKeyboard.up" }));
+
+    expect(Haptics.impact).toHaveBeenCalledWith({ style: ImpactStyle.Light });
   });
 
   it("should send generic remote actions when platform is unknown", async () => {
@@ -362,6 +374,32 @@ describe("RemoteKeyboardModal", () => {
     expect(toast.error).toHaveBeenCalledWith("remoteKeyboard.screenshotError");
   });
 
+  it("should trigger light haptics for screenshot capture and clear controls", async () => {
+    const user = userEvent.setup();
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+
+    render(<RemoteKeyboardModal isOpen close={vi.fn()} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "remoteKeyboard.screenshotAction",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: "remoteKeyboard.screenshotClear",
+      }),
+    );
+
+    expect(Haptics.impact).toHaveBeenCalledTimes(2);
+    expect(Haptics.impact).toHaveBeenNthCalledWith(1, {
+      style: ImpactStyle.Light,
+    });
+    expect(Haptics.impact).toHaveBeenNthCalledWith(2, {
+      style: ImpactStyle.Light,
+    });
+  });
+
   it("should send literal key presses from keyboard mode", async () => {
     const user = userEvent.setup();
 
@@ -374,6 +412,26 @@ describe("RemoteKeyboardModal", () => {
 
     await waitFor(() => {
       expect(CoreAPI.inputKeyboard).toHaveBeenCalledWith({ keys: "q" });
+    });
+  });
+
+  it("should trigger light haptics for mode and keyboard key controls", async () => {
+    const user = userEvent.setup();
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+
+    render(<RemoteKeyboardModal isOpen close={vi.fn()} />);
+
+    await user.click(
+      screen.getByRole("radio", { name: "remoteKeyboard.keyboardMode" }),
+    );
+    await user.click(screen.getByRole("button", { name: "q" }));
+
+    expect(Haptics.impact).toHaveBeenCalledTimes(2);
+    expect(Haptics.impact).toHaveBeenNthCalledWith(1, {
+      style: ImpactStyle.Light,
+    });
+    expect(Haptics.impact).toHaveBeenNthCalledWith(2, {
+      style: ImpactStyle.Light,
     });
   });
 

--- a/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
+++ b/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
@@ -1,0 +1,176 @@
+import { act, fireEvent, render, screen, waitFor } from "@/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WhatsNewInitializer } from "@/components/WhatsNewInitializer";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+import type {
+  RuntimeReleaseIdentity,
+  WhatsNewAnnouncement,
+} from "@/lib/whatsNew";
+
+const whatsNewMock = vi.hoisted(() => ({
+  resolveRuntimeReleaseIdentity: vi.fn(),
+  getWhatsNewAnnouncement: vi.fn(),
+}));
+
+vi.mock("@/lib/whatsNew", () => ({
+  resolveRuntimeReleaseIdentity: whatsNewMock.resolveRuntimeReleaseIdentity,
+  getWhatsNewAnnouncement: whatsNewMock.getWhatsNewAnnouncement,
+}));
+
+const identity: RuntimeReleaseIdentity = {
+  nativeVersion: "1.0.1",
+  nativeBuild: "2",
+  liveBundleId: null,
+  releaseKey: "native:1.0.1+2",
+};
+
+const announcement: WhatsNewAnnouncement = {
+  id: "release-1.0.1",
+  releaseKeys: [identity.releaseKey],
+  title: "What's new in test",
+  items: ["First test item", "Second test item"],
+};
+
+function setPreferencesState(
+  values: Partial<ReturnType<typeof usePreferencesStore.getState>>,
+) {
+  usePreferencesStore.setState({
+    ...usePreferencesStore.getState(),
+    _hasHydrated: true,
+    tourCompleted: true,
+    whatsNewInitialized: true,
+    lastWhatsNewRuntimeKey: "native:1.0.0+1",
+    seenWhatsNewAnnouncementIds: [],
+    ...values,
+  });
+}
+
+describe("WhatsNewInitializer", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    whatsNewMock.resolveRuntimeReleaseIdentity.mockResolvedValue(identity);
+    whatsNewMock.getWhatsNewAnnouncement.mockReturnValue(announcement);
+    setPreferencesState({});
+  });
+
+  it("should seed fresh installs without showing the dialog", async () => {
+    setPreferencesState({ whatsNewInitialized: false, tourCompleted: false });
+
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(usePreferencesStore.getState().whatsNewInitialized).toBe(true);
+    });
+
+    expect(usePreferencesStore.getState().lastWhatsNewRuntimeKey).toBe(
+      identity.releaseKey,
+    );
+    expect(
+      usePreferencesStore.getState().seenWhatsNewAnnouncementIds,
+    ).toContain(announcement.id);
+
+    act(() => {
+      usePreferencesStore.setState({ tourCompleted: true });
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should treat uninitialized users with completed tours as legacy installs", async () => {
+    setPreferencesState({ whatsNewInitialized: false, tourCompleted: true });
+
+    render(<WhatsNewInitializer />);
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "whatsNew.gotIt" }),
+    );
+
+    expect(usePreferencesStore.getState().whatsNewInitialized).toBe(true);
+    expect(
+      usePreferencesStore.getState().seenWhatsNewAnnouncementIds,
+    ).toContain(announcement.id);
+  });
+
+  it("should show an unseen announcement for existing users", async () => {
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(whatsNewMock.getWhatsNewAnnouncement).toHaveBeenCalledWith(
+        identity.releaseKey,
+      );
+    });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("What's new in test")).toBeInTheDocument();
+    expect(screen.getByText("First test item")).toBeInTheDocument();
+    expect(screen.getByText("Second test item")).toBeInTheDocument();
+  });
+
+  it("should wait for the getting started tour before showing", async () => {
+    setPreferencesState({ tourCompleted: false });
+
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(whatsNewMock.getWhatsNewAnnouncement).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    act(() => {
+      usePreferencesStore.setState({ tourCompleted: true });
+    });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should mark the announcement seen on dismiss", async () => {
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(whatsNewMock.getWhatsNewAnnouncement).toHaveBeenCalled();
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "whatsNew.gotIt" }),
+    );
+
+    expect(
+      usePreferencesStore.getState().seenWhatsNewAnnouncementIds,
+    ).toContain(announcement.id);
+    expect(usePreferencesStore.getState().lastWhatsNewRuntimeKey).toBe(
+      identity.releaseKey,
+    );
+  });
+
+  it("should not repeat seen announcements", async () => {
+    setPreferencesState({ seenWhatsNewAnnouncementIds: [announcement.id] });
+
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(whatsNewMock.getWhatsNewAnnouncement).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(usePreferencesStore.getState().lastWhatsNewRuntimeKey).toBe(
+      identity.releaseKey,
+    );
+  });
+
+  it("should ignore releases without announcements", async () => {
+    whatsNewMock.getWhatsNewAnnouncement.mockReturnValue(undefined);
+
+    render(<WhatsNewInitializer />);
+
+    await waitFor(() => {
+      expect(usePreferencesStore.getState().lastWhatsNewRuntimeKey).toBe(
+        identity.releaseKey,
+      );
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
+++ b/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
@@ -1,11 +1,12 @@
-import { act, fireEvent, render, screen, waitFor } from "@/test-utils";
+import { act, render, screen, waitFor } from "@/test-utils";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WhatsNewInitializer } from "@/components/WhatsNewInitializer";
 import { usePreferencesStore } from "@/lib/preferencesStore";
-import type {
-  RuntimeReleaseIdentity,
-  WhatsNewAnnouncement,
-} from "@/lib/whatsNew";
+import {
+  buildRuntimeReleaseIdentity,
+  buildWhatsNewAnnouncement,
+} from "@/test-utils/factories";
 
 const whatsNewMock = vi.hoisted(() => ({
   resolveRuntimeReleaseIdentity: vi.fn(),
@@ -17,19 +18,10 @@ vi.mock("@/lib/whatsNew", () => ({
   getWhatsNewAnnouncement: whatsNewMock.getWhatsNewAnnouncement,
 }));
 
-const identity: RuntimeReleaseIdentity = {
-  nativeVersion: "1.0.1",
-  nativeBuild: "2",
-  liveBundleId: null,
-  releaseKey: "native:1.0.1+2",
-};
-
-const announcement: WhatsNewAnnouncement = {
-  id: "release-1.0.1",
+const identity = buildRuntimeReleaseIdentity();
+const announcement = buildWhatsNewAnnouncement({
   releaseKeys: [identity.releaseKey],
-  title: "What's new in test",
-  items: ["First test item", "Second test item"],
-};
+});
 
 function setPreferencesState(
   values: Partial<ReturnType<typeof usePreferencesStore.getState>>,
@@ -77,13 +69,14 @@ describe("WhatsNewInitializer", () => {
   });
 
   it("should treat uninitialized users with completed tours as legacy installs", async () => {
+    const user = userEvent.setup();
     setPreferencesState({ whatsNewInitialized: false, tourCompleted: true });
 
     render(<WhatsNewInitializer />);
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole("button", { name: "whatsNew.gotIt" }),
     );
 
@@ -127,13 +120,15 @@ describe("WhatsNewInitializer", () => {
   });
 
   it("should mark the announcement seen on dismiss", async () => {
+    const user = userEvent.setup();
+
     render(<WhatsNewInitializer />);
 
     await waitFor(() => {
       expect(whatsNewMock.getWhatsNewAnnouncement).toHaveBeenCalled();
     });
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole("button", { name: "whatsNew.gotIt" }),
     );
 

--- a/src/__tests__/unit/coreApi.error-handling.test.ts
+++ b/src/__tests__/unit/coreApi.error-handling.test.ts
@@ -1,7 +1,14 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { CoreAPI } from "@/lib/coreApi";
+import { CoreAPI, isRequestCancelledError } from "@/lib/coreApi";
 
 describe("CoreAPI Error Handling Coverage", () => {
+  it("should identify connection reset cancellation errors", () => {
+    expect(
+      isRequestCancelledError(new Error("Request cancelled: connection reset")),
+    ).toBe(true);
+    expect(isRequestCancelledError(new Error("Network error"))).toBe(false);
+  });
+
   const mockSend = vi.fn();
 
   beforeEach(() => {

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -6,6 +6,7 @@ import {
   getWhatsNewAnnouncement,
   resolveRuntimeReleaseIdentity,
 } from "@/lib/whatsNew";
+import { buildRuntimeReleaseIdentity } from "@/test-utils/factories";
 
 describe("whatsNew", () => {
   beforeEach(() => {
@@ -29,12 +30,14 @@ describe("whatsNew", () => {
   it("should resolve native identity when no live bundle is active", async () => {
     const identity = await resolveRuntimeReleaseIdentity();
 
-    expect(identity).toEqual({
-      nativeVersion: "1.2.3",
-      nativeBuild: "42",
-      liveBundleId: null,
-      releaseKey: "native:1.2.3+42",
-    });
+    expect(identity).toEqual(
+      buildRuntimeReleaseIdentity({
+        nativeVersion: "1.2.3",
+        nativeBuild: "42",
+        liveBundleId: null,
+        releaseKey: "native:1.2.3+42",
+      }),
+    );
   });
 
   it("should include the current live bundle in the fallback release key", async () => {
@@ -46,12 +49,14 @@ describe("whatsNew", () => {
 
     const identity = await resolveRuntimeReleaseIdentity();
 
-    expect(identity).toEqual({
-      nativeVersion: "1.2.3",
-      nativeBuild: "42",
-      liveBundleId: "bundle-2026-06-04",
-      releaseKey: "native:1.2.3+42:bundle:bundle-2026-06-04",
-    });
+    expect(identity).toEqual(
+      buildRuntimeReleaseIdentity({
+        nativeVersion: "1.2.3",
+        nativeBuild: "42",
+        liveBundleId: "bundle-2026-06-04",
+        releaseKey: "native:1.2.3+42:bundle:bundle-2026-06-04",
+      }),
+    );
   });
 
   it("should prefer the injected release key", async () => {

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -1,0 +1,77 @@
+import { App } from "@capacitor/app";
+import { Capacitor } from "@capacitor/core";
+import { LiveUpdate } from "@capawesome/capacitor-live-update";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getWhatsNewAnnouncement,
+  resolveRuntimeReleaseIdentity,
+} from "@/lib/whatsNew";
+
+describe("whatsNew", () => {
+  beforeEach(() => {
+    vi.mocked(App.getInfo).mockResolvedValue({
+      name: "Zaparoo",
+      id: "dev.wizzo.tapto",
+      version: "1.2.3",
+      build: "42",
+    });
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(false);
+    vi.mocked(LiveUpdate.getCurrentBundle).mockResolvedValue({
+      bundleId: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should resolve native identity when no live bundle is active", async () => {
+    const identity = await resolveRuntimeReleaseIdentity();
+
+    expect(identity).toEqual({
+      nativeVersion: "1.2.3",
+      nativeBuild: "42",
+      liveBundleId: null,
+      releaseKey: "native:1.2.3+42",
+    });
+  });
+
+  it("should include the current live bundle in the fallback release key", async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    vi.mocked(LiveUpdate.getCurrentBundle).mockResolvedValue({
+      bundleId: "bundle-2026-06-04",
+    });
+
+    const identity = await resolveRuntimeReleaseIdentity();
+
+    expect(identity).toEqual({
+      nativeVersion: "1.2.3",
+      nativeBuild: "42",
+      liveBundleId: "bundle-2026-06-04",
+      releaseKey: "native:1.2.3+42:bundle:bundle-2026-06-04",
+    });
+  });
+
+  it("should prefer the injected release key", async () => {
+    vi.stubEnv("VITE_RELEASE_KEY", "live:1.2.3-ota.1");
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    vi.mocked(LiveUpdate.getCurrentBundle).mockResolvedValue({
+      bundleId: "bundle-2026-06-04",
+    });
+
+    const identity = await resolveRuntimeReleaseIdentity();
+
+    expect(identity.releaseKey).toBe("live:1.2.3-ota.1");
+    expect(identity.liveBundleId).toBe("bundle-2026-06-04");
+  });
+
+  it("should find the first 1.11.0 announcement", () => {
+    const announcement = getWhatsNewAnnouncement("native:1.11.0+25");
+
+    expect(announcement?.id).toBe("release-1.11.0");
+    expect(announcement?.items).toHaveLength(5);
+  });
+});

--- a/src/__tests__/unit/routes/create.search.loader.test.ts
+++ b/src/__tests__/unit/routes/create.search.loader.test.ts
@@ -11,6 +11,12 @@ vi.mock("../../../lib/coreApi", () => ({
   CoreAPI: {
     systems: vi.fn(),
   },
+  isRequestCancelledError: (error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    return /request cancelled|request canceled|connection reset|aborted/i.test(
+      message,
+    );
+  },
 }));
 
 describe("Create Search Route Loader", () => {
@@ -122,6 +128,23 @@ describe("Create Search Route Loader", () => {
 
     // CoreAPI.systems is called in parallel, so it will be called even if preferences fail
     expect(mockCoreApiSystems).toHaveBeenCalled();
+  });
+
+  it("should use empty systems when CoreAPI systems request is cancelled", async () => {
+    mockPreferencesGet
+      .mockResolvedValueOnce({ value: "snes" })
+      .mockResolvedValueOnce({ value: "[]" });
+    mockCoreApiSystems.mockRejectedValue(
+      new Error("Request cancelled: connection reset"),
+    );
+
+    const result = await Route.options?.loader?.({} as any);
+
+    expect(result).toEqual({
+      systemQuery: "snes",
+      tagQuery: [],
+      systems: { systems: [] },
+    });
   });
 
   it("should handle CoreAPI systems failure", async () => {

--- a/src/components/RemoteKeyboardModal.tsx
+++ b/src/components/RemoteKeyboardModal.tsx
@@ -22,6 +22,7 @@ import "react-simple-keyboard/build/css/index.css";
 import { SlideModal } from "@/components/SlideModal";
 import { Segmented } from "@/components/wui/Segmented";
 import { CoreAPI } from "@/lib/coreApi";
+import { useHaptics } from "@/hooks/useHaptics";
 import { logger } from "@/lib/logger";
 import { useStatusStore } from "@/lib/store";
 
@@ -213,6 +214,7 @@ export function RemoteKeyboardModal(props: {
   close: () => void;
 }) {
   const { t } = useTranslation();
+  const { impact } = useHaptics();
   const connected = useStatusStore((state) => state.connected);
   const corePlatform = useStatusStore((state) => state.corePlatform);
   const [layoutName, setLayoutName] = useState<KeyboardLayoutName>("default");
@@ -229,7 +231,13 @@ export function RemoteKeyboardModal(props: {
     { value: "keyboard", label: t("remoteKeyboard.keyboardMode") },
   ];
 
+  const triggerControlHaptic = () => {
+    impact("light");
+  };
+
   const sendMacro = (keys: string) => {
+    triggerControlHaptic();
+
     if (!connected) {
       const message = t("remoteKeyboard.disconnected");
       setError(null);
@@ -256,6 +264,7 @@ export function RemoteKeyboardModal(props: {
   const handleKeyPress = (button: string) => {
     const nextLayout = layoutSwitches[button];
     if (nextLayout) {
+      triggerControlHaptic();
       setLayoutName(nextLayout);
       return;
     }
@@ -267,6 +276,8 @@ export function RemoteKeyboardModal(props: {
   };
 
   const handleScreenshot = () => {
+    triggerControlHaptic();
+
     if (!connected) {
       const message = t("remoteKeyboard.disconnected");
       setError(null);
@@ -294,6 +305,8 @@ export function RemoteKeyboardModal(props: {
   };
 
   const shareScreenshot = async () => {
+    triggerControlHaptic();
+
     if (!screenshot) return;
 
     try {
@@ -351,7 +364,10 @@ export function RemoteKeyboardModal(props: {
           labelHidden
           options={modeOptions}
           value={mode}
-          onChange={setMode}
+          onChange={(next) => {
+            triggerControlHaptic();
+            setMode(next);
+          }}
         />
         {mode === "remote" ? (
           <div className="remote-keyboard-pad">
@@ -449,6 +465,7 @@ export function RemoteKeyboardModal(props: {
                       className="remote-keyboard-screenshot-control"
                       href={screenshotUrl}
                       download={getScreenshotFileName(screenshot.path)}
+                      onClick={triggerControlHaptic}
                     >
                       <Download size={20} aria-hidden="true" />
                       {t("remoteKeyboard.screenshotDownload")}
@@ -457,7 +474,10 @@ export function RemoteKeyboardModal(props: {
                   <button
                     type="button"
                     className="remote-keyboard-screenshot-control"
-                    onClick={() => setScreenshot(null)}
+                    onClick={() => {
+                      triggerControlHaptic();
+                      setScreenshot(null);
+                    }}
                   >
                     <X size={20} aria-hidden="true" />
                     {t("remoteKeyboard.screenshotClear")}

--- a/src/components/RemoteKeyboardModal.tsx
+++ b/src/components/RemoteKeyboardModal.tsx
@@ -465,7 +465,6 @@ export function RemoteKeyboardModal(props: {
                       className="remote-keyboard-screenshot-control"
                       href={screenshotUrl}
                       download={getScreenshotFileName(screenshot.path)}
-                      onClick={triggerControlHaptic}
                     >
                       <Download size={20} aria-hidden="true" />
                       {t("remoteKeyboard.screenshotDownload")}

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -14,7 +14,7 @@ import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
 import { BackToTop } from "./BackToTop";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "./ui/tabs";
+import { TabBar } from "./wui/TabBar";
 
 export interface System {
   id: string;
@@ -302,12 +302,8 @@ export function SystemSelector({
           </div>
         </div>
 
-        {/* Category tabs using shadcn tabs */}
-        <Tabs
-          value={selectedCategory}
-          onValueChange={setSelectedCategory}
-          className="flex min-h-0 flex-1 flex-col"
-        >
+        {/* Category tabs */}
+        <div className="flex min-h-0 flex-1 flex-col">
           <div className="px-2 py-2">
             <div className="relative overflow-hidden rounded-lg">
               {/* Left gradient - only show when scrolled and overflowing */}
@@ -320,16 +316,24 @@ export function SystemSelector({
                 />
               )}
 
-              <TabsList {...tabsProps}>
-                <TabsTrigger value="all">
-                  {t("systemSelector.allCategories")}
-                </TabsTrigger>
-                {categories.map((category) => (
-                  <TabsTrigger key={category} value={category}>
-                    {category}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+              <TabBar
+                label={t("systemSelector.categories")}
+                layout="scroll"
+                role="tab"
+                options={[
+                  {
+                    value: "all",
+                    label: t("systemSelector.allCategories"),
+                  },
+                  ...categories.map((category) => ({
+                    value: category,
+                    label: category,
+                  })),
+                ]}
+                value={selectedCategory}
+                onChange={setSelectedCategory}
+                containerProps={tabsProps}
+              />
 
               {/* Right gradient - only show when more content and overflowing */}
               {hasOverflow && (
@@ -343,11 +347,7 @@ export function SystemSelector({
             </div>
           </div>
 
-          <TabsContent
-            value={selectedCategory}
-            className="min-h-0 flex-1 overflow-hidden"
-            tabIndex={-1}
-          >
+          <div className="min-h-0 flex-1 overflow-hidden" tabIndex={-1}>
             {isLoading ? (
               <div className="flex h-32 items-center justify-center">
                 <span className="text-muted-foreground">{t("loading")}</span>
@@ -517,8 +517,8 @@ export function SystemSelector({
                 </div>
               </>
             )}
-          </TabsContent>
-        </Tabs>
+          </div>
+        </div>
 
         {/* Scroll to top button */}
         <BackToTop

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -10,11 +10,15 @@ import { compareStrings } from "@/lib/utils";
 import { useStatusStore } from "@/lib/store";
 import { useSmartTabs } from "@/hooks/useSmartTabs";
 import { EmptyState } from "@/components/wui/EmptyState";
+import {
+  getTabBarPanelId,
+  getTabBarTabId,
+  TabBar,
+} from "@/components/wui/TabBar";
 import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
 import { BackToTop } from "./BackToTop";
-import { TabBar } from "./wui/TabBar";
 
 export interface System {
   id: string;
@@ -224,6 +228,13 @@ export function SystemSelector({
     overscan: 5,
   });
 
+  const systemTabIdPrefix = "system-category-tab";
+  const selectedCategoryTabId = getTabBarTabId(
+    selectedCategory,
+    systemTabIdPrefix,
+  );
+  const selectedCategoryPanelId = getTabBarPanelId(selectedCategoryTabId);
+
   // Footer for multi-select mode
   const footer =
     mode === "multi" ? (
@@ -324,10 +335,12 @@ export function SystemSelector({
                   {
                     value: "all",
                     label: t("systemSelector.allCategories"),
+                    id: getTabBarTabId("all", systemTabIdPrefix),
                   },
                   ...categories.map((category) => ({
                     value: category,
                     label: category,
+                    id: getTabBarTabId(category, systemTabIdPrefix),
                   })),
                 ]}
                 value={selectedCategory}
@@ -347,7 +360,13 @@ export function SystemSelector({
             </div>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-hidden" tabIndex={-1}>
+          <div
+            id={selectedCategoryPanelId}
+            role="tabpanel"
+            aria-labelledby={selectedCategoryTabId}
+            className="min-h-0 flex-1 overflow-hidden"
+            tabIndex={-1}
+          >
             {isLoading ? (
               <div className="flex h-32 items-center justify-center">
                 <span className="text-muted-foreground">{t("loading")}</span>

--- a/src/components/WhatsNewDialog.tsx
+++ b/src/components/WhatsNewDialog.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/wui/Button";
+import type { WhatsNewAnnouncement } from "@/lib/whatsNew";
+
+export function WhatsNewDialog(props: {
+  isOpen: boolean;
+  announcement: WhatsNewAnnouncement | null;
+  onDismiss: () => void;
+}) {
+  const { t } = useTranslation();
+
+  if (!props.announcement) return null;
+
+  return (
+    <Dialog
+      open={props.isOpen}
+      onOpenChange={(open) => !open && props.onDismiss()}
+    >
+      <DialogContent
+        className="max-w-[340px] gap-5"
+        aria-describedby={undefined}
+        onOpenChange={(open) => !open && props.onDismiss()}
+      >
+        <DialogHeader>
+          <DialogTitle>{props.announcement.title}</DialogTitle>
+        </DialogHeader>
+        <ul className="text-muted-foreground list-disc space-y-2 pl-5 text-sm">
+          {props.announcement.items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+        <Button
+          label={t("whatsNew.gotIt")}
+          intent="primary"
+          onClick={props.onDismiss}
+          className="w-full"
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/WhatsNewInitializer.tsx
+++ b/src/components/WhatsNewInitializer.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WhatsNewDialog } from "@/components/WhatsNewDialog";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+import {
+  getWhatsNewAnnouncement,
+  resolveRuntimeReleaseIdentity,
+  type WhatsNewAnnouncement,
+} from "@/lib/whatsNew";
+
+export function WhatsNewInitializer() {
+  const hasHydrated = usePreferencesStore((state) => state._hasHydrated);
+  const tourCompleted = usePreferencesStore((state) => state.tourCompleted);
+  const whatsNewInitialized = usePreferencesStore(
+    (state) => state.whatsNewInitialized,
+  );
+  const seenAnnouncementIds = usePreferencesStore(
+    (state) => state.seenWhatsNewAnnouncementIds,
+  );
+  const initializeWhatsNew = usePreferencesStore(
+    (state) => state.initializeWhatsNew,
+  );
+  const setLastWhatsNewRuntimeKey = usePreferencesStore(
+    (state) => state.setLastWhatsNewRuntimeKey,
+  );
+  const markWhatsNewSeen = usePreferencesStore(
+    (state) => state.markWhatsNewSeen,
+  );
+
+  const [pendingAnnouncement, setPendingAnnouncement] =
+    useState<WhatsNewAnnouncement | null>(null);
+  const [pendingRuntimeKey, setPendingRuntimeKey] = useState<string | null>(
+    null,
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const processedRuntimeKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    let cancelled = false;
+
+    const prepareWhatsNew = async () => {
+      const identity = await resolveRuntimeReleaseIdentity();
+      if (cancelled || processedRuntimeKeyRef.current === identity.releaseKey) {
+        return;
+      }
+
+      processedRuntimeKeyRef.current = identity.releaseKey;
+      const announcement = getWhatsNewAnnouncement(identity.releaseKey);
+
+      if (!whatsNewInitialized) {
+        if (tourCompleted && announcement) {
+          // TODO: After one release has shipped with whats-new state seeded,
+          // remove this legacy-install branch and always seed uninitialized
+          // installs without showing an announcement.
+          setPendingAnnouncement(announcement);
+          setPendingRuntimeKey(identity.releaseKey);
+          return;
+        }
+
+        initializeWhatsNew(identity.releaseKey, announcement?.id ?? null);
+        return;
+      }
+
+      if (!announcement) {
+        setLastWhatsNewRuntimeKey(identity.releaseKey);
+        return;
+      }
+
+      if (seenAnnouncementIds.includes(announcement.id)) {
+        setLastWhatsNewRuntimeKey(identity.releaseKey);
+        return;
+      }
+
+      setPendingAnnouncement(announcement);
+      setPendingRuntimeKey(identity.releaseKey);
+    };
+
+    prepareWhatsNew();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    hasHydrated,
+    initializeWhatsNew,
+    seenAnnouncementIds,
+    setLastWhatsNewRuntimeKey,
+    tourCompleted,
+    whatsNewInitialized,
+  ]);
+
+  useEffect(() => {
+    if (!pendingAnnouncement || !tourCompleted || isOpen) return;
+
+    const timer = setTimeout(() => {
+      setIsOpen(true);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [isOpen, pendingAnnouncement, tourCompleted]);
+
+  const handleDismiss = useCallback(() => {
+    if (pendingAnnouncement && pendingRuntimeKey) {
+      markWhatsNewSeen(pendingAnnouncement.id, pendingRuntimeKey);
+    }
+    setIsOpen(false);
+    setPendingAnnouncement(null);
+    setPendingRuntimeKey(null);
+  }, [markWhatsNewSeen, pendingAnnouncement, pendingRuntimeKey]);
+
+  return (
+    <WhatsNewDialog
+      isOpen={isOpen}
+      announcement={pendingAnnouncement}
+      onDismiss={handleDismiss}
+    />
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "bg-wui-card text-muted-foreground flex h-12 items-center justify-center rounded-lg border border-white/20 p-1",
+      "text-muted-foreground flex items-center justify-center gap-1 rounded-md border border-solid border-white/10 p-1",
       className,
     )}
     {...props}
@@ -26,7 +26,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:ring-ring data-[state=active]:bg-primary/20 data-[state=active]:text-primary inline-flex items-center justify-center rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-lg",
+      "data-[state=active]:bg-button-pattern inline-flex cursor-pointer items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-white",
       className,
     )}
     {...props}

--- a/src/components/wui/Segmented.tsx
+++ b/src/components/wui/Segmented.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { useRef, type KeyboardEvent } from "react";
+import { TabBar } from "@/components/wui/TabBar";
 
 interface SegmentedProps<T extends string> {
   label: string;
@@ -18,82 +18,17 @@ export function Segmented<T extends string>({
   value,
   onChange,
 }: SegmentedProps<T>) {
-  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  const focusAndSelect = (index: number) => {
-    const target = options[index];
-    if (!target) return;
-    onChange(target.value);
-    buttonRefs.current[index]?.focus();
-  };
-
-  const onKeyDown = (
-    event: KeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) => {
-    switch (event.key) {
-      case "ArrowRight":
-      case "ArrowDown":
-        event.preventDefault();
-        focusAndSelect((index + 1) % options.length);
-        break;
-      case "ArrowLeft":
-      case "ArrowUp":
-        event.preventDefault();
-        focusAndSelect((index - 1 + options.length) % options.length);
-        break;
-      case "Home":
-        event.preventDefault();
-        focusAndSelect(0);
-        break;
-      case "End":
-        event.preventDefault();
-        focusAndSelect(options.length - 1);
-        break;
-    }
-  };
-
   return (
     <div className="flex flex-col">
       <label className={classNames("mb-1 block", { "sr-only": labelHidden })}>
         {label}
       </label>
-      <div
-        role="radiogroup"
-        aria-label={label}
-        className="border-bd-outline grid gap-1 rounded-md border border-solid p-1"
-        style={{
-          gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`,
-        }}
-      >
-        {options.map((option, index) => {
-          const active = option.value === value;
-          return (
-            <button
-              key={option.value}
-              ref={(el) => {
-                buttonRefs.current[index] = el;
-              }}
-              type="button"
-              role="radio"
-              aria-checked={active}
-              tabIndex={active ? 0 : -1}
-              onClick={() => onChange(option.value)}
-              onKeyDown={(event) => onKeyDown(event, index)}
-              className={classNames(
-                "cursor-pointer rounded-sm py-1.5 text-sm font-medium transition-colors",
-                "focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
-                {
-                  "bg-button-pattern text-white": active,
-                  "text-muted-foreground": !active,
-                },
-              )}
-            >
-              {option.label}
-            </button>
-          );
-        })}
-      </div>
+      <TabBar
+        label={label}
+        options={options}
+        value={value}
+        onChange={onChange}
+      />
       {help && (
         <span className="text-muted-foreground mt-1 text-sm">{help}</span>
       )}

--- a/src/components/wui/TabBar.tsx
+++ b/src/components/wui/TabBar.tsx
@@ -1,0 +1,123 @@
+import classNames from "classnames";
+import {
+  useRef,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+} from "react";
+
+type TabBarRole = "radio" | "tab";
+
+export interface TabBarOption<T extends string> {
+  value: T;
+  label: ReactNode;
+}
+
+interface TabBarProps<T extends string> {
+  label: string;
+  options: TabBarOption<T>[];
+  value: T;
+  onChange: (next: T) => void;
+  role?: TabBarRole;
+  layout?: "grid" | "scroll";
+  containerProps?: HTMLAttributes<HTMLDivElement> & {
+    ref?: Ref<HTMLDivElement>;
+  };
+}
+
+export function TabBar<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  role = "radio",
+  layout = "grid",
+  containerProps,
+}: TabBarProps<T>) {
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const focusAndSelect = (index: number) => {
+    const target = options[index];
+    if (!target) return;
+    onChange(target.value);
+    buttonRefs.current[index]?.focus();
+  };
+
+  const onKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        focusAndSelect((index + 1) % options.length);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        focusAndSelect((index - 1 + options.length) % options.length);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusAndSelect(0);
+        break;
+      case "End":
+        event.preventDefault();
+        focusAndSelect(options.length - 1);
+        break;
+    }
+  };
+
+  const { className, ...restContainerProps } = containerProps ?? {};
+
+  return (
+    <div
+      role={role === "tab" ? "tablist" : "radiogroup"}
+      aria-label={label}
+      className={classNames(
+        "gap-1 rounded-md border border-solid border-white/15 p-1",
+        layout === "grid" ? "grid" : "flex",
+        className,
+      )}
+      style={{
+        ...(layout === "grid"
+          ? { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }
+          : null),
+        ...containerProps?.style,
+      }}
+      {...restContainerProps}
+    >
+      {options.map((option, index) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            ref={(el) => {
+              buttonRefs.current[index] = el;
+            }}
+            type="button"
+            role={role}
+            aria-checked={role === "radio" ? active : undefined}
+            aria-selected={role === "tab" ? active : undefined}
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(option.value)}
+            onKeyDown={(event) => onKeyDown(event, index)}
+            className={classNames(
+              "cursor-pointer rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-colors",
+              "focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
+              layout === "scroll" && "shrink-0",
+              {
+                "bg-button-pattern text-white": active,
+                "text-muted-foreground": !active,
+              },
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/wui/TabBar.tsx
+++ b/src/components/wui/TabBar.tsx
@@ -12,6 +12,16 @@ type TabBarRole = "radio" | "tab";
 export interface TabBarOption<T extends string> {
   value: T;
   label: ReactNode;
+  id?: string;
+}
+
+export function getTabBarTabId(value: string, prefix = "tab"): string {
+  const safeValue = value.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  return `${prefix}-${safeValue}`;
+}
+
+export function getTabBarPanelId(tabId: string): string {
+  return `tabpanel-${tabId}`;
 }
 
 interface TabBarProps<T extends string> {
@@ -70,7 +80,11 @@ export function TabBar<T extends string>({
     }
   };
 
-  const { className, ...restContainerProps } = containerProps ?? {};
+  const {
+    className,
+    style: containerStyle,
+    ...restContainerProps
+  } = containerProps ?? {};
 
   return (
     <div
@@ -84,16 +98,19 @@ export function TabBar<T extends string>({
       style={{
         ...(layout === "grid"
           ? { gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }
-          : null),
-        ...containerProps?.style,
+          : {}),
+        ...containerStyle,
       }}
       {...restContainerProps}
     >
       {options.map((option, index) => {
         const active = option.value === value;
+        const tabId = option.id ?? getTabBarTabId(option.value);
+        const panelId = getTabBarPanelId(tabId);
         return (
           <button
             key={option.value}
+            id={role === "tab" ? tabId : undefined}
             ref={(el) => {
               buttonRefs.current[index] = el;
             }}
@@ -101,6 +118,7 @@ export function TabBar<T extends string>({
             role={role}
             aria-checked={role === "radio" ? active : undefined}
             aria-selected={role === "tab" ? active : undefined}
+            aria-controls={role === "tab" ? panelId : undefined}
             tabIndex={active ? 0 : -1}
             onClick={() => onChange(option.value)}
             onKeyDown={(event) => onKeyDown(event, index)}

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -205,6 +205,19 @@ export function isCancelled<T>(
   );
 }
 
+export function isRequestCancelledError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+
+  return /request cancelled|request canceled|connection reset|aborted/i.test(
+    message,
+  );
+}
+
 interface ApiResponse {
   jsonrpc: string;
   id: string;
@@ -1230,7 +1243,11 @@ class CoreApi {
           }
         })
         .catch((error) => {
-          logger.error("Systems API call failed:", error);
+          if (isRequestCancelledError(error)) {
+            logger.debug("Systems API call cancelled:", error);
+          } else {
+            logger.error("Systems API call failed:", error);
+          }
           reject(error);
         });
     });

--- a/src/lib/preferencesStore.ts
+++ b/src/lib/preferencesStore.ts
@@ -77,6 +77,11 @@ export interface PreferencesState {
   // Tour completion tracking
   tourCompleted: boolean;
 
+  // What's new tracking
+  whatsNewInitialized: boolean;
+  lastWhatsNewRuntimeKey: string | null;
+  seenWhatsNewAnnouncementIds: string[];
+
   // Log viewer settings
   logLevelFilters: {
     debug: boolean;
@@ -136,6 +141,12 @@ export interface PreferencesActions {
   setShakeZapscript: (value: string) => void;
   setCustomText: (value: string) => void;
   setTourCompleted: (value: boolean) => void;
+  initializeWhatsNew: (
+    runtimeKey: string,
+    announcementId: string | null,
+  ) => void;
+  setLastWhatsNewRuntimeKey: (runtimeKey: string) => void;
+  markWhatsNewSeen: (announcementId: string, runtimeKey: string) => void;
   setLogLevelFilters: (filters: PreferencesState["logLevelFilters"]) => void;
   setShowFilenames: (value: boolean) => void;
   setHapticsEnabled: (value: boolean) => void;
@@ -173,6 +184,9 @@ const DEFAULT_PREFERENCES: Omit<
   shakeZapscript: "",
   customText: "",
   tourCompleted: false,
+  whatsNewInitialized: false,
+  lastWhatsNewRuntimeKey: null,
+  seenWhatsNewAnnouncementIds: [],
   logLevelFilters: {
     debug: true,
     info: true,
@@ -245,6 +259,23 @@ export const usePreferencesStore = create<PreferencesStore>()(
       setShakeZapscript: (value) => set({ shakeZapscript: value }),
       setCustomText: (value) => set({ customText: value }),
       setTourCompleted: (value) => set({ tourCompleted: value }),
+      initializeWhatsNew: (runtimeKey, announcementId) =>
+        set({
+          whatsNewInitialized: true,
+          lastWhatsNewRuntimeKey: runtimeKey,
+          seenWhatsNewAnnouncementIds: announcementId ? [announcementId] : [],
+        }),
+      setLastWhatsNewRuntimeKey: (runtimeKey) =>
+        set({ whatsNewInitialized: true, lastWhatsNewRuntimeKey: runtimeKey }),
+      markWhatsNewSeen: (announcementId, runtimeKey) =>
+        set((state) => ({
+          whatsNewInitialized: true,
+          lastWhatsNewRuntimeKey: runtimeKey,
+          seenWhatsNewAnnouncementIds:
+            state.seenWhatsNewAnnouncementIds.includes(announcementId)
+              ? state.seenWhatsNewAnnouncementIds
+              : [...state.seenWhatsNewAnnouncementIds, announcementId],
+        })),
       setLogLevelFilters: (filters) => set({ logLevelFilters: filters }),
       setShowFilenames: (value) => set({ showFilenames: value }),
       setHapticsEnabled: (value) => set({ hapticsEnabled: value }),
@@ -265,6 +296,9 @@ export const usePreferencesStore = create<PreferencesStore>()(
         shakeZapscript: state.shakeZapscript,
         customText: state.customText,
         tourCompleted: state.tourCompleted,
+        whatsNewInitialized: state.whatsNewInitialized,
+        lastWhatsNewRuntimeKey: state.lastWhatsNewRuntimeKey,
+        seenWhatsNewAnnouncementIds: state.seenWhatsNewAnnouncementIds,
         logLevelFilters: state.logLevelFilters,
         showFilenames: state.showFilenames,
         hapticsEnabled: state.hapticsEnabled,

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -1,0 +1,85 @@
+import { App } from "@capacitor/app";
+import { Capacitor } from "@capacitor/core";
+import { LiveUpdate } from "@capawesome/capacitor-live-update";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
+import { logger } from "@/lib/logger";
+
+export type RuntimeReleaseIdentity = {
+  nativeVersion: string;
+  nativeBuild: string;
+  liveBundleId: string | null;
+  releaseKey: string;
+};
+
+export type WhatsNewAnnouncement = {
+  id: string;
+  releaseKeys: string[];
+  title: string;
+  items: string[];
+};
+
+export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
+  {
+    id: "release-1.11.0",
+    releaseKeys: ["native:1.11.0+25", "native:1.11.0+1"],
+    title: "What's new in 1.11.0",
+    items: [
+      "Use the new Controls modal for remote and keyboard input.",
+      "View and manage existing mappings from the Mappings page.",
+      "Monitor and start media scraper runs from Settings.",
+      "Use encrypted sessions with supported Core versions.",
+      "Reliability fixes for deep links, startup, media search, NFC, and purchases.",
+    ],
+  },
+];
+
+function getInjectedReleaseKey(): string | undefined {
+  const releaseKey = import.meta.env.VITE_RELEASE_KEY?.trim();
+  return releaseKey || undefined;
+}
+
+export async function resolveRuntimeReleaseIdentity(): Promise<RuntimeReleaseIdentity> {
+  let nativeVersion = import.meta.env.VITE_VERSION || "unknown";
+  let nativeBuild = "web";
+
+  try {
+    const info = await App.getInfo();
+    nativeVersion = info.version || nativeVersion;
+    nativeBuild = info.build || nativeBuild;
+  } catch (error) {
+    logger.warn("What's New: Failed to read app info", error);
+  }
+
+  let liveBundleId: string | null = null;
+
+  if (Capacitor.isNativePlatform() && isNativePluginAvailable("LiveUpdate")) {
+    try {
+      const currentBundle = await LiveUpdate.getCurrentBundle();
+      liveBundleId = currentBundle.bundleId;
+    } catch (error) {
+      logger.warn("What's New: Failed to read live update bundle", error);
+    }
+  }
+
+  const injectedReleaseKey = getInjectedReleaseKey();
+  const releaseKey =
+    injectedReleaseKey ??
+    (liveBundleId
+      ? `native:${nativeVersion}+${nativeBuild}:bundle:${liveBundleId}`
+      : `native:${nativeVersion}+${nativeBuild}`);
+
+  return {
+    nativeVersion,
+    nativeBuild,
+    liveBundleId,
+    releaseKey,
+  };
+}
+
+export function getWhatsNewAnnouncement(
+  releaseKey: string,
+): WhatsNewAnnouncement | undefined {
+  return WHATS_NEW_ANNOUNCEMENTS.find((announcement) =>
+    announcement.releaseKeys.includes(releaseKey),
+  );
+}

--- a/src/routes/create.mappings.tsx
+++ b/src/routes/create.mappings.tsx
@@ -95,7 +95,8 @@ function Mappings() {
     }
   };
 
-  const isEmpty = !mappings.isLoading && sortedMappings.length === 0;
+  const isInitialLoading = mappings.isLoading && !mappings.data;
+  const isEmpty = !isInitialLoading && sortedMappings.length === 0;
 
   return (
     <PageFrame
@@ -122,7 +123,7 @@ function Mappings() {
       }
     >
       <div className="flex flex-col gap-3">
-        {isEmpty ? (
+        {isInitialLoading ? null : isEmpty ? (
           <EmptyState
             title={t("create.mappings.list.empty")}
             description={t("create.mappings.list.emptyDescription")}

--- a/src/routes/create.nfc.tsx
+++ b/src/routes/create.nfc.tsx
@@ -16,7 +16,11 @@ import { usePreferencesStore } from "@/lib/preferencesStore";
 import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { BackIcon } from "@/lib/images";
-import { TabBar } from "@/components/wui/TabBar";
+import {
+  getTabBarPanelId,
+  getTabBarTabId,
+  TabBar,
+} from "@/components/wui/TabBar";
 import { ReadTab } from "@/components/nfc/ReadTab";
 import { ToolsTab } from "@/components/nfc/ToolsTab";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
@@ -79,6 +83,9 @@ function NfcUtils() {
     setWriteIntent(true);
   };
 
+  const activeTabId = getTabBarTabId(activeTab, "nfc-tab");
+  const activePanelId = getTabBarPanelId(activeTabId);
+
   return (
     <>
       <div {...swipeHandlers} className="flex h-full w-full flex-col">
@@ -99,8 +106,16 @@ function NfcUtils() {
               label={t("create.nfc.title")}
               role="tab"
               options={[
-                { value: "read", label: "Read" },
-                { value: "tools", label: "Tools" },
+                {
+                  value: "read",
+                  label: "Read",
+                  id: getTabBarTabId("read", "nfc-tab"),
+                },
+                {
+                  value: "tools",
+                  label: "Tools",
+                  id: getTabBarTabId("tools", "nfc-tab"),
+                },
               ]}
               value={activeTab}
               onChange={(value) => {
@@ -108,7 +123,12 @@ function NfcUtils() {
                 setActiveTab(value);
               }}
             />
-            <div className="flex-1 overflow-y-auto">
+            <div
+              id={activePanelId}
+              role="tabpanel"
+              aria-labelledby={activeTabId}
+              className="flex-1 overflow-y-auto"
+            >
               {activeTab === "read" ? (
                 <ReadTab result={nfcWriter.result} onScan={handleScan} />
               ) : (

--- a/src/routes/create.nfc.tsx
+++ b/src/routes/create.nfc.tsx
@@ -16,7 +16,7 @@ import { usePreferencesStore } from "@/lib/preferencesStore";
 import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { BackIcon } from "@/lib/images";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { TabBar } from "@/components/wui/TabBar";
 import { ReadTab } from "@/components/nfc/ReadTab";
 import { ToolsTab } from "@/components/nfc/ToolsTab";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
@@ -94,28 +94,31 @@ function NfcUtils() {
             <h1 className="text-foreground text-xl">{t("create.nfc.title")}</h1>
           }
         >
-          <Tabs
-            value={activeTab}
-            onValueChange={(value) => {
-              impact("light");
-              setActiveTab(value);
-            }}
-            className="flex h-full flex-col"
-          >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="read">Read</TabsTrigger>
-              <TabsTrigger value="tools">Tools</TabsTrigger>
-            </TabsList>
-            <TabsContent value="read" className="flex-1 overflow-y-auto">
-              <ReadTab result={nfcWriter.result} onScan={handleScan} />
-            </TabsContent>
-            <TabsContent value="tools" className="flex-1 overflow-y-auto">
-              <ToolsTab
-                onToolAction={handleToolAction}
-                isProcessing={nfcWriter.writing}
-              />
-            </TabsContent>
-          </Tabs>
+          <div className="flex h-full flex-col">
+            <TabBar
+              label={t("create.nfc.title")}
+              role="tab"
+              options={[
+                { value: "read", label: "Read" },
+                { value: "tools", label: "Tools" },
+              ]}
+              value={activeTab}
+              onChange={(value) => {
+                impact("light");
+                setActiveTab(value);
+              }}
+            />
+            <div className="flex-1 overflow-y-auto">
+              {activeTab === "read" ? (
+                <ReadTab result={nfcWriter.result} onScan={handleScan} />
+              ) : (
+                <ToolsTab
+                  onToolAction={handleToolAction}
+                  isProcessing={nfcWriter.writing}
+                />
+              )}
+            </div>
+          </div>
         </PageFrame>
       </div>
       <WriteModal isOpen={writeOpen} close={closeWriteModal} />

--- a/src/routes/create.search.tsx
+++ b/src/routes/create.search.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Preferences } from "@capacitor/preferences";
 import { logger } from "@/lib/logger";
-import { CoreAPI } from "@/lib/coreApi";
+import { CoreAPI, isRequestCancelledError } from "@/lib/coreApi";
 import { Search, type LoaderData } from "./-pages/Search";
 
 export const Route = createFileRoute("/create/search")({
@@ -10,7 +10,13 @@ export const Route = createFileRoute("/create/search")({
       await Promise.all([
         Preferences.get({ key: "searchSystem" }),
         Preferences.get({ key: "searchTags" }),
-        CoreAPI.systems(),
+        CoreAPI.systems().catch((error) => {
+          if (!isRequestCancelledError(error)) {
+            throw error;
+          }
+          logger.debug("Search systems loader request cancelled", error);
+          return { systems: [] };
+        }),
       ]);
 
     let savedTags: string[] = [];

--- a/src/test-utils/factories.ts
+++ b/src/test-utils/factories.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { InboxMessage, InboxSeverity, ReaderInfo } from "../lib/models";
+import type {
+  RuntimeReleaseIdentity,
+  WhatsNewAnnouncement,
+} from "../lib/whatsNew";
 
 export const mockReaderInfo = (
   overrides?: Partial<ReaderInfo>,
@@ -30,5 +34,25 @@ export const mockInboxMessage = (
     InboxSeverity.Error,
   ]),
   createdAt: faker.date.recent().toISOString(),
+  ...overrides,
+});
+
+export const buildRuntimeReleaseIdentity = (
+  overrides?: Partial<RuntimeReleaseIdentity>,
+): RuntimeReleaseIdentity => ({
+  nativeVersion: "1.0.1",
+  nativeBuild: "2",
+  liveBundleId: null,
+  releaseKey: "native:1.0.1+2",
+  ...overrides,
+});
+
+export const buildWhatsNewAnnouncement = (
+  overrides?: Partial<WhatsNewAnnouncement>,
+): WhatsNewAnnouncement => ({
+  id: "release-1.0.1",
+  releaseKeys: ["native:1.0.1+2"],
+  title: "What's new in test",
+  items: ["First test item", "Second test item"],
   ...overrides,
 });

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -684,6 +684,7 @@
       "selected": "{{name}} selected",
       "deselected": "{{name}} deselected",
       "allSystems": "All systems",
+      "categories": "System categories",
       "allCategories": "All",
       "noResults": "No systems found",
       "noResultsHint": "Try a shorter query or clear the search.",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -68,6 +68,10 @@
       "filesFound": "{{count}} items scanned",
       "nowPlayingHeading": "Now playing"
     },
+    "whatsNew": {
+      "title": "What's new",
+      "gotIt": "Got it"
+    },
     "write": {
       "noWriteMethodAvailable": "No NFC writing capability available",
       "nfcNotSupported": "NFC is not supported on this device"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ declare const __APP_BASE_PATH__: string;
 
 interface ImportMetaEnv {
   readonly VITE_VERSION: string;
+  readonly VITE_RELEASE_KEY?: string;
   readonly VITE_GOOGLE_STORE_API: string;
   readonly VITE_APPLE_STORE_API: string;
   readonly VITE_ROLLBAR_ACCESS_TOKEN: string;


### PR DESCRIPTION
Summary:
- add remote keyboard haptics and unify tab bar styling across controls, NFC, and system selector tabs
- add a one-time What's New dialog with native/live-update release keys and 1.11.0 copy
- avoid mappings initial-load flicker and prevent cancelled search systems requests from crashing the route

Verified:
- npm run lint
- npm run typecheck
- focused Vitest coverage for remote keyboard, mappings, What's New, NFC, SystemSelector, and CoreAPI cancellation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "What's new" feature to notify users of app releases and new features with dismissible announcements.
  * Enhanced haptic feedback in remote keyboard modal for directional controls, screenshots, and keyboard actions.

* **Bug Fixes**
  * Improved handling of cancelled network requests to prevent route failures.
  * Better distinction between initial data loading and empty states in mappings view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->