### PR TITLE
Prepare 1.11.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ docs/                focused guides for Capacitor, deployment, and testing
 
 - Keep the summary concise.
 - Do not include a separate test plan section.
-- For a store release, bump version fields in the three files documented in `docs/deployment.md`.
+- For a store release, follow the checklist in `docs/deployment.md` and bump all version fields in lockstep.
 
 ## Pointer docs
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "dev.wizzo.tapto"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 24
-        versionName "1.10.2"
+        versionCode 25
+        versionName "1.11.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,7 +39,7 @@ If a bad update crashes the app before `ready()` is called, the plugin automatic
 ### Pushing a Live Update
 
 ```bash
-VITE_RELEASE_KEY="live:1.10.2-ota.1" npm run live-update
+VITE_RELEASE_KEY="live:1.11.0-ota.1" npm run live-update
 ```
 
 This command:
@@ -80,6 +80,36 @@ Required for:
 - Capacitor version upgrades
 - Plugin configuration changes in `capacitor.config.ts`
 
+### Store Release Checklist
+
+1. Choose the release version and next store build number.
+2. Bump version files in lockstep:
+   - `package.json` (`version`)
+   - `package-lock.json` (top-level and root package `version`)
+   - `android/app/build.gradle` (`versionCode`, `versionName`)
+   - `ios/App/App.xcodeproj/project.pbxproj` (`MARKETING_VERSION`; `CURRENT_PROJECT_VERSION` if the iOS build number changes)
+3. Confirm `src/lib/whatsNew.ts` has announcement `releaseKeys` for the native version/build, e.g. `native:1.11.0+25` and `native:1.11.0+1`.
+4. Check About page credits in `src/routes/settings.about.tsx`:
+   - translation credits
+   - active Patreon CSV export names
+   - Patreon tier coloring (`#F1C40D` Supporter/Sponsor, `#E74C3C` Mega Supporter, `#E91E63` Ultra Supporter)
+5. Run validation:
+   - `npm run typecheck`
+   - `npm run format:check`
+   - `npm run lint`
+   - `npm run test -- --run`
+6. Optionally run `npm run build:web` for a web-only production build. Run `npm run build` only when ready for Capacitor sync/native file updates.
+7. Commit the release prep changes.
+8. Create and push the version tag:
+
+   ```bash
+   git tag v1.11.0
+   git push origin v1.11.0
+   ```
+
+9. Confirm GitHub release artifacts and Capawesome Cloud iOS/Android builds complete.
+10. Submit/release from App Store Connect and Google Play Console.
+
 ---
 
 ## Code Signing
@@ -101,8 +131,7 @@ The app uses Capawesome Cloud for building iOS and Android binaries.
 
 ### Configuration Files
 
-- `capawesome.config.json` - Build commands and app configuration
-- `capawesome.config.json` — Build commands (injects GitHub Packages auth via `NPM_TOKEN`)
+- `capawesome.config.json` — Build commands and app configuration. It injects GitHub Packages auth via `NPM_TOKEN`.
 
 ### Build Process
 
@@ -116,8 +145,8 @@ The app uses Capawesome Cloud for building iOS and Android binaries.
 
 ```bash
 # Create and push a version tag
-git tag v1.9.2
-git push origin v1.9.2
+git tag v1.11.0
+git push origin v1.11.0
 ```
 
 ### Required Secrets in Capawesome Cloud

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.2;
+				MARKETING_VERSION = 1.11.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -413,7 +413,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.2;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zaparoo-app",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zaparoo-app",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zaparoo-app",
   "private": true,
   "license": "Apache-2.0",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/routes/settings.about.tsx
+++ b/src/routes/settings.about.tsx
@@ -110,14 +110,13 @@ function About() {
             Tuxosaurus,{" "}
             <span style={{ color: "#E74C3C" }}>Retrosoft Studios</span>, Casey
             McGinty, <span style={{ color: "#E91E63" }}>Biddle</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>
-              Gentlemen&apos;s Pixel Club
-            </span>
-            , <span style={{ color: "#F1C40D" }}>VolJoe</span>,{" "}
             <span style={{ color: "#F1C40D" }}>Shijuro</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Tim Sullivan</span>,{" "}
             <span style={{ color: "#F1C40D" }}>TheJesusFish</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>disctoad</span>
+            <span style={{ color: "#F1C40D" }}>disctoad</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>Mark Dodsworth</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>ayoub</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>Michael Quinn</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>Lina Blue</span>
           </div>
 
           <Button


### PR DESCRIPTION
## Summary
- bump app, Android, and iOS release versions to 1.11.0 / build 25
- refresh About page Patreon credits from the current CSV export
- document the store release checklist for next time

Validation passed: npm run format:check, npm run typecheck, npm run lint, npm run test -- --run