### PR TITLE
Fix CI Node version and prepare 1.11.1 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
       - name: Authenticate NPM registry
         run: echo -e "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}\n@capawesome-team:registry=https://npm.pkg.github.com/" > ~/.npmrc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Authenticate NPM registry

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "dev.wizzo.tapto"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 25
-        versionName "1.11.0"
+        versionCode 26
+        versionName "1.11.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,7 +39,7 @@ If a bad update crashes the app before `ready()` is called, the plugin automatic
 ### Pushing a Live Update
 
 ```bash
-VITE_RELEASE_KEY="live:1.11.0-ota.1" npm run live-update
+VITE_RELEASE_KEY="live:1.11.1-ota.1" npm run live-update
 ```
 
 This command:
@@ -88,27 +88,28 @@ Required for:
    - `package-lock.json` (top-level and root package `version`)
    - `android/app/build.gradle` (`versionCode`, `versionName`)
    - `ios/App/App.xcodeproj/project.pbxproj` (`MARKETING_VERSION`; `CURRENT_PROJECT_VERSION` if the iOS build number changes)
-3. Confirm `src/lib/whatsNew.ts` has announcement `releaseKeys` for the native version/build, e.g. `native:1.11.0+25` and `native:1.11.0+1`.
-4. Check About page credits in `src/routes/settings.about.tsx`:
+3. Confirm `src/lib/whatsNew.ts` has announcement `releaseKeys` for the native version/build, e.g. `native:1.11.1+26` and `native:1.11.1+1`.
+4. After Capacitor upgrades, confirm GitHub Actions and Capawesome Cloud use a Node.js version supported by `@capacitor/cli`. Capacitor 8 requires Node 22+.
+5. Check About page credits in `src/routes/settings.about.tsx`:
    - translation credits
    - active Patreon CSV export names
    - Patreon tier coloring (`#F1C40D` Supporter/Sponsor, `#E74C3C` Mega Supporter, `#E91E63` Ultra Supporter)
-5. Run validation:
+6. Run validation:
    - `npm run typecheck`
    - `npm run format:check`
    - `npm run lint`
    - `npm run test -- --run`
-6. Optionally run `npm run build:web` for a web-only production build. Run `npm run build` only when ready for Capacitor sync/native file updates.
-7. Commit the release prep changes.
-8. Create and push the version tag:
+7. Optionally run `npm run build:web` for a web-only production build. Run `npm run build` only when ready for Capacitor sync/native file updates.
+8. Commit the release prep changes.
+9. Create and push the version tag:
 
    ```bash
-   git tag v1.11.0
-   git push origin v1.11.0
+   git tag v1.11.1
+   git push origin v1.11.1
    ```
 
-9. Confirm GitHub release artifacts and Capawesome Cloud iOS/Android builds complete.
-10. Submit/release from App Store Connect and Google Play Console.
+10. Confirm GitHub release artifacts and Capawesome Cloud iOS/Android builds complete.
+11. Submit/release from App Store Connect and Google Play Console.
 
 ---
 
@@ -145,9 +146,13 @@ The app uses Capawesome Cloud for building iOS and Android binaries.
 
 ```bash
 # Create and push a version tag
-git tag v1.11.0
-git push origin v1.11.0
+git tag v1.11.1
+git push origin v1.11.1
 ```
+
+### Build Runtime
+
+GitHub Actions use Node 22 because Capacitor 8's CLI requires Node 22 or newer. If Capawesome Cloud builds fail with a Node version error, set the `NODE_VERSION` environment variable to `22` in the selected Capawesome Cloud environment.
 
 ### Required Secrets in Capawesome Cloud
 

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.11.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -413,7 +413,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "zaparoo-app",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zaparoo-app",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
         "@capacitor-community/keep-awake": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "zaparoo-app",
   "private": true,
   "license": "Apache-2.0",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "dev:server": "cross-env NODE_ENV=development vite",

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -73,10 +73,10 @@ describe("whatsNew", () => {
     expect(identity.liveBundleId).toBe("bundle-2026-06-04");
   });
 
-  it("should find the first 1.11.0 announcement", () => {
-    const announcement = getWhatsNewAnnouncement("native:1.11.0+25");
+  it("should find the first 1.11.1 announcement", () => {
+    const announcement = getWhatsNewAnnouncement("native:1.11.1+26");
 
-    expect(announcement?.id).toBe("release-1.11.0");
+    expect(announcement?.id).toBe("release-1.11.1");
     expect(announcement?.items).toHaveLength(5);
   });
 });

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -20,9 +20,9 @@ export type WhatsNewAnnouncement = {
 
 export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
   {
-    id: "release-1.11.0",
-    releaseKeys: ["native:1.11.0+25", "native:1.11.0+1"],
-    title: "What's new in 1.11.0",
+    id: "release-1.11.1",
+    releaseKeys: ["native:1.11.1+26", "native:1.11.1+1"],
+    title: "What's new in 1.11.1",
     items: [
       "Use the new Controls modal for remote and keyboard input.",
       "View and manage existing mappings from the Mappings page.",


### PR DESCRIPTION
## Summary
- move GitHub Actions builds/tests to Node 22 for Capacitor 8
- add a Node >=22 engine requirement
- bump release surfaces and What's New from 1.11.0 to 1.11.1 / Android build 26
- document the Node runtime check for future releases

Validation passed: npm run format:check, npm run typecheck, npm run lint, npm run test -- --run

Note: v1.11.0 tag remains a failed/stale release; use v1.11.1 after this merges.