### PR TITLE
Add current media write choices

### DIFF
--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "../../../test-utils";
+import { render, screen } from "@/test-utils";
 import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 import type { SearchResultGame } from "@/lib/models";
 import { usePreferencesStore } from "@/lib/preferencesStore";

--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "../../../test-utils";
+import { MediaDetailsModal } from "@/components/MediaDetailsModal";
+import type { SearchResultGame } from "@/lib/models";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+
+vi.mock("@/hooks/useHaptics", () => ({
+  useHaptics: () => ({
+    impact: vi.fn(),
+    notification: vi.fn(),
+    vibrate: vi.fn(),
+  }),
+}));
+
+const mediaWithZapScript: SearchResultGame = {
+  system: {
+    id: "SNES",
+    name: "Super Nintendo",
+  },
+  name: "Super Mario World",
+  path: "/games/snes/Super Mario World.sfc",
+  zapScript: "@SNES/Super Mario World",
+  tags: [
+    { type: "genre", tag: "platformer" },
+    { type: "year", tag: "1990" },
+  ],
+};
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof MediaDetailsModal>> = {},
+) {
+  const props: React.ComponentProps<typeof MediaDetailsModal> = {
+    isOpen: true,
+    close: vi.fn(),
+    media: mediaWithZapScript,
+    onWrite: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<MediaDetailsModal {...props} />), props };
+}
+
+describe("MediaDetailsModal", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ showFilenames: false });
+  });
+
+  it("should show available media details", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("dialog", { name: "Super Mario World" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
+    expect(screen.getByLabelText("genre platformer")).toBeInTheDocument();
+    expect(screen.getByLabelText("year 1990")).toBeInTheDocument();
+    expect(
+      screen.getByText("/games/snes/Super Mario World.sfc"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("@SNES/Super Mario World")).toBeInTheDocument();
+  });
+
+  it("should default to ZapScript when available", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("radio", {
+        name: /create\.search\.zapscriptLabel/i,
+      }),
+    ).toBeChecked();
+  });
+
+  it("should default to path when ZapScript is unavailable", () => {
+    renderModal({
+      media: {
+        ...mediaWithZapScript,
+        zapScript: undefined,
+        tags: [],
+      },
+    });
+
+    expect(
+      screen.getByRole("radio", { name: /create\.search\.pathLabel/i }),
+    ).toBeChecked();
+    expect(
+      screen.queryByRole("radio", {
+        name: /create\.search\.zapscriptLabel/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("genre platformer")).not.toBeInTheDocument();
+  });
+
+  it("should pass selected path to every supplied action", async () => {
+    const user = userEvent.setup();
+    const onWrite = vi.fn();
+    const onCopy = vi.fn();
+    const onPreview = vi.fn();
+    renderModal({ onWrite, onCopy, onPreview });
+
+    await user.click(
+      screen.getByRole("radio", { name: /create\.search\.pathLabel/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.writeLabel/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.copyLabel/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.playLabel/i }),
+    );
+
+    expect(onWrite).toHaveBeenCalledWith(mediaWithZapScript.path);
+    expect(onCopy).toHaveBeenCalledWith(mediaWithZapScript.path);
+    expect(onPreview).toHaveBeenCalledWith(mediaWithZapScript.path);
+  });
+
+  it("should omit optional copy and preview actions", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("button", { name: /create\.search\.writeLabel/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create\.search\.copyLabel/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create\.search\.playLabel/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should honor filename display preference in title", () => {
+    usePreferencesStore.setState({ showFilenames: true });
+    renderModal({
+      media: {
+        ...mediaWithZapScript,
+        path: "/games/snes/Super Mario World (USA).sfc",
+      },
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Super Mario World (USA)" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/featureGates.test.ts
+++ b/src/__tests__/unit/featureGates.test.ts
@@ -69,4 +69,10 @@ describe("isCoreFeatureAvailable", () => {
     expect(isCoreFeatureAvailable("mediaBrowseAllSearch", "2.9.1")).toBe(false);
     expect(isCoreFeatureAvailable("mediaBrowseAllSearch", "2.10.0")).toBe(true);
   });
+
+  it("should gate active-media ZapScript behind Core 2.9.0", () => {
+    expect(FEATURE_GATES.activeMediaZapScript?.since).toBe("2.9.0");
+    expect(isCoreFeatureAvailable("activeMediaZapScript", "2.8.9")).toBe(false);
+    expect(isCoreFeatureAvailable("activeMediaZapScript", "2.9.0")).toBe(true);
+  });
 });

--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -214,7 +214,7 @@ describe("CoreAPI", () => {
     },
   );
 
-  it("should resolve media.active object and null responses", async () => {
+  it("should resolve media.active object, null, and cancellation responses", async () => {
     const activeMedia = {
       systemId: "SNES",
       systemName: "Super Nintendo",
@@ -248,6 +248,20 @@ describe("CoreAPI", () => {
     } as MessageEvent).catch(() => undefined);
 
     await expect(emptyPromise).resolves.toBeNull();
+
+    mockSend.mockClear();
+    const cancelledPromise = CoreAPI.mediaActive();
+    const cancelledRequest = JSON.parse(mockSend.mock.calls[0][0]);
+
+    CoreAPI.processReceived({
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        id: cancelledRequest.id,
+        result: { cancelled: true },
+      }),
+    } as MessageEvent).catch(() => undefined);
+
+    await expect(cancelledPromise).resolves.toBeNull();
   });
 
   it("should handle tokens.removed notification", async () => {

--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -214,6 +214,42 @@ describe("CoreAPI", () => {
     },
   );
 
+  it("should resolve media.active object and null responses", async () => {
+    const activeMedia = {
+      systemId: "SNES",
+      systemName: "Super Nintendo",
+      mediaName: "Super Mario World",
+      mediaPath: "/games/smw.sfc",
+      zapScript: "@SNES/Super Mario World",
+    };
+    const activePromise = CoreAPI.mediaActive();
+    const activeRequest = JSON.parse(mockSend.mock.calls[0][0]);
+
+    CoreAPI.processReceived({
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        id: activeRequest.id,
+        result: activeMedia,
+      }),
+    } as MessageEvent).catch(() => undefined);
+
+    await expect(activePromise).resolves.toEqual(activeMedia);
+
+    mockSend.mockClear();
+    const emptyPromise = CoreAPI.mediaActive();
+    const emptyRequest = JSON.parse(mockSend.mock.calls[0][0]);
+
+    CoreAPI.processReceived({
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        id: emptyRequest.id,
+        result: null,
+      }),
+    } as MessageEvent).catch(() => undefined);
+
+    await expect(emptyPromise).resolves.toBeNull();
+  });
+
   it("should handle tokens.removed notification", async () => {
     const tokensRemovedEvent = {
       data: JSON.stringify({

--- a/src/__tests__/unit/routes/create.index.test.tsx
+++ b/src/__tests__/unit/routes/create.index.test.tsx
@@ -1,17 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "../../../test-utils";
+import { render, screen, waitFor } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
+import type { PlayingResponse } from "@/lib/models";
 
 // Use vi.hoisted for all variables that need to be accessed in mock factories
-const { componentRef, mockState, mockNfcWriter } = vi.hoisted(() => ({
+const {
+  componentRef,
+  mockState,
+  mockNfcWriter,
+  mockMediaActive,
+  mockLoggerError,
+} = vi.hoisted(() => ({
   componentRef: { current: null as any },
   mockState: {
     connected: true,
     playing: {
+      systemId: "",
       mediaName: "",
       mediaPath: "",
       systemName: "",
-    },
+    } as PlayingResponse,
+    coreVersion: "2.9.0" as string | null,
+    coreVersionPending: false,
     nfcAvailable: true,
     platform: "ios" as string,
   },
@@ -25,6 +35,8 @@ const { componentRef, mockState, mockNfcWriter } = vi.hoisted(() => ({
     verifyError: null,
     getVerifyError: vi.fn(() => null),
   },
+  mockMediaActive: vi.fn(),
+  mockLoggerError: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -60,6 +72,8 @@ vi.mock("@/lib/store", async (importOriginal) => {
       selector({
         connected: mockState.connected,
         playing: mockState.playing,
+        coreVersion: mockState.coreVersion,
+        coreVersionPending: mockState.coreVersionPending,
         safeInsets: { top: "0px", bottom: "0px", left: "0px", right: "0px" },
       }),
   };
@@ -70,7 +84,21 @@ vi.mock("@/lib/preferencesStore", () => ({
   usePreferencesStore: (selector: any) =>
     selector({
       nfcAvailable: mockState.nfcAvailable,
+      preferRemoteWriter: false,
+      showFilenames: false,
     }),
+}));
+
+vi.mock("@/lib/coreApi", () => ({
+  CoreAPI: {
+    mediaActive: mockMediaActive,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: mockLoggerError,
+  },
 }));
 
 // Mock NFC writer
@@ -106,8 +134,13 @@ vi.mock("@/components/WriteModal", () => ({
     writeIntent: boolean,
     writer: { status: unknown; verifyError: unknown },
   ) => writeIntent && (writer.status === null || writer.verifyError !== null),
-  WriteModal: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="write-modal">Write Modal</div> : null,
+  WriteModal: ({ isOpen, close }: { isOpen: boolean; close: () => void }) =>
+    isOpen ? (
+      <div data-testid="write-modal">
+        Write Modal
+        <button onClick={close}>Close write modal</button>
+      </div>
+    ) : null,
 }));
 
 // Import the route module to trigger createFileRoute which captures the component
@@ -120,12 +153,23 @@ describe("Create Index Route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.connected = true;
-    mockState.playing = { mediaName: "", mediaPath: "", systemName: "" };
+    mockState.playing = {
+      systemId: "",
+      mediaName: "",
+      mediaPath: "",
+      systemName: "",
+    };
+    mockState.coreVersion = "2.9.0";
+    mockState.coreVersionPending = false;
     mockState.nfcAvailable = true;
     mockState.platform = "ios";
     mockNfcWriter.status = null;
     mockNfcWriter.write.mockClear();
     mockNfcWriter.end.mockClear();
+    mockMediaActive.mockImplementation(async () => ({
+      ...mockState.playing,
+      zapScript: "@SNES/Super Mario World",
+    }));
   });
 
   afterEach(() => {
@@ -135,6 +179,15 @@ describe("Create Index Route", () => {
   const renderComponent = () => {
     const Create = getCreate();
     return render(<Create />);
+  };
+
+  const setActiveMedia = () => {
+    mockState.playing = {
+      systemId: "SNES",
+      mediaName: "Super Mario World",
+      mediaPath: "/games/smw.sfc",
+      systemName: "Super Nintendo",
+    };
   };
 
   describe("rendering", () => {
@@ -181,9 +234,10 @@ describe("Create Index Route", () => {
   describe("current game display", () => {
     it("should show current game name when playing", () => {
       mockState.playing = {
+        systemId: "SNES",
         mediaName: "Super Mario World",
         mediaPath: "/games/smw.sfc",
-        systemName: "SNES",
+        systemName: "Super Nintendo",
       };
       renderComponent();
       // The translation with interpolation
@@ -191,7 +245,12 @@ describe("Create Index Route", () => {
     });
 
     it("should show fallback when no game playing", () => {
-      mockState.playing = { mediaName: "", mediaPath: "", systemName: "" };
+      mockState.playing = {
+        systemId: "",
+        mediaName: "",
+        mediaPath: "",
+        systemName: "",
+      };
       renderComponent();
       expect(
         screen.getByText("create.currentGameSubFallback"),
@@ -282,22 +341,75 @@ describe("Create Index Route", () => {
     });
   });
 
-  describe("current game card interaction", () => {
-    it("should call nfcWriter.write when current game card is clicked with valid media", async () => {
-      mockState.playing = {
-        mediaName: "Super Mario World",
-        mediaPath: "/games/smw.sfc",
-        systemName: "SNES",
-      };
-
+  describe("current media details", () => {
+    it("should open details without immediately writing", async () => {
+      setActiveMedia();
       const user = userEvent.setup();
       renderComponent();
 
-      // Card has role="button" when onClick is provided
-      const currentGameCard = screen.getByRole("button", {
-        name: /create\.currentGameHeading/i,
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(mockMediaActive).toHaveBeenCalledOnce();
+      expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
+      expect(screen.getByText("/games/smw.sfc")).toBeInTheDocument();
+      expect(screen.getByText("@SNES/Super Mario World")).toBeInTheDocument();
+      expect(mockNfcWriter.write).not.toHaveBeenCalled();
+    });
+
+    it("should default to ZapScript and write it", async () => {
+      setActiveMedia();
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      const zapScriptRadio = await screen.findByRole("radio", {
+        name: /create\.search\.zapscriptLabel/i,
       });
-      await user.click(currentGameCard);
+      expect(zapScriptRadio).toBeChecked();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.search\.writeLabel/i,
+        }),
+      );
+
+      expect(mockNfcWriter.write).toHaveBeenCalledWith(
+        "write",
+        "@SNES/Super Mario World",
+      );
+      expect(screen.getByTestId("write-modal")).toBeInTheDocument();
+    });
+
+    it("should write path when path is selected", async () => {
+      setActiveMedia();
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+      await user.click(
+        await screen.findByRole("radio", {
+          name: /create\.search\.pathLabel/i,
+        }),
+      );
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.search\.writeLabel/i,
+        }),
+      );
 
       expect(mockNfcWriter.write).toHaveBeenCalledWith(
         "write",
@@ -305,85 +417,165 @@ describe("Create Index Route", () => {
       );
     });
 
-    it("should open write modal when current game card is clicked", async () => {
-      mockState.playing = {
-        mediaName: "Super Mario World",
-        mediaPath: "/games/smw.sfc",
-        systemName: "SNES",
-      };
-      mockNfcWriter.status = null;
-
+    it("should only expose write action", async () => {
+      setActiveMedia();
       const user = userEvent.setup();
       renderComponent();
 
-      const currentGameCard = screen.getByRole("button", {
-        name: /create\.currentGameHeading/i,
-      });
-      await user.click(currentGameCard);
-
-      expect(screen.getByTestId("write-modal")).toBeInTheDocument();
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+      expect(
+        await screen.findByRole("button", {
+          name: /create\.search\.writeLabel/i,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", {
+          name: /create\.search\.copyLabel/i,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", {
+          name: /create\.search\.playLabel/i,
+        }),
+      ).not.toBeInTheDocument();
     });
 
-    it("should not call nfcWriter.write when current game has no media path", async () => {
-      mockState.playing = {
-        mediaName: "",
-        mediaPath: "",
-        systemName: "",
-      };
-
+    it("should show path-only details before Core 2.9.0", async () => {
+      setActiveMedia();
+      mockState.coreVersion = "2.8.9";
       const user = userEvent.setup();
       renderComponent();
 
-      // Card is disabled when no media path, but still has button role
-      const currentGameCard = screen.getByRole("button", {
-        name: /create\.currentGameHeading/i,
-      });
-      await user.click(currentGameCard);
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
 
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(mockMediaActive).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("radio", { name: /create\.search\.pathLabel/i }),
+      ).toBeChecked();
+      expect(
+        screen.queryByRole("radio", {
+          name: /create\.search\.zapscriptLabel/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show path-only details while Core version is pending", async () => {
+      setActiveMedia();
+      mockState.coreVersionPending = true;
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(mockMediaActive).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole("radio", {
+          name: /create\.search\.zapscriptLabel/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should fall back to cached path when enrichment fails", async () => {
+      setActiveMedia();
+      const error = new Error("media.active failed");
+      mockMediaActive.mockRejectedValueOnce(error);
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("/games/smw.sfc")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radio", {
+          name: /create\.search\.zapscriptLabel/i,
+        }),
+      ).not.toBeInTheDocument();
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        "Failed to fetch active media details:",
+        error,
+        {
+          category: "api",
+          action: "mediaActive",
+          severity: "warning",
+        },
+      );
+    });
+
+    it("should not open stale details when Core reports no active media", async () => {
+      setActiveMedia();
+      mockMediaActive.mockResolvedValueOnce(null);
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      await waitFor(() => expect(mockMediaActive).toHaveBeenCalledOnce());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(mockNfcWriter.write).not.toHaveBeenCalled();
+    });
+
+    it("should not open or write when current media has no path", async () => {
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+
+      expect(mockMediaActive).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(mockNfcWriter.write).not.toHaveBeenCalled();
     });
   });
 
   describe("write modal", () => {
-    it("should close write modal and call nfcWriter.end when dismissed", async () => {
-      mockState.playing = {
-        mediaName: "Super Mario World",
-        mediaPath: "/games/smw.sfc",
-        systemName: "SNES",
-      };
-      mockNfcWriter.status = null;
-
+    it("should end writer when dismissed", async () => {
+      setActiveMedia();
       const user = userEvent.setup();
       renderComponent();
 
-      // Open modal by clicking current game card
-      const currentGameCard = screen.getByRole("button", {
-        name: /create\.currentGameHeading/i,
-      });
-      await user.click(currentGameCard);
+      await user.click(
+        screen.getByRole("button", {
+          name: /create\.currentGameHeading/i,
+        }),
+      );
+      await user.click(
+        await screen.findByRole("button", {
+          name: /create\.search\.writeLabel/i,
+        }),
+      );
+      await user.click(
+        screen.getByRole("button", { name: "Close write modal" }),
+      );
 
-      expect(screen.getByTestId("write-modal")).toBeInTheDocument();
-
-      // The modal would be closed via closeWriteModal which sets writeIntent to false
-      // and calls nfcWriter.end(). Since our mock just shows/hides based on isOpen,
-      // we verify the nfcWriter.write was called
-      expect(mockNfcWriter.write).toHaveBeenCalled();
-    });
-
-    it("should hide write modal when nfcWriter.status becomes non-null", () => {
-      mockState.playing = {
-        mediaName: "Super Mario World",
-        mediaPath: "/games/smw.sfc",
-        systemName: "SNES",
-      };
-      // Status is non-null, so modal should not show even with writeIntent
-      mockNfcWriter.status = "success";
-
-      renderComponent();
-
-      // Modal derives visibility from writeIntent && status === null
-      // Since we haven't clicked anything yet, writeIntent is false
+      await waitFor(() => expect(mockNfcWriter.end).toHaveBeenCalledOnce());
       expect(screen.queryByTestId("write-modal")).not.toBeInTheDocument();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/unit/routes/create.index.test.tsx
+++ b/src/__tests__/unit/routes/create.index.test.tsx
@@ -10,6 +10,7 @@ const {
   mockNfcWriter,
   mockMediaActive,
   mockLoggerError,
+  mockShowRateLimitedErrorToast,
 } = vi.hoisted(() => ({
   componentRef: { current: null as any },
   mockState: {
@@ -37,6 +38,7 @@ const {
   },
   mockMediaActive: vi.fn(),
   mockLoggerError: vi.fn(),
+  mockShowRateLimitedErrorToast: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -99,6 +101,10 @@ vi.mock("@/lib/logger", () => ({
   logger: {
     error: mockLoggerError,
   },
+}));
+
+vi.mock("@/lib/toastUtils", () => ({
+  showRateLimitedErrorToast: mockShowRateLimitedErrorToast,
 }));
 
 // Mock NFC writer
@@ -533,6 +539,7 @@ describe("Create Index Route", () => {
       );
 
       await waitFor(() => expect(mockMediaActive).toHaveBeenCalledOnce());
+      expect(mockShowRateLimitedErrorToast).toHaveBeenCalledWith("error");
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(mockNfcWriter.write).not.toHaveBeenCalled();
     });

--- a/src/components/MediaDetailsModal.tsx
+++ b/src/components/MediaDetailsModal.tsx
@@ -112,13 +112,13 @@ export function MediaDetailsModal({
                   impact("light");
                   setWriteMode("path");
                 }}
-                className="sr-only"
+                className="peer sr-only"
               />
               <label
                 htmlFor={pathInputId}
                 aria-label={`${t("create.search.pathLabel")}: ${media.path}${writeMode === "path" ? `, ${t("selected")}` : ""}`}
                 className={classNames(
-                  "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
+                  "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-white/50",
                   {
                     "border-white/30 bg-white/10": writeMode === "path",
                     "border-white/10 bg-white/5 hover:bg-white/[0.07]":
@@ -169,13 +169,13 @@ export function MediaDetailsModal({
                     impact("light");
                     setWriteMode("zapScript");
                   }}
-                  className="sr-only"
+                  className="peer sr-only"
                 />
                 <label
                   htmlFor={zapScriptInputId}
                   aria-label={`${t("create.search.zapscriptLabel")}: ${media.zapScript}${writeMode === "zapScript" ? `, ${t("selected")}` : ""}`}
                   className={classNames(
-                    "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
+                    "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-white/50",
                     {
                       "border-white/30 bg-white/10": writeMode === "zapScript",
                       "border-white/10 bg-white/5 hover:bg-white/[0.07]":

--- a/src/components/MediaDetailsModal.tsx
+++ b/src/components/MediaDetailsModal.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useId, useState } from "react";
+import { useTranslation } from "react-i18next";
+import classNames from "classnames";
+import { Copy, FileCode, Folder, Tag } from "lucide-react";
+import { useHaptics } from "@/hooks/useHaptics";
+import { CreateIcon, DeviceIcon, PlayIcon } from "@/lib/images";
+import type { SearchResultGame } from "@/lib/models";
+import { filenameFromPath } from "@/lib/path";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+import { SlideModal } from "@/components/SlideModal";
+import { TagBadge } from "@/components/TagBadge";
+import { Button } from "@/components/wui/Button";
+
+type MediaDetailsAction = (value: string) => void | Promise<void>;
+
+export interface MediaDetailsModalProps {
+  isOpen: boolean;
+  close: () => void;
+  media: SearchResultGame | null;
+  onWrite: MediaDetailsAction;
+  onCopy?: MediaDetailsAction;
+  onPreview?: MediaDetailsAction;
+  previewDisabled?: boolean;
+}
+
+export function MediaDetailsModal({
+  isOpen,
+  close,
+  media,
+  onWrite,
+  onCopy,
+  onPreview,
+  previewDisabled = false,
+}: MediaDetailsModalProps) {
+  const { t } = useTranslation();
+  const { impact } = useHaptics();
+  const showFilenames = usePreferencesStore((state) => state.showFilenames);
+  const radioGroupName = useId();
+  const pathInputId = `${radioGroupName}-path`;
+  const zapScriptInputId = `${radioGroupName}-zapscript`;
+  const [writeMode, setWriteMode] = useState<"path" | "zapScript">("path");
+
+  useEffect(() => {
+    if (media) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize mode from newly selected external media.
+      setWriteMode(media.zapScript ? "zapScript" : "path");
+    }
+  }, [media]);
+
+  const selectedValue =
+    writeMode === "zapScript" && media?.zapScript
+      ? media.zapScript
+      : (media?.path ?? "");
+  const title = media
+    ? showFilenames
+      ? filenameFromPath(media.path) || media.name
+      : media.name
+    : "";
+
+  return (
+    <SlideModal isOpen={isOpen} close={close} title={title}>
+      {media && (
+        <div className="flex flex-col gap-4 pt-2">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+              <div className="flex items-center gap-2 sm:min-w-[100px]">
+                <DeviceIcon size="16" className="text-white/60" />
+                <span className="text-sm text-white/60">
+                  {t("create.search.systemLabel")}
+                </span>
+              </div>
+              <span className="flex-1 font-medium">{media.system.name}</span>
+            </div>
+            {media.tags.length > 0 && (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+                <div className="flex items-center gap-2 sm:min-w-[100px]">
+                  <Tag size={16} className="text-white/60" />
+                  <span className="text-sm text-white/60">
+                    {t("create.search.tagsLabel")}
+                  </span>
+                </div>
+                <div className="flex flex-1 flex-wrap gap-1.5">
+                  {media.tags.map((tag, index) => (
+                    <TagBadge
+                      key={`${tag.type}:${tag.tag}:${index}`}
+                      type={tag.type}
+                      tag={tag.tag}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <fieldset
+            className="space-y-2"
+            role="radiogroup"
+            aria-label={t("create.search.selectWriteValue")}
+          >
+            <legend className="sr-only">
+              {t("create.search.selectWriteValue")}
+            </legend>
+
+            <div className="flex items-center gap-2">
+              <input
+                type="radio"
+                id={pathInputId}
+                name={radioGroupName}
+                value="path"
+                checked={writeMode === "path"}
+                onChange={() => {
+                  impact("light");
+                  setWriteMode("path");
+                }}
+                className="sr-only"
+              />
+              <label
+                htmlFor={pathInputId}
+                aria-label={`${t("create.search.pathLabel")}: ${media.path}${writeMode === "path" ? `, ${t("selected")}` : ""}`}
+                className={classNames(
+                  "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
+                  {
+                    "border-white/30 bg-white/10": writeMode === "path",
+                    "border-white/10 bg-white/5 hover:bg-white/[0.07]":
+                      writeMode !== "path",
+                  },
+                )}
+              >
+                <div
+                  className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:gap-3"
+                  aria-hidden="true"
+                >
+                  <div className="flex items-center gap-2 sm:min-w-[100px]">
+                    <Folder size={16} className="flex-shrink-0 text-white/60" />
+                    <span className="text-sm text-white/60">
+                      {t("create.search.pathLabel")}
+                    </span>
+                  </div>
+                  <code className="flex-1 text-left font-mono text-sm break-all text-white/90">
+                    {media.path}
+                  </code>
+                </div>
+                <div
+                  aria-hidden="true"
+                  className={classNames(
+                    "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all",
+                    {
+                      "border-white bg-white": writeMode === "path",
+                      "border-white/30": writeMode !== "path",
+                    },
+                  )}
+                >
+                  {writeMode === "path" && (
+                    <div className="bg-background h-2 w-2 rounded-full" />
+                  )}
+                </div>
+              </label>
+            </div>
+
+            {media.zapScript && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  id={zapScriptInputId}
+                  name={radioGroupName}
+                  value="zapScript"
+                  checked={writeMode === "zapScript"}
+                  onChange={() => {
+                    impact("light");
+                    setWriteMode("zapScript");
+                  }}
+                  className="sr-only"
+                />
+                <label
+                  htmlFor={zapScriptInputId}
+                  aria-label={`${t("create.search.zapscriptLabel")}: ${media.zapScript}${writeMode === "zapScript" ? `, ${t("selected")}` : ""}`}
+                  className={classNames(
+                    "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
+                    {
+                      "border-white/30 bg-white/10": writeMode === "zapScript",
+                      "border-white/10 bg-white/5 hover:bg-white/[0.07]":
+                        writeMode !== "zapScript",
+                    },
+                  )}
+                >
+                  <div
+                    className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:gap-3"
+                    aria-hidden="true"
+                  >
+                    <div className="flex items-center gap-2 sm:min-w-[100px]">
+                      <FileCode
+                        size={16}
+                        className="flex-shrink-0 text-white/60"
+                      />
+                      <span className="text-sm text-white/60">
+                        {t("create.search.zapscriptLabel")}
+                      </span>
+                    </div>
+                    <code className="flex-1 text-left font-mono text-sm break-words text-white/90">
+                      {media.zapScript}
+                    </code>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    className={classNames(
+                      "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all",
+                      {
+                        "border-white bg-white": writeMode === "zapScript",
+                        "border-white/30": writeMode !== "zapScript",
+                      },
+                    )}
+                  >
+                    {writeMode === "zapScript" && (
+                      <div className="bg-background h-2 w-2 rounded-full" />
+                    )}
+                  </div>
+                </label>
+              </div>
+            )}
+          </fieldset>
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button
+              label={t("create.search.writeLabel")}
+              icon={<CreateIcon size="20" />}
+              intent="primary"
+              onClick={() => void onWrite(selectedValue)}
+              className="w-full"
+            />
+            {(onCopy || onPreview) && (
+              <div className="flex flex-row gap-2">
+                {onCopy && (
+                  <Button
+                    label={t("create.search.copyLabel")}
+                    icon={<Copy size="20" />}
+                    variant="outline"
+                    onClick={() => void onCopy(selectedValue)}
+                    className="flex-1"
+                  />
+                )}
+                {onPreview && (
+                  <Button
+                    label={t("create.search.playLabel")}
+                    icon={<PlayIcon size="20" />}
+                    variant="outline"
+                    disabled={previewDisabled}
+                    onClick={() => void onPreview(selectedValue)}
+                    className="flex-1"
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </SlideModal>
+  );
+}

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -25,6 +25,7 @@ import {
   PlaytimeLimitsConfig,
   PlaytimeLimitsUpdateRequest,
   PlaytimeStatus,
+  PlayingResponse,
   ReadersResponse,
   ScrapersResponse,
   ScrapingStatusNotification,
@@ -1493,11 +1494,11 @@ class CoreApi {
     });
   }
 
-  mediaActive(): Promise<MediaResponse["active"]> {
-    return new Promise<MediaResponse["active"]>((resolve, reject) => {
+  mediaActive(): Promise<PlayingResponse | null> {
+    return new Promise<PlayingResponse | null>((resolve, reject) => {
       this.call(Method.MediaActive)
         .then((result) => {
-          resolve(result as MediaResponse["active"]);
+          resolve(result as PlayingResponse | null);
         })
         .catch((error) => {
           logMediaApiFailure(

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -1498,6 +1498,10 @@ class CoreApi {
     return new Promise<PlayingResponse | null>((resolve, reject) => {
       this.call(Method.MediaActive)
         .then((result) => {
+          if (isCancelled(result)) {
+            resolve(null);
+            return;
+          }
           resolve(result as PlayingResponse | null);
         })
         .catch((error) => {

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -41,6 +41,11 @@ export const FEATURE_GATES: Record<string, FeatureGate> = {
     marquee: false,
     labelKey: "features.mediaBrowseAllSearch",
   },
+  activeMediaZapScript: {
+    since: "2.9.0",
+    marquee: false,
+    labelKey: "features.activeMediaZapScript",
+  },
   remoteInput: {
     since: "2.10.0",
     marquee: true,

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -254,6 +254,7 @@ export interface PlayingResponse {
   systemName: string;
   mediaName: string;
   mediaPath: string;
+  zapScript?: string;
   started?: string;
   launcherId?: string;
 }

--- a/src/routes/-pages/Search.tsx
+++ b/src/routes/-pages/Search.tsx
@@ -3,31 +3,19 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Preferences } from "@capacitor/preferences";
 import { Capacitor } from "@capacitor/core";
-import classNames from "classnames";
-import { Folder, FileCode, Tag, Copy } from "lucide-react";
 import { VirtualSearchResults } from "@/components/VirtualSearchResults.tsx";
 import { BackToTop } from "@/components/BackToTop.tsx";
-import { TagBadge } from "@/components/TagBadge.tsx";
+import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 import { logger } from "@/lib/logger";
 import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 import { CoreAPI, isExpectedMediaDatabaseError } from "@/lib/coreApi";
-import {
-  BackIcon,
-  CreateIcon,
-  PlayIcon,
-  SearchIcon,
-  HistoryIcon,
-  DeviceIcon,
-} from "@/lib/images";
+import { BackIcon, SearchIcon, HistoryIcon } from "@/lib/images";
 import { useNfcWriter, WriteAction, WriteMethod } from "@/lib/writeNfcHook";
 import { SearchResultGame, SystemsResponse } from "@/lib/models";
 import { usePreferencesStore } from "@/lib/preferencesStore";
-import { filenameFromPath } from "@/lib/path";
-import { SlideModal } from "@/components/SlideModal";
 import { Button } from "@/components/wui/Button";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { useSmartSwipe } from "@/hooks/useSmartSwipe";
-import { useHaptics } from "@/hooks/useHaptics";
 import { DEFAULT_GAMES_INDEX, useStatusStore } from "@/lib/store";
 import { TextInput } from "@/components/wui/TextInput";
 import { WriteModal } from "@/components/WriteModal";
@@ -54,7 +42,6 @@ export function Search() {
   const { t } = useTranslation();
   usePageHeadingFocus(t("create.search.title"));
   const loaderData = route.useLoaderData();
-  const { impact } = useHaptics();
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
   const setGamesIndex = useStatusStore((state) => state.setGamesIndex);
   const connected = useStatusStore((state) => state.connected);
@@ -62,7 +49,6 @@ export function Search() {
   const coreVersionPending = useStatusStore(
     (state) => state.coreVersionPending,
   );
-  const showFilenames = usePreferencesStore((s) => s.showFilenames);
 
   const [querySystem, setQuerySystem] = useState(loaderData.systemQuery);
   const [queryTags, setQueryTags] = useState<string[]>(loaderData.tagQuery);
@@ -145,7 +131,6 @@ export function Search() {
   const [selectedResult, setSelectedResult] = useState<SearchResultGame | null>(
     null,
   );
-  const [writeMode, setWriteMode] = useState<"path" | "zapScript">("zapScript");
 
   const preferRemoteWriter = usePreferencesStore(
     (state) => state.preferRemoteWriter,
@@ -198,14 +183,6 @@ export function Search() {
       cancelled = true;
     };
   }, [setGamesIndex]);
-
-  // Set default write mode when selected result changes
-  useEffect(() => {
-    if (selectedResult) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize mode from the newly selected external result.
-      setWriteMode(selectedResult.zapScript ? "zapScript" : "path");
-    }
-  }, [selectedResult]);
 
   useEffect(() => {
     if (!mediaTagsAvailable) {
@@ -430,284 +407,74 @@ export function Search() {
         />
       </PageFrame>
 
-      <SlideModal
+      <MediaDetailsModal
         isOpen={selectedResult !== null && !writeOpen}
         close={() => setSelectedResult(null)}
-        title={
-          selectedResult
-            ? showFilenames
-              ? filenameFromPath(selectedResult.path) || selectedResult.name
-              : selectedResult.name
-            : "Game Details"
-        }
-      >
-        <div className="flex flex-col gap-4 pt-2">
-          {/* Primary Info */}
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
-              <div className="flex items-center gap-2 sm:min-w-[100px]">
-                <DeviceIcon size="16" className="text-white/60" />
-                <span className="text-sm text-white/60">
-                  {t("create.search.systemLabel")}
-                </span>
-              </div>
-              <span className="flex-1 font-medium">
-                {selectedResult?.system.name}
-              </span>
-            </div>
-            {selectedResult?.tags && selectedResult.tags.length > 0 && (
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
-                <div className="flex items-center gap-2 sm:min-w-[100px]">
-                  <Tag size={16} className="text-white/60" />
-                  <span className="text-sm text-white/60">
-                    {t("create.search.tagsLabel")}
-                  </span>
-                </div>
-                <div className="flex flex-1 flex-wrap gap-1.5">
-                  {selectedResult.tags.map((tag, tagIndex) => (
-                    <TagBadge key={tagIndex} type={tag.type} tag={tag.tag} />
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Technical Details - Selectable Options */}
-          <fieldset
-            className="space-y-2"
-            role="radiogroup"
-            aria-label={t("create.search.selectWriteValue")}
-          >
-            <legend className="sr-only">
-              {t("create.search.selectWriteValue")}
-            </legend>
-
-            {/* Path Option */}
-            <div className="flex items-center gap-2">
-              <input
-                type="radio"
-                id="write-mode-path"
-                name="write-mode"
-                value="path"
-                checked={writeMode === "path"}
-                onChange={() => {
-                  impact("light");
-                  setWriteMode("path");
-                }}
-                className="sr-only"
-              />
-              <label
-                htmlFor="write-mode-path"
-                aria-label={`${t("create.search.pathLabel")}: ${selectedResult?.path || ""}${writeMode === "path" ? `, ${t("selected")}` : ""}`}
-                className={classNames(
-                  "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
-                  {
-                    "border-white/30 bg-white/10": writeMode === "path",
-                    "border-white/10 bg-white/5 hover:bg-white/[0.07]":
-                      writeMode !== "path",
-                  },
-                )}
-              >
-                <div
-                  className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:gap-3"
-                  aria-hidden="true"
-                >
-                  <div className="flex items-center gap-2 sm:min-w-[100px]">
-                    <Folder size={16} className="flex-shrink-0 text-white/60" />
-                    <span className="text-sm text-white/60">
-                      {t("create.search.pathLabel")}
-                    </span>
-                  </div>
-                  <code className="flex-1 text-left font-mono text-sm break-all text-white/90">
-                    {selectedResult?.path}
-                  </code>
-                </div>
-                <div
-                  aria-hidden="true"
-                  className={classNames(
-                    "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all",
-                    {
-                      "border-white bg-white": writeMode === "path",
-                      "border-white/30": writeMode !== "path",
-                    },
-                  )}
-                >
-                  {writeMode === "path" && (
-                    <div className="bg-background h-2 w-2 rounded-full" />
-                  )}
-                </div>
-              </label>
-            </div>
-
-            {/* ZapScript Option */}
-            {selectedResult?.zapScript && (
-              <div className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  id="write-mode-zapscript"
-                  name="write-mode"
-                  value="zapScript"
-                  checked={writeMode === "zapScript"}
-                  onChange={() => {
-                    impact("light");
-                    setWriteMode("zapScript");
-                  }}
-                  className="sr-only"
-                />
-                <label
-                  htmlFor="write-mode-zapscript"
-                  aria-label={`${t("create.search.zapscriptLabel")}: ${selectedResult.zapScript}${writeMode === "zapScript" ? `, ${t("selected")}` : ""}`}
-                  className={classNames(
-                    "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200",
-                    {
-                      "border-white/30 bg-white/10": writeMode === "zapScript",
-                      "border-white/10 bg-white/5 hover:bg-white/[0.07]":
-                        writeMode !== "zapScript",
-                    },
-                  )}
-                >
-                  <div
-                    className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-start sm:gap-3"
-                    aria-hidden="true"
-                  >
-                    <div className="flex items-center gap-2 sm:min-w-[100px]">
-                      <FileCode
-                        size={16}
-                        className="flex-shrink-0 text-white/60"
-                      />
-                      <span className="text-sm text-white/60">
-                        {t("create.search.zapscriptLabel")}
-                      </span>
-                    </div>
-                    <code className="flex-1 text-left font-mono text-sm break-words text-white/90">
-                      {selectedResult.zapScript}
-                    </code>
-                  </div>
-                  <div
-                    aria-hidden="true"
-                    className={classNames(
-                      "flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 transition-all",
-                      {
-                        "border-white bg-white": writeMode === "zapScript",
-                        "border-white/30": writeMode !== "zapScript",
-                      },
-                    )}
-                  >
-                    {writeMode === "zapScript" && (
-                      <div className="bg-background h-2 w-2 rounded-full" />
-                    )}
-                  </div>
-                </label>
-              </div>
-            )}
-          </fieldset>
-
-          {/* Actions */}
-          <div className="flex flex-col gap-2 pt-2">
-            <Button
-              label={t("create.search.writeLabel")}
-              icon={<CreateIcon size="20" />}
-              intent="primary"
-              disabled={!selectedResult}
-              onClick={async () => {
-                if (!selectedResult) return;
-                const textToWrite =
-                  writeMode === "zapScript" && selectedResult.zapScript
-                    ? selectedResult.zapScript
-                    : selectedResult.path;
-                try {
-                  // Open the modal first: write() resolves when the whole
-                  // operation completes, not when it starts
-                  setWriteOpen(true);
-                  await nfcWriter.write(WriteAction.Write, textToWrite);
-                } catch (err) {
-                  logger.error("NFC write failed", err, {
-                    category: "nfc",
-                    action: "writeFromSearch",
-                    severity: "error",
-                  });
-                  showRateLimitedErrorToast(
-                    t("error", {
-                      msg: err instanceof Error ? err.message : String(err),
-                    }),
-                  );
-                }
-              }}
-              className="w-full"
-            />
-            <div className="flex flex-row gap-2">
-              <Button
-                label={t("create.search.copyLabel")}
-                icon={<Copy size="20" />}
-                variant="outline"
-                disabled={!selectedResult}
-                onClick={async () => {
-                  if (!selectedResult) return;
-                  const textToCopy =
-                    writeMode === "zapScript" && selectedResult.zapScript
-                      ? selectedResult.zapScript
-                      : selectedResult.path;
-                  try {
-                    await navigator.clipboard.writeText(textToCopy);
-                  } catch (webErr) {
-                    if (Capacitor.isNativePlatform()) {
-                      try {
-                        const { Clipboard } =
-                          await import("@capacitor/clipboard");
-                        await Clipboard.write({ string: textToCopy });
-                      } catch (nativeErr) {
-                        logger.error("Failed to copy to clipboard", nativeErr, {
-                          category: "share",
-                          action: "copyResult",
-                          severity: "error",
-                        });
-                      }
-                    } else {
-                      logger.error("Failed to copy to clipboard", webErr, {
-                        category: "share",
-                        action: "copyResult",
-                        severity: "error",
-                      });
-                    }
-                  }
-                }}
-                className="flex-1"
-              />
-              <Button
-                label={t("create.search.playLabel")}
-                icon={<PlayIcon size="20" />}
-                variant="outline"
-                disabled={!selectedResult || !connected}
-                onClick={async () => {
-                  if (!selectedResult) return;
-                  const textToRun =
-                    writeMode === "zapScript" && selectedResult.zapScript
-                      ? selectedResult.zapScript
-                      : selectedResult.path;
-                  try {
-                    await CoreAPI.run({
-                      uid: "",
-                      text: textToRun,
-                    });
-                  } catch (e) {
-                    logger.error("CoreAPI.run failed", e, {
-                      category: "api",
-                      action: "run",
-                      severity: "error",
-                    });
-                    showRateLimitedErrorToast(
-                      t("error", {
-                        msg: e instanceof Error ? e.message : String(e),
-                      }),
-                    );
-                  }
-                }}
-                className="flex-1"
-              />
-            </div>
-          </div>
-        </div>
-      </SlideModal>
+        media={selectedResult}
+        onWrite={async (textToWrite) => {
+          try {
+            // Open the modal first: write() resolves when the whole operation
+            // completes, not when it starts.
+            setWriteOpen(true);
+            await nfcWriter.write(WriteAction.Write, textToWrite);
+          } catch (err) {
+            logger.error("NFC write failed", err, {
+              category: "nfc",
+              action: "writeFromSearch",
+              severity: "error",
+            });
+            showRateLimitedErrorToast(
+              t("error", {
+                msg: err instanceof Error ? err.message : String(err),
+              }),
+            );
+          }
+        }}
+        onCopy={async (textToCopy) => {
+          try {
+            await navigator.clipboard.writeText(textToCopy);
+          } catch (webErr) {
+            if (Capacitor.isNativePlatform()) {
+              try {
+                const { Clipboard } = await import("@capacitor/clipboard");
+                await Clipboard.write({ string: textToCopy });
+              } catch (nativeErr) {
+                logger.error("Failed to copy to clipboard", nativeErr, {
+                  category: "share",
+                  action: "copyResult",
+                  severity: "error",
+                });
+              }
+            } else {
+              logger.error("Failed to copy to clipboard", webErr, {
+                category: "share",
+                action: "copyResult",
+                severity: "error",
+              });
+            }
+          }
+        }}
+        onPreview={async (textToRun) => {
+          try {
+            await CoreAPI.run({
+              uid: "",
+              text: textToRun,
+            });
+          } catch (e) {
+            logger.error("CoreAPI.run failed", e, {
+              category: "api",
+              action: "run",
+              severity: "error",
+            });
+            showRateLimitedErrorToast(
+              t("error", {
+                msg: e instanceof Error ? e.message : String(e),
+              }),
+            );
+          }
+        }}
+        previewDisabled={!connected}
+      />
       <BackToTop
         scrollContainerRef={scrollContainerRef}
         threshold={200}

--- a/src/routes/create.index.tsx
+++ b/src/routes/create.index.tsx
@@ -10,6 +10,7 @@ import { useNfcWriter, WriteAction, WriteMethod } from "@/lib/writeNfcHook";
 import { CoreAPI } from "@/lib/coreApi";
 import { isCoreFeatureAvailable } from "@/lib/featureGates";
 import { logger } from "@/lib/logger";
+import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 import type { PlayingResponse, SearchResultGame } from "@/lib/models";
 import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 import { Card } from "@/components/wui/Card";
@@ -76,6 +77,9 @@ export function Create() {
       try {
         const response = await CoreAPI.mediaActive();
         if (!response || response.mediaPath === "") {
+          showRateLimitedErrorToast(
+            t("error", { msg: t("create.currentGameUnavailable") }),
+          );
           setCurrentMediaDetails(null);
           return;
         }

--- a/src/routes/create.index.tsx
+++ b/src/routes/create.index.tsx
@@ -7,7 +7,11 @@ import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { NextIcon, PlayIcon, SearchIcon, TextIcon } from "@/lib/images";
 import { useStatusStore } from "@/lib/store";
 import { useNfcWriter, WriteAction, WriteMethod } from "@/lib/writeNfcHook";
+import { CoreAPI } from "@/lib/coreApi";
+import { isCoreFeatureAvailable } from "@/lib/featureGates";
 import { logger } from "@/lib/logger";
+import type { PlayingResponse, SearchResultGame } from "@/lib/models";
+import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 import { Card } from "@/components/wui/Card";
 import { Button } from "@/components/wui/Button";
 import { isWriteModalOpen, WriteModal } from "@/components/WriteModal";
@@ -18,22 +22,76 @@ export const Route = createFileRoute("/create/")({
   component: Create,
 });
 
+function toMediaDetails(
+  playing: PlayingResponse,
+  includeZapScript: boolean,
+): SearchResultGame {
+  return {
+    system: {
+      id: playing.systemId,
+      name: playing.systemName || playing.systemId,
+    },
+    name: playing.mediaName,
+    path: playing.mediaPath,
+    zapScript: includeZapScript ? playing.zapScript : undefined,
+    tags: [],
+  };
+}
+
 export function Create() {
   const { t } = useTranslation();
   const headingRef = usePageHeadingFocus<HTMLHeadingElement>(t("create.title"));
   const connected = useStatusStore((state) => state.connected);
   const playing = useStatusStore((state) => state.playing);
+  const coreVersion = useStatusStore((state) => state.coreVersion);
+  const coreVersionPending = useStatusStore(
+    (state) => state.coreVersionPending,
+  );
   const nfcAvailable = usePreferencesStore((state) => state.nfcAvailable);
   const preferRemoteWriter = usePreferencesStore(
     (state) => state.preferRemoteWriter,
   );
   const nfcWriter = useNfcWriter(WriteMethod.Auto, preferRemoteWriter);
+  const [currentMediaDetails, setCurrentMediaDetails] =
+    useState<SearchResultGame | null>(null);
   // Track user intent to open modal; actual visibility derived from NFC status
   const [writeIntent, setWriteIntent] = useState(false);
   const writeOpen = isWriteModalOpen(writeIntent, nfcWriter);
+  const activeMediaZapScriptAvailable =
+    connected &&
+    !coreVersionPending &&
+    isCoreFeatureAvailable("activeMediaZapScript", coreVersion);
   const closeWriteModal = async () => {
     setWriteIntent(false);
     await nfcWriter.end();
+  };
+
+  const openCurrentMediaDetails = async () => {
+    if (!connected || playing.mediaPath === "") {
+      return;
+    }
+
+    let activeMedia = playing;
+    if (activeMediaZapScriptAvailable) {
+      try {
+        const response = await CoreAPI.mediaActive();
+        if (!response || response.mediaPath === "") {
+          setCurrentMediaDetails(null);
+          return;
+        }
+        activeMedia = response;
+      } catch (error) {
+        logger.error("Failed to fetch active media details:", error, {
+          category: "api",
+          action: "mediaActive",
+          severity: "warning",
+        });
+      }
+    }
+
+    setCurrentMediaDetails(
+      toMediaDetails(activeMedia, activeMediaZapScriptAvailable),
+    );
   };
 
   return (
@@ -75,20 +133,7 @@ export function Create() {
           <Card
             className="cursor-pointer"
             disabled={!connected || playing.mediaPath === ""}
-            onClick={() => {
-              if (playing.mediaPath !== "") {
-                nfcWriter
-                  .write(WriteAction.Write, playing.mediaPath)
-                  .catch((e) => {
-                    logger.error("NFC write failed:", e, {
-                      category: "nfc",
-                      action: "writeCurrentMedia",
-                      severity: "error",
-                    });
-                  });
-                setWriteIntent(true);
-              }
-            }}
+            onClick={() => void openCurrentMediaDetails()}
           >
             <div className="flex flex-row items-center gap-3">
               <Button
@@ -177,6 +222,21 @@ export function Create() {
           </Link>
         </div>
       </PageFrame>
+      <MediaDetailsModal
+        isOpen={currentMediaDetails !== null && !writeOpen}
+        close={() => setCurrentMediaDetails(null)}
+        media={currentMediaDetails}
+        onWrite={(value) => {
+          setWriteIntent(true);
+          return nfcWriter.write(WriteAction.Write, value).catch((error) => {
+            logger.error("NFC write failed:", error, {
+              category: "nfc",
+              action: "writeCurrentMedia",
+              severity: "error",
+            });
+          });
+        }}
+      />
       <WriteModal
         isOpen={writeOpen}
         close={closeWriteModal}

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -773,6 +773,7 @@
       "mediaCleanOrphans": "Clean missing media",
       "mediaTags": "Media tags",
       "mediaBrowseAllSearch": "Browse all media search",
+      "activeMediaZapScript": "Current media ZapScript",
       "remoteInput": "Remote input"
     },
     "inbox": {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -139,6 +139,7 @@
       "currentGameHeading": "Current media",
       "currentGameSub": "Write '{{game}}' to a tag",
       "currentGameSubFallback": "Write 'Now Playing' to a tag",
+      "currentGameUnavailable": "Current media is no longer active",
       "customHeading": "Custom ZapScript",
       "customSub": "Write ZapScript to an NFC tag",
       "nfcHeading": "NFC utilities",


### PR DESCRIPTION
## Summary
- show current media in shared details sheet before writing
- offer Path or ZapScript on Core 2.9.0+, with path-only fallback on older Core
- reuse media details UI across Create and search while preserving search actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a media details modal to view system, tags, path, and (when available) ZapScript.
  - Users can choose between writing a media path or ZapScript, with copy/preview actions when supported.
  - The Search and Create flows now use the new modal for current-media details and NFC writing.

- **Improvements**
  - Modal title reflects the filename display preference.
  - ZapScript option appears only when the Core version gate (2.9.0+) is available; pending/ineligible states hide ZapScript.

- **Bug Fixes**
  - Media “active” requests now correctly treat cancelled responses as no active media.

- **Tests**
  - Added/expanded unit tests for the modal, feature gate behavior, Core API handling, and Create-route flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->