### PR TITLE
Fix media path insertion from ZapScript editor

### DIFF
--- a/src/__tests__/unit/components/MediaSearchModal.test.tsx
+++ b/src/__tests__/unit/components/MediaSearchModal.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MediaSearchModal } from "@/components/MediaSearchModal";
+import type { SearchResultGame } from "@/lib/models";
 
 const mockStoreState = {
   connected: true,
@@ -95,9 +96,7 @@ vi.mock("@/components/VirtualSearchResults", () => ({
   }: {
     query: string;
     hasSearched: boolean;
-    setSelectedResult: (
-      result: { path: string; zapScript?: string } | null,
-    ) => void;
+    setSelectedResult: (result: SearchResultGame | null) => void;
   }) => {
     if (!hasSearched) {
       return (
@@ -115,8 +114,11 @@ vi.mock("@/components/VirtualSearchResults", () => ({
           data-testid="result-0"
           onClick={() =>
             setSelectedResult({
+              system: { id: "snes", name: "Super Nintendo" },
+              name: "Super Mario World",
               path: "/games/mario.sfc",
               zapScript: "**launch:/games/mario.sfc",
+              tags: [],
             })
           }
         >
@@ -292,7 +294,7 @@ describe("MediaSearchModal", () => {
     expect(await screen.findByRole("combobox")).toBeDisabled();
   });
 
-  it("should call onSelect and close when result is selected", async () => {
+  it("should default to ZapScript and insert it after confirmation", async () => {
     render(
       <MediaSearchModal
         isOpen={true}
@@ -301,30 +303,64 @@ describe("MediaSearchModal", () => {
       />,
     );
 
-    // Enter search query and trigger search
     const searchInput = screen.getByPlaceholderText(
       "create.search.gameInputPlaceholder",
     );
     fireEvent.change(searchInput, { target: { value: "mario" } });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /create\.search\.searchButton/i,
+      }),
+    );
+    fireEvent.click(await screen.findByTestId("result-0"));
 
-    const searchButton = screen.getByRole("button", {
-      name: /create\.search\.searchButton/i,
+    const zapScriptRadio = await screen.findByRole("radio", {
+      name: /create\.search\.zapscriptLabel/i,
     });
-    fireEvent.click(searchButton);
+    expect(zapScriptRadio).toBeChecked();
+    expect(mockOnSelect).not.toHaveBeenCalled();
 
-    // Wait for search results
-    await waitFor(() => {
-      expect(screen.getByTestId("result-0")).toBeInTheDocument();
-    });
-
-    // Click on a result
-    fireEvent.click(screen.getByTestId("result-0"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "create.custom.insert" }),
+    );
 
     expect(mockOnSelect).toHaveBeenCalledWith("**launch:/games/mario.sfc");
-    expect(mockClose).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalledOnce();
   });
 
-  it("should not render modal content when closed (aria-hidden)", () => {
+  it("should allow selecting and inserting the media path", async () => {
+    render(
+      <MediaSearchModal
+        isOpen={true}
+        close={mockClose}
+        onSelect={mockOnSelect}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText(
+      "create.search.gameInputPlaceholder",
+    );
+    fireEvent.change(searchInput, { target: { value: "mario" } });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /create\.search\.searchButton/i,
+      }),
+    );
+    fireEvent.click(await screen.findByTestId("result-0"));
+    fireEvent.click(
+      await screen.findByRole("radio", {
+        name: /create\.search\.pathLabel/i,
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "create.custom.insert" }),
+    );
+
+    expect(mockOnSelect).toHaveBeenCalledWith("/games/mario.sfc");
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("should hide all modal content when closed", () => {
     render(
       <MediaSearchModal
         isOpen={false}
@@ -333,9 +369,11 @@ describe("MediaSearchModal", () => {
       />,
     );
 
-    // Modal should have aria-hidden when closed
-    const modal = screen.getByRole("dialog", { hidden: true });
-    expect(modal).toHaveAttribute("aria-hidden", "true");
+    const modals = screen.getAllByRole("dialog", { hidden: true });
+    expect(modals).toHaveLength(2);
+    expect(
+      modals.every((modal) => modal.getAttribute("aria-hidden") === "true"),
+    ).toBe(true);
   });
 
   it("should trigger search on Enter key press", async () => {

--- a/src/__tests__/unit/components/MediaSearchModal.test.tsx
+++ b/src/__tests__/unit/components/MediaSearchModal.test.tsx
@@ -295,6 +295,7 @@ describe("MediaSearchModal", () => {
   });
 
   it("should default to ZapScript and insert it after confirmation", async () => {
+    const user = userEvent.setup();
     render(
       <MediaSearchModal
         isOpen={true}
@@ -303,16 +304,18 @@ describe("MediaSearchModal", () => {
       />,
     );
 
-    const searchInput = screen.getByPlaceholderText(
-      "create.search.gameInputPlaceholder",
-    );
-    fireEvent.change(searchInput, { target: { value: "mario" } });
-    fireEvent.click(
+    const searchInput = screen.getByRole("searchbox", {
+      name: "create.search.gameInput",
+    });
+    await user.type(searchInput, "mario");
+    await user.click(
       screen.getByRole("button", {
         name: /create\.search\.searchButton/i,
       }),
     );
-    fireEvent.click(await screen.findByTestId("result-0"));
+    await user.click(
+      await screen.findByRole("button", { name: "Super Mario World" }),
+    );
 
     const zapScriptRadio = await screen.findByRole("radio", {
       name: /create\.search\.zapscriptLabel/i,
@@ -320,7 +323,7 @@ describe("MediaSearchModal", () => {
     expect(zapScriptRadio).toBeChecked();
     expect(mockOnSelect).not.toHaveBeenCalled();
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: "create.custom.insert" }),
     );
 
@@ -329,6 +332,7 @@ describe("MediaSearchModal", () => {
   });
 
   it("should allow selecting and inserting the media path", async () => {
+    const user = userEvent.setup();
     render(
       <MediaSearchModal
         isOpen={true}
@@ -337,22 +341,24 @@ describe("MediaSearchModal", () => {
       />,
     );
 
-    const searchInput = screen.getByPlaceholderText(
-      "create.search.gameInputPlaceholder",
-    );
-    fireEvent.change(searchInput, { target: { value: "mario" } });
-    fireEvent.click(
+    const searchInput = screen.getByRole("searchbox", {
+      name: "create.search.gameInput",
+    });
+    await user.type(searchInput, "mario");
+    await user.click(
       screen.getByRole("button", {
         name: /create\.search\.searchButton/i,
       }),
     );
-    fireEvent.click(await screen.findByTestId("result-0"));
-    fireEvent.click(
+    await user.click(
+      await screen.findByRole("button", { name: "Super Mario World" }),
+    );
+    await user.click(
       await screen.findByRole("radio", {
         name: /create\.search\.pathLabel/i,
       }),
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: "create.custom.insert" }),
     );
 

--- a/src/components/MediaDetailsModal.tsx
+++ b/src/components/MediaDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { type ReactElement, useEffect, useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { Copy, FileCode, Folder, Tag } from "lucide-react";
@@ -21,6 +21,8 @@ export interface MediaDetailsModalProps {
   onCopy?: MediaDetailsAction;
   onPreview?: MediaDetailsAction;
   previewDisabled?: boolean;
+  primaryActionLabel?: string;
+  primaryActionIcon?: ReactElement;
 }
 
 export function MediaDetailsModal({
@@ -31,6 +33,8 @@ export function MediaDetailsModal({
   onCopy,
   onPreview,
   previewDisabled = false,
+  primaryActionLabel,
+  primaryActionIcon,
 }: MediaDetailsModalProps) {
   const { t } = useTranslation();
   const { impact } = useHaptics();
@@ -221,8 +225,8 @@ export function MediaDetailsModal({
 
           <div className="flex flex-col gap-2 pt-2">
             <Button
-              label={t("create.search.writeLabel")}
-              icon={<CreateIcon size="20" />}
+              label={primaryActionLabel ?? t("create.search.writeLabel")}
+              icon={primaryActionIcon ?? <CreateIcon size="20" />}
               intent="primary"
               onClick={() => void onWrite(selectedValue)}
               className="w-full"

--- a/src/components/MediaSearchModal.tsx
+++ b/src/components/MediaSearchModal.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useRef, useState } from "react";
 import { Preferences } from "@capacitor/preferences";
+import { PlusIcon } from "lucide-react";
 import { useStatusStore } from "@/lib/store.ts";
 import { logger } from "@/lib/logger";
 import { SlideModal } from "@/components/SlideModal.tsx";
@@ -11,11 +12,12 @@ import { SearchResultGame } from "@/lib/models.ts";
 import { BackToTop } from "@/components/BackToTop.tsx";
 import { SearchIcon } from "@/lib/images.tsx";
 import { SimpleSystemSelect } from "@/components/SimpleSystemSelect.tsx";
+import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 
 export function MediaSearchModal(props: {
   isOpen: boolean;
   close: () => void;
-  onSelect: (path: string) => void;
+  onSelect: (value: string) => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -69,12 +71,6 @@ export function MediaSearchModal(props: {
 
   // Handle result selection - called by VirtualSearchResults when a result is clicked
   const handleResultSelect = (result: SearchResultGame | null) => {
-    if (result) {
-      // Use zapScript if available, otherwise fall back to path
-      const valueToInsert = result.zapScript || result.path;
-      onSelect(valueToInsert);
-      close();
-    }
     setSelectedResult(result);
   };
 
@@ -83,7 +79,7 @@ export function MediaSearchModal(props: {
   return (
     <>
       <SlideModal
-        isOpen={props.isOpen}
+        isOpen={props.isOpen && selectedResult === null}
         close={props.close}
         title={t("create.search.title")}
         scrollRef={scrollContainerRef}
@@ -155,6 +151,18 @@ export function MediaSearchModal(props: {
           bottomOffset="1rem"
         />
       </SlideModal>
+      <MediaDetailsModal
+        isOpen={props.isOpen && selectedResult !== null}
+        close={() => setSelectedResult(null)}
+        media={selectedResult}
+        onWrite={(value) => {
+          onSelect(value);
+          setSelectedResult(null);
+          close();
+        }}
+        primaryActionLabel={t("create.custom.insert")}
+        primaryActionIcon={<PlusIcon size="20" />}
+      />
     </>
   );
 }

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -204,6 +204,7 @@
         "insertCommandStart": "Insert command start",
         "insertCommandSeparator": "Insert command separator",
         "insertMedia": "Insert media path",
+        "insert": "Insert",
         "insertSystem": "Insert system",
         "insertCommand": "Insert command",
         "runZapScript": "Run ZapScript"


### PR DESCRIPTION
## Summary
- show media details after selecting a search result in ZapScript editor
- let users choose Path or ZapScript before insertion
- reuse shared details modal with an Insert action

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-step media insertion flow: select a result, configure the insert option, then confirm.
  * Added an “Insert” action label to the editor interface.
  * Enhanced media detail dialogs with optional customization for the primary action label and icon.
* **Bug Fixes**
  * Updated selection behavior so insert confirmation triggers the callback, while selection alone does not.
  * Improved modal visibility and accessibility expectations when transitioning between dialogs.
* **Tests**
  * Updated `MediaSearchModal` unit tests to match the typed search result model and the new user-flow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->