### PR TITLE
Render disambiguating tags in search results

### DIFF
--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -25,6 +25,7 @@ const mediaWithZapScript: SearchResultGame = {
     { type: "genre", tag: "platformer" },
     { type: "year", tag: "1990" },
   ],
+  disambiguatingTags: [{ type: "year", tag: "1990" }],
 };
 
 function renderModal(

--- a/src/__tests__/unit/components/TagList.test.tsx
+++ b/src/__tests__/unit/components/TagList.test.tsx
@@ -43,6 +43,19 @@ describe("TagList", () => {
     expect(tagElements[3]).toHaveAccessibleName("player 1p");
   });
 
+  it("should preserve server tag order when requested", () => {
+    const tags: TagInfo[] = [
+      { type: "unfinished", tag: "wip" },
+      { type: "region", tag: "usa" },
+    ];
+
+    render(<TagList tags={tags} preserveOrder />);
+
+    const tagElements = screen.getAllByLabelText(/^(unfinished|region)/);
+    expect(tagElements[0]).toHaveAccessibleName("unfinished wip");
+    expect(tagElements[1]).toHaveAccessibleName("region usa");
+  });
+
   it("should limit visible tags based on maxDesktop", () => {
     const tags: TagInfo[] = [
       { type: "genre", tag: "action" },

--- a/src/__tests__/unit/components/VirtualSearchResults.test.tsx
+++ b/src/__tests__/unit/components/VirtualSearchResults.test.tsx
@@ -18,6 +18,8 @@ vi.mock("react-i18next", () => ({
 // Flexible store mock - state can be modified per test
 const mockStoreState = {
   connected: true,
+  coreVersion: "2.15.0",
+  coreVersionPending: false,
   gamesIndex: { exists: true, indexing: false },
 };
 
@@ -89,6 +91,8 @@ describe("VirtualSearchResults", () => {
     mockGetVirtualItems.mockReturnValue([]);
     // Reset to default state
     mockStoreState.connected = true;
+    mockStoreState.coreVersion = "2.15.0";
+    mockStoreState.coreVersionPending = false;
     mockStoreState.gamesIndex = { exists: true, indexing: false };
     mockPreferencesState.showFilenames = false;
   });
@@ -343,6 +347,110 @@ describe("VirtualSearchResults", () => {
       await waitFor(() => {
         expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
       });
+    });
+
+    it("should show only ordered disambiguating tags on supported Core", async () => {
+      const results = [
+        {
+          ...createMockResults(1)[0]!,
+          name: "Variant Game",
+          path: "/games/Variant Game (USA).rom",
+          tags: [
+            { type: "genre", tag: "action" },
+            { type: "region", tag: "usa" },
+          ],
+          disambiguatingTags: [
+            { type: "unfinished", tag: "wip" },
+            { type: "region", tag: "usa" },
+          ],
+        },
+        {
+          ...createMockResults(1, 1)[0]!,
+          name: "Variant Game",
+          path: "/games/Variant Game (Europe).rom",
+          tags: [
+            { type: "genre", tag: "action" },
+            { type: "region", tag: "eu" },
+          ],
+          disambiguatingTags: [{ type: "region", tag: "eu" }],
+        },
+      ];
+      vi.spyOn(CoreAPI, "mediaSearch").mockResolvedValueOnce({
+        results,
+        total: 2,
+        pagination: { hasNextPage: false, pageSize: 100, nextCursor: null },
+      });
+      mockGetVirtualItems.mockReturnValue([
+        { index: 0, key: 0, start: 0, size: 100 },
+        { index: 1, key: 1, start: 100, size: 100 },
+      ]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("unfinished wip")).toBeInTheDocument();
+      });
+      const firstResultTags = screen
+        .getByTestId("result-0")
+        .querySelectorAll('[aria-label^="unfinished"], [aria-label^="region"]');
+      expect(firstResultTags[0]).toHaveAccessibleName("unfinished wip");
+      expect(firstResultTags[1]).toHaveAccessibleName("region usa");
+      expect(screen.queryByLabelText("genre action")).not.toBeInTheDocument();
+      expect(screen.getAllByText("Variant Game")).toHaveLength(2);
+      expect(screen.queryByText("Variant Game (USA)")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Variant Game (Europe)"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should fall back to full tags before Core 2.15.0", async () => {
+      mockStoreState.coreVersion = "2.14.1";
+      vi.spyOn(CoreAPI, "mediaSearch").mockResolvedValueOnce({
+        results: [
+          {
+            ...createMockResults(1)[0]!,
+            tags: [{ type: "genre", tag: "action" }],
+            disambiguatingTags: [{ type: "region", tag: "usa" }],
+          },
+        ],
+        total: 1,
+        pagination: { hasNextPage: false, pageSize: 100, nextCursor: null },
+      });
+      mockGetVirtualItems.mockReturnValue([
+        { index: 0, key: 0, start: 0, size: 100 },
+      ]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("genre action")).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText("region usa")).not.toBeInTheDocument();
+    });
+
+    it("should still honor the filename display preference", async () => {
+      mockPreferencesState.showFilenames = true;
+      vi.spyOn(CoreAPI, "mediaSearch").mockResolvedValueOnce({
+        results: [
+          {
+            ...createMockResults(1)[0]!,
+            name: "Variant Game",
+            path: "/games/Variant Game (USA).rom",
+          },
+        ],
+        total: 1,
+        pagination: { hasNextPage: false, pageSize: 100, nextCursor: null },
+      });
+      mockGetVirtualItems.mockReturnValue([
+        { index: 0, key: 0, start: 0, size: 100 },
+      ]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText("Variant Game (USA)")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Variant Game")).not.toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/unit/featureGates.test.ts
+++ b/src/__tests__/unit/featureGates.test.ts
@@ -70,6 +70,16 @@ describe("isCoreFeatureAvailable", () => {
     expect(isCoreFeatureAvailable("mediaBrowseAllSearch", "2.10.0")).toBe(true);
   });
 
+  it("should gate media disambiguating tags behind Core 2.15.0", () => {
+    expect(FEATURE_GATES.mediaDisambiguatingTags?.since).toBe("2.15.0");
+    expect(isCoreFeatureAvailable("mediaDisambiguatingTags", "2.14.1")).toBe(
+      false,
+    );
+    expect(isCoreFeatureAvailable("mediaDisambiguatingTags", "2.15.0")).toBe(
+      true,
+    );
+  });
+
   it("should gate active-media ZapScript behind Core 2.9.0", () => {
     expect(FEATURE_GATES.activeMediaZapScript?.since).toBe("2.9.0");
     expect(isCoreFeatureAvailable("activeMediaZapScript", "2.8.9")).toBe(false);

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
 import { SearchResultGame, SearchResultsResponse } from "@/lib/models.ts";
@@ -11,6 +10,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner.tsx";
 import { Button } from "@/components/wui/Button.tsx";
 import { EmptyState } from "@/components/wui/EmptyState.tsx";
 import { TagList } from "@/components/TagList.tsx";
+import { isCoreFeatureAvailable } from "@/lib/featureGates";
 
 export function SearchResults(props: {
   loading: boolean;
@@ -25,23 +25,14 @@ export function SearchResults(props: {
   onClearFilters?: () => void;
 }) {
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
+  const disambiguatingTagsAvailable = useStatusStore(
+    (state) =>
+      state.connected &&
+      !state.coreVersionPending &&
+      isCoreFeatureAvailable("mediaDisambiguatingTags", state.coreVersion),
+  );
   const showFilenames = usePreferencesStore((s) => s.showFilenames);
   const { t } = useTranslation();
-
-  // Build a set of names that appear more than once in results (duplicates)
-  const results = props.resp?.results;
-  const duplicateNames = useMemo(() => {
-    if (!results) return new Set<string>();
-    const nameCounts = new Map<string, number>();
-    for (const item of results) {
-      nameCounts.set(item.name, (nameCounts.get(item.name) ?? 0) + 1);
-    }
-    const duplicates = new Set<string>();
-    for (const [name, count] of nameCounts) {
-      if (count > 1) duplicates.add(name);
-    }
-    return duplicates;
-  }, [results]);
 
   // Screen reader announcement for search results
   const getAriaLiveMessage = () => {
@@ -169,18 +160,13 @@ export function SearchResults(props: {
         {/* Results list */}
         <div>
           {props.resp.results.map((game, i) => {
-            const isDuplicate = duplicateNames.has(game.name);
             // Primary display: filename if global pref enabled, otherwise clean name
             const displayName = showFilenames
               ? filenameFromPath(game.path) || game.name
               : game.name;
-            // For duplicates (when not using global filename pref), show filename as subtitle
-            const filename = filenameFromPath(game.path);
-            const showFilenameSubtitle =
-              isDuplicate &&
-              !showFilenames &&
-              filename &&
-              filename !== game.name;
+            const displayTags = disambiguatingTagsAvailable
+              ? (game.disambiguatingTags ?? [])
+              : game.tags;
 
             const handleGameSelect = () => {
               if (
@@ -226,11 +212,13 @@ export function SearchResults(props: {
               >
                 <div className="flex flex-col">
                   <p className="font-semibold">{displayName}</p>
-                  {showFilenameSubtitle && (
-                    <p className="text-sm text-white/60">{filename}</p>
-                  )}
                   <p className="text-sm">{game.system.name}</p>
-                  <TagList tags={game.tags} maxMobile={2} maxDesktop={4} />
+                  <TagList
+                    tags={displayTags}
+                    maxMobile={2}
+                    maxDesktop={4}
+                    preserveOrder={disambiguatingTagsAvailable}
+                  />
                 </div>
                 <div>
                   <NextIcon size="20" />

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -10,7 +10,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner.tsx";
 import { Button } from "@/components/wui/Button.tsx";
 import { EmptyState } from "@/components/wui/EmptyState.tsx";
 import { TagList } from "@/components/TagList.tsx";
-import { isCoreFeatureAvailable } from "@/lib/featureGates";
+import { useCoreFeature } from "@/hooks/useCoreFeature";
 
 export function SearchResults(props: {
   loading: boolean;
@@ -25,11 +25,9 @@ export function SearchResults(props: {
   onClearFilters?: () => void;
 }) {
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
-  const disambiguatingTagsAvailable = useStatusStore(
-    (state) =>
-      state.connected &&
-      !state.coreVersionPending &&
-      isCoreFeatureAvailable("mediaDisambiguatingTags", state.coreVersion),
+  const { available: disambiguatingTagsAvailable } = useCoreFeature(
+    "mediaDisambiguatingTags",
+    { requireKnownSupport: true },
   );
   const showFilenames = usePreferencesStore((s) => s.showFilenames);
   const { t } = useTranslation();

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -6,21 +6,29 @@ interface TagListProps {
   tags: TagInfo[];
   maxMobile?: number;
   maxDesktop?: number;
+  preserveOrder?: boolean;
 }
 
-export function TagList({ tags, maxMobile = 2, maxDesktop = 4 }: TagListProps) {
+export function TagList({
+  tags,
+  maxMobile = 2,
+  maxDesktop = 4,
+  preserveOrder = false,
+}: TagListProps) {
   if (!tags || tags.length === 0) return null;
 
-  const sortedTags = tags.sort((a, b) => {
-    // Prioritize region and lang tags first
-    const aPriority = a.type === "region" || a.type === "lang" ? 0 : 1;
-    const bPriority = b.type === "region" || b.type === "lang" ? 0 : 1;
-    return aPriority - bPriority;
-  });
+  const displayTags = preserveOrder
+    ? tags
+    : [...tags].sort((a, b) => {
+        // Prioritize region and lang tags first
+        const aPriority = a.type === "region" || a.type === "lang" ? 0 : 1;
+        const bPriority = b.type === "region" || b.type === "lang" ? 0 : 1;
+        return aPriority - bPriority;
+      });
 
   return (
     <div className="mt-1 flex flex-wrap gap-1.5">
-      {sortedTags.slice(0, maxDesktop).map((tag, tagIndex) => (
+      {displayTags.slice(0, maxDesktop).map((tag, tagIndex) => (
         <span
           key={tagIndex}
           className={tagIndex >= maxMobile ? "hidden sm:inline-block" : ""}

--- a/src/components/VirtualSearchResults.tsx
+++ b/src/components/VirtualSearchResults.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/wui/Button.tsx";
 import { EmptyState } from "@/components/wui/EmptyState.tsx";
 import { useVirtualInfiniteSearch } from "@/hooks/useVirtualInfiniteSearch";
 import { TagList } from "@/components/TagList.tsx";
-import { isCoreFeatureAvailable } from "@/lib/featureGates";
+import { useCoreFeature } from "@/hooks/useCoreFeature";
 
 export interface VirtualSearchResultsProps {
   query: string;
@@ -45,11 +45,9 @@ export function VirtualSearchResults({
   scrollContainerRef,
 }: VirtualSearchResultsProps) {
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
-  const disambiguatingTagsAvailable = useStatusStore(
-    (state) =>
-      state.connected &&
-      !state.coreVersionPending &&
-      isCoreFeatureAvailable("mediaDisambiguatingTags", state.coreVersion),
+  const { available: disambiguatingTagsAvailable } = useCoreFeature(
+    "mediaDisambiguatingTags",
+    { requireKnownSupport: true },
   );
   const { t } = useTranslation();
 

--- a/src/components/VirtualSearchResults.tsx
+++ b/src/components/VirtualSearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, RefObject } from "react";
+import React, { useCallback, useEffect, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Link } from "@tanstack/react-router";
@@ -13,6 +13,7 @@ import { Button } from "@/components/wui/Button.tsx";
 import { EmptyState } from "@/components/wui/EmptyState.tsx";
 import { useVirtualInfiniteSearch } from "@/hooks/useVirtualInfiniteSearch";
 import { TagList } from "@/components/TagList.tsx";
+import { isCoreFeatureAvailable } from "@/lib/featureGates";
 
 export interface VirtualSearchResultsProps {
   query: string;
@@ -44,6 +45,12 @@ export function VirtualSearchResults({
   scrollContainerRef,
 }: VirtualSearchResultsProps) {
   const gamesIndex = useStatusStore((state) => state.gamesIndex);
+  const disambiguatingTagsAvailable = useStatusStore(
+    (state) =>
+      state.connected &&
+      !state.coreVersionPending &&
+      isCoreFeatureAvailable("mediaDisambiguatingTags", state.coreVersion),
+  );
   const { t } = useTranslation();
 
   const {
@@ -71,20 +78,7 @@ export function VirtualSearchResults({
     }
   }, [isLoading, hasSearched, onSearchComplete]);
 
-  // Build a set of names that appear more than once in results (duplicates)
-  const duplicateNames = useMemo(() => {
-    const nameCounts = new Map<string, number>();
-    for (const item of allItems) {
-      nameCounts.set(item.name, (nameCounts.get(item.name) ?? 0) + 1);
-    }
-    const duplicates = new Set<string>();
-    for (const [name, count] of nameCounts) {
-      if (count > 1) duplicates.add(name);
-    }
-    return duplicates;
-  }, [allItems]);
-
-  // Calculate estimated item height based on whether tags are shown and duplicates
+  // Calculate estimated item height based on whether displayed tags are shown.
   const estimateSize = useCallback(
     (index: number) => {
       if (index >= allItems.length) return 60; // Loading item
@@ -93,13 +87,12 @@ export function VirtualSearchResults({
       // Base height: 32px (pt-3 pb-5) + content + 1px border = total (gap handled by virtualizer)
       // Without tags: ~60px content + 32px padding + 1px border = 93px
       // With tags: ~80px content + 32px padding + 1px border = 113px
-      const hasTags = item?.tags && item.tags.length > 0;
-      const isDuplicate = item ? duplicateNames.has(item.name) : false;
-      // Add ~18px for subtitle line when duplicate
-      const baseHeight = hasTags ? 113 : 93;
-      return isDuplicate ? baseHeight + 18 : baseHeight;
+      const displayTags = disambiguatingTagsAvailable
+        ? item?.disambiguatingTags
+        : item?.tags;
+      return displayTags && displayTags.length > 0 ? 113 : 93;
     },
-    [allItems, duplicateNames],
+    [allItems, disambiguatingTagsAvailable],
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -292,7 +285,7 @@ export function VirtualSearchResults({
               ) : game ? (
                 <SearchResultItem
                   game={game}
-                  isDuplicate={duplicateNames.has(game.name)}
+                  disambiguatingTagsAvailable={disambiguatingTagsAvailable}
                   selectedResult={selectedResult}
                   setSelectedResult={setSelectedResult}
                   isLast={virtualItem.index === totalCount - 1}
@@ -309,7 +302,7 @@ export function VirtualSearchResults({
 
 interface SearchResultItemProps {
   game: SearchResultGame;
-  isDuplicate: boolean;
+  disambiguatingTagsAvailable: boolean;
   selectedResult: SearchResultGame | null;
   setSelectedResult: (game: SearchResultGame | null) => void;
   isLast: boolean;
@@ -318,7 +311,7 @@ interface SearchResultItemProps {
 
 const SearchResultItem = React.memo(function SearchResultItem({
   game,
-  isDuplicate,
+  disambiguatingTagsAvailable,
   selectedResult,
   setSelectedResult,
   isLast,
@@ -331,10 +324,9 @@ const SearchResultItem = React.memo(function SearchResultItem({
     ? filenameFromPath(game.path) || game.name
     : game.name;
 
-  // For duplicates (when not using global filename pref), show filename as subtitle
-  const filename = filenameFromPath(game.path);
-  const showFilenameSubtitle =
-    isDuplicate && !showFilenames && filename && filename !== game.name;
+  const displayTags = disambiguatingTagsAvailable
+    ? (game.disambiguatingTags ?? [])
+    : game.tags;
 
   const handleGameSelect = () => {
     if (selectedResult && selectedResult.path === game.path) {
@@ -371,11 +363,13 @@ const SearchResultItem = React.memo(function SearchResultItem({
     >
       <div className="flex flex-col">
         <p className="font-semibold">{displayName}</p>
-        {showFilenameSubtitle && (
-          <p className="text-sm text-white/60">{filename}</p>
-        )}
         <p className="text-sm">{game.system.name}</p>
-        <TagList tags={game.tags} maxMobile={2} maxDesktop={4} />
+        <TagList
+          tags={displayTags}
+          maxMobile={2}
+          maxDesktop={4}
+          preserveOrder={disambiguatingTagsAvailable}
+        />
       </div>
       <div>
         <NextIcon size="20" />

--- a/src/hooks/useCoreFeature.ts
+++ b/src/hooks/useCoreFeature.ts
@@ -12,7 +12,15 @@ interface CoreFeatureResult {
   marquee: boolean;
 }
 
-export function useCoreFeature(id: FeatureId): CoreFeatureResult {
+interface CoreFeatureOptions {
+  requireKnownSupport?: boolean;
+}
+
+export function useCoreFeature(
+  id: FeatureId,
+  options: CoreFeatureOptions = {},
+): CoreFeatureResult {
+  const connected = useStatusStore((state) => state.connected);
   const coreVersion = useStatusStore((state) => state.coreVersion);
   const coreVersionPending = useStatusStore(
     (state) => state.coreVersionPending,
@@ -21,8 +29,12 @@ export function useCoreFeature(id: FeatureId): CoreFeatureResult {
   // When version is unknown (null or still loading), treat as available so we
   // don't falsely show features as "outdated" — consistent with CoreOutdatedNotice.
   const versionUnknown = coreVersion === null || coreVersionPending;
+  const knownAvailable =
+    connected && !coreVersionPending && isCoreFeatureAvailable(id, coreVersion);
   return {
-    available: versionUnknown || isCoreFeatureAvailable(id, coreVersion),
+    available: options.requireKnownSupport
+      ? knownAvailable
+      : versionUnknown || isCoreFeatureAvailable(id, coreVersion),
     requiredVersion: gate?.since ?? "",
     currentVersion: coreVersion,
     marquee: gate?.marquee ?? false,

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -41,6 +41,11 @@ export const FEATURE_GATES: Record<string, FeatureGate> = {
     marquee: false,
     labelKey: "features.mediaBrowseAllSearch",
   },
+  mediaDisambiguatingTags: {
+    since: "2.15.0",
+    marquee: false,
+    labelKey: "features.mediaDisambiguatingTags",
+  },
   activeMediaZapScript: {
     since: "2.9.0",
     marquee: false,

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -112,6 +112,7 @@ export interface SearchResultGame {
   path: string;
   zapScript?: string;
   tags: TagInfo[];
+  disambiguatingTags?: TagInfo[];
 }
 
 export interface Pagination {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -775,6 +775,7 @@
       "mediaCleanOrphans": "Clean missing media",
       "mediaTags": "Media tags",
       "mediaBrowseAllSearch": "Browse all media search",
+      "mediaDisambiguatingTags": "Search result disambiguation",
       "activeMediaZapScript": "Current media ZapScript",
       "remoteInput": "Remote input"
     },


### PR DESCRIPTION
## Summary

- gate Core 2.15.0 `disambiguatingTags` and render its server-ordered subset in search rows
- remove page-scoped duplicate filename fallback while preserving explicit filename preference
- keep full tags in media details and fall back to full result tags on older Core versions
- add regression coverage for version gating, tag ordering, and filename behavior

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now display clearer, ordered disambiguating tags when supported by the connected Core version.
  * Tag lists can preserve server-provided tag order when applicable.
* **Bug Fixes**
  * Improved search-result row sizing and tag rendering across Core versions.
  * Removed duplicate-name subtitle behavior in favor of tag-based disambiguation; older Core versions fall back to standard tags.
* **Tests**
  * Expanded unit coverage for tag ordering, feature gating, and Core-version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->