### PR TITLE
Show read-only file mappings

### DIFF
--- a/src/__tests__/integration/create-mappings.test.tsx
+++ b/src/__tests__/integration/create-mappings.test.tsx
@@ -23,16 +23,21 @@ const {
   mockNavigate,
   mockToastSuccess,
   mockToastError,
+  mockMappings,
   mockMappingsReload,
   mockRefetch,
   mockMappingsData,
+  mockMappingsQueryFn,
   mockIsLoading,
+  mockCoreVersion,
+  mockCoreVersionPending,
 } = vi.hoisted(() => ({
   componentRef: { current: null as any },
   mockGoBack: vi.fn(),
   mockNavigate: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockMappings: vi.fn(),
   mockMappingsReload: vi.fn(),
   mockRefetch: vi.fn(),
   mockMappingsData: {
@@ -40,7 +45,12 @@ const {
       | { mappings: MappingResponse[] }
       | undefined,
   },
+  mockMappingsQueryFn: {
+    current: undefined as (() => Promise<unknown>) | undefined,
+  },
   mockIsLoading: { current: false },
+  mockCoreVersion: { current: "2.15.0" as string | null },
+  mockCoreVersionPending: { current: false },
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -65,7 +75,7 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
 
 vi.mock("@/lib/coreApi", () => ({
   CoreAPI: {
-    mappings: vi.fn(),
+    mappings: mockMappings,
     mappingsReload: mockMappingsReload,
     systems: vi.fn().mockResolvedValue({ systems: [] }),
     run: vi.fn().mockResolvedValue({}),
@@ -82,6 +92,8 @@ vi.mock("@/lib/store", async (importOriginal) => {
     useStatusStore: (selector: any) =>
       selector({
         connected: mockConnected,
+        coreVersion: mockCoreVersion.current,
+        coreVersionPending: mockCoreVersionPending.current,
         safeInsets: { top: "0px", bottom: "0px", left: "0px", right: "0px" },
       }),
   };
@@ -91,22 +103,31 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = (await importOriginal()) as any;
   return {
     ...actual,
-    useQuery: vi.fn(({ queryKey }: { queryKey: string[] }) => {
-      if (queryKey[0] === "mappings") {
+    useQuery: vi.fn(
+      ({
+        queryKey,
+        queryFn,
+      }: {
+        queryKey: readonly unknown[];
+        queryFn: () => Promise<unknown>;
+      }) => {
+        if (queryKey[0] === "mappings") {
+          mockMappingsQueryFn.current = queryFn;
+          return {
+            data: mockMappingsData.current,
+            isLoading: mockIsLoading.current,
+            isError: false,
+            refetch: mockRefetch,
+          };
+        }
         return {
-          data: mockMappingsData.current,
-          isLoading: mockIsLoading.current,
+          data: undefined,
+          isLoading: false,
           isError: false,
-          refetch: mockRefetch,
+          refetch: vi.fn(),
         };
-      }
-      return {
-        data: undefined,
-        isLoading: false,
-        isError: false,
-        refetch: vi.fn(),
-      };
-    }),
+      },
+    ),
   };
 });
 
@@ -131,6 +152,8 @@ const buildMapping = (
   match: "exact",
   pattern: "AABB",
   override: "**launch.random",
+  source: "database",
+  readOnly: false,
   ...overrides,
 });
 
@@ -141,7 +164,11 @@ describe("Create Mappings List Route", () => {
     vi.clearAllMocks();
     mockConnected = true;
     mockMappingsData.current = { mappings: [] };
+    mockMappingsQueryFn.current = undefined;
     mockIsLoading.current = false;
+    mockCoreVersion.current = "2.15.0";
+    mockCoreVersionPending.current = false;
+    mockMappings.mockResolvedValue({ mappings: [] });
     mockMappingsReload.mockResolvedValue(undefined);
     mockRefetch.mockResolvedValue({});
   });
@@ -264,6 +291,50 @@ describe("Create Mappings List Route", () => {
         screen.getByText("create.mappings.list.disabledBadge"),
       ).toBeInTheDocument();
     });
+
+    it("should render file mapping details with a read-only badge", () => {
+      mockMappingsData.current = {
+        mappings: [
+          buildMapping({
+            id: "",
+            added: "",
+            label: "Config mapping",
+            pattern: "config-pattern",
+            override: "**launch.system:snes",
+            source: "file",
+            readOnly: true,
+          }),
+        ],
+      };
+
+      renderList();
+
+      expect(screen.getByText("Config mapping")).toBeInTheDocument();
+      expect(screen.getByText("config-pattern")).toBeInTheDocument();
+      expect(screen.getByText("**launch.system:snes")).toBeInTheDocument();
+      expect(
+        screen.getByText("create.mappings.list.readOnlyBadge"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("API request", () => {
+    it("should request read-only mappings from supported Core versions", async () => {
+      renderList();
+
+      await mockMappingsQueryFn.current?.();
+
+      expect(mockMappings).toHaveBeenCalledWith({ includeReadOnly: true });
+    });
+
+    it("should omit read-only mappings for older Core versions", async () => {
+      mockCoreVersion.current = "2.14.1";
+      renderList();
+
+      await mockMappingsQueryFn.current?.();
+
+      expect(mockMappings).toHaveBeenCalledWith();
+    });
   });
 
   describe("search", () => {
@@ -371,6 +442,28 @@ describe("Create Mappings List Route", () => {
         to: "/create/mappings/edit/$id",
         params: { id: "42" },
       });
+    });
+
+    it("should not navigate when a read-only row is tapped", async () => {
+      mockMappingsData.current = {
+        mappings: [
+          buildMapping({
+            id: "",
+            added: "",
+            label: "Config mapping",
+            source: "file",
+            readOnly: true,
+          }),
+        ],
+      };
+      const user = userEvent.setup();
+      renderList();
+
+      const mappingLabel = screen.getByText("Config mapping");
+      expect(mappingLabel.closest('[role="button"]')).toBeNull();
+      await user.click(mappingLabel);
+
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it("should navigate from the empty-state CTA to /create/mappings/new", async () => {

--- a/src/__tests__/unit/coreApi.api-contract.test.ts
+++ b/src/__tests__/unit/coreApi.api-contract.test.ts
@@ -103,6 +103,16 @@ describe("CoreAPI API Contract", () => {
       expect(sentData.method).toBe("settings");
     });
 
+    it("mappings should request read-only entries when enabled", async () => {
+      const promise = CoreAPI.mappings({ includeReadOnly: true });
+      simulateResponse(mockSend, { mappings: [] });
+      await promise;
+
+      const sentData = JSON.parse(mockSend.mock.calls[0]![0]);
+      expect(sentData.method).toBe("mappings");
+      expect(sentData.params).toEqual({ includeReadOnly: true });
+    });
+
     it("mediaGenerateResume should send correct JSON-RPC format", async () => {
       const promise = CoreAPI.mediaGenerateResume();
       simulateResponse(mockSend, null);

--- a/src/components/MappingRow.tsx
+++ b/src/components/MappingRow.tsx
@@ -20,12 +20,13 @@ const MATCH_LABEL_KEYS: Record<string, string> = {
 
 interface MappingRowProps {
   mapping: MappingResponse;
-  onTap: () => void;
+  onTap?: () => void;
   isLast?: boolean;
 }
 
 export function MappingRow({ mapping, onTap, isLast }: MappingRowProps) {
   const { t } = useTranslation();
+  const isInteractive = !mapping.readOnly && onTap !== undefined;
 
   const primaryText =
     mapping.label.trim() !== ""
@@ -43,22 +44,29 @@ export function MappingRow({ mapping, onTap, isLast }: MappingRowProps) {
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onTap}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onTap();
-        }
-      }}
+      role={isInteractive ? "button" : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      onClick={isInteractive ? onTap : undefined}
+      onKeyDown={
+        isInteractive
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onTap?.();
+              }
+            }
+          : undefined
+      }
       className={classNames(
-        "flex cursor-pointer flex-row items-center justify-between gap-3 px-1 py-3",
-        "focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
-        { "border-bd-outline border-b border-solid": !isLast },
+        "flex flex-row items-center justify-between gap-3 px-1 py-3",
+        {
+          "cursor-pointer focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none":
+            isInteractive,
+          "border-bd-outline border-b border-solid": !isLast,
+        },
       )}
     >
-      <span className="sr-only">{accessibleName}</span>
+      {isInteractive && <span className="sr-only">{accessibleName}</span>}
       <div className="flex min-w-0 flex-col gap-1">
         <div className="flex items-center gap-2">
           <span
@@ -68,6 +76,9 @@ export function MappingRow({ mapping, onTap, isLast }: MappingRowProps) {
           >
             {primaryText}
           </span>
+          {mapping.readOnly && (
+            <Badge>{t("create.mappings.list.readOnlyBadge")}</Badge>
+          )}
           {!mapping.enabled && (
             <Badge variant="error">
               {t("create.mappings.list.disabledBadge")}
@@ -91,9 +102,11 @@ export function MappingRow({ mapping, onTap, isLast }: MappingRowProps) {
           {overridePreview}
         </div>
       </div>
-      <div className="text-muted-foreground shrink-0">
-        <NextIcon size="20" />
-      </div>
+      {isInteractive && (
+        <div className="text-muted-foreground shrink-0">
+          <NextIcon size="20" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -5,6 +5,7 @@ import { logger } from "./logger.ts";
 import { RequestCancelledError } from "./errors";
 import {
   AddMappingRequest,
+  AllMappingsParams,
   AllMappingsResponse,
   DeleteInboxRequest,
   HistoryResponse,
@@ -1354,9 +1355,9 @@ class CoreApi {
     });
   }
 
-  mappings(): Promise<AllMappingsResponse> {
+  mappings(params?: AllMappingsParams): Promise<AllMappingsResponse> {
     return new Promise<AllMappingsResponse>((resolve, reject) => {
-      this.call(Method.Mappings)
+      this.call(Method.Mappings, params)
         .then((result) => {
           try {
             const response = result as AllMappingsResponse;

--- a/src/lib/featureGates.ts
+++ b/src/lib/featureGates.ts
@@ -51,6 +51,11 @@ export const FEATURE_GATES: Record<string, FeatureGate> = {
     marquee: false,
     labelKey: "features.activeMediaZapScript",
   },
+  readOnlyMappings: {
+    since: "2.15.0",
+    marquee: false,
+    labelKey: "features.readOnlyMappings",
+  },
   remoteInput: {
     since: "2.10.0",
     marquee: true,

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -149,6 +149,7 @@ export interface MediaTagsResponse {
 }
 
 export type MappingType = "uid" | "text" | "data";
+export type MappingSource = "database" | "file";
 
 export interface MappingResponse {
   id: string;
@@ -159,6 +160,12 @@ export interface MappingResponse {
   match: string;
   pattern: string;
   override: string;
+  source: MappingSource;
+  readOnly: boolean;
+}
+
+export interface AllMappingsParams {
+  includeReadOnly?: boolean;
 }
 
 export interface AllMappingsResponse {

--- a/src/routes/create.mappings.tsx
+++ b/src/routes/create.mappings.tsx
@@ -20,6 +20,7 @@ import { PageFrame } from "@/components/PageFrame";
 import { MappingRow } from "@/components/MappingRow";
 import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
+import { useCoreFeature } from "@/hooks/useCoreFeature";
 
 export const Route = createFileRoute("/create/mappings")({
   component: Mappings,
@@ -34,6 +35,10 @@ export function Mappings() {
   const goBack = () => router.history.back();
   const [search, setSearch] = useState("");
   const [reloading, setReloading] = useState(false);
+  const { available: readOnlyMappingsAvailable } = useCoreFeature(
+    "readOnlyMappings",
+    { requireKnownSupport: true },
+  );
 
   const swipeHandlers = useSmartSwipe({
     onSwipeRight: goBack,
@@ -41,8 +46,11 @@ export function Mappings() {
   });
 
   const mappings = useQuery({
-    queryKey: ["mappings"],
-    queryFn: () => CoreAPI.mappings(),
+    queryKey: ["mappings", { includeReadOnly: readOnlyMappingsAvailable }],
+    queryFn: () =>
+      readOnlyMappingsAvailable
+        ? CoreAPI.mappings({ includeReadOnly: true })
+        : CoreAPI.mappings(),
   });
 
   const sortedMappings = useMemo(() => {
@@ -164,9 +172,14 @@ export function Mappings() {
               <div className="flex flex-col">
                 {filteredMappings.map((mapping, i) => (
                   <MappingRow
-                    key={mapping.id}
+                    key={
+                      mapping.id ||
+                      `file:${mapping.type}:${mapping.match}:${mapping.pattern}:${i}`
+                    }
                     mapping={mapping}
-                    onTap={() => goToEdit(mapping.id)}
+                    onTap={
+                      mapping.readOnly ? undefined : () => goToEdit(mapping.id)
+                    }
                     isLast={i === filteredMappings.length - 1}
                   />
                 ))}

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -301,6 +301,7 @@
           "reloadedSuccess": "Reloaded mappings from config files",
           "reloadFailed": "Failed to reload mappings",
           "disabledBadge": "Disabled",
+          "readOnlyBadge": "Read-only",
           "noOverride": "No action",
           "openMapping": "Open {{name}}"
         },
@@ -777,6 +778,7 @@
       "mediaBrowseAllSearch": "Browse all media search",
       "mediaDisambiguatingTags": "Search result disambiguation",
       "activeMediaZapScript": "Current media ZapScript",
+      "readOnlyMappings": "File mappings",
       "remoteInput": "Remote input"
     },
     "inbox": {


### PR DESCRIPTION
## Summary

- request file-based mappings from Core 2.15.0 and newer
- show file mapping details with a read-only badge and no edit interaction
- preserve compatibility with older Core versions through feature gating
- cover API parameters, version handling, display, and navigation behavior

Ref ZaparooProject/zaparoo-core#1165
Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying read-only mappings with a clear badge.
  * Read-only mappings are available on supported Core versions.
* **Bug Fixes**
  * Prevented read-only mappings from opening edit screens.
  * Improved mapping list handling when an item lacks an identifier.
* **Accessibility**
  * Interactive mapping rows now expose appropriate keyboard and screen-reader behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->