### PR TITLE
Hide media indexing cancel action

### DIFF
--- a/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
+++ b/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
@@ -661,7 +661,8 @@ describe("MediaDatabaseCard", () => {
     expect(CoreAPI.mediaGenerateResume).toHaveBeenCalledOnce();
   });
 
-  it("should re-enable the Resume button after a failed resume so user can retry", async () => {
+  it("should show unexpected resume failures and allow retry", async () => {
+    const user = userEvent.setup();
     mockStore.gamesIndex = {
       indexing: true,
       exists: false,
@@ -681,7 +682,7 @@ describe("MediaDatabaseCard", () => {
     const resumeButton = screen.getByRole("button", {
       name: /settings\.updateDb\.resume/i,
     });
-    fireEvent.click(resumeButton);
+    await user.click(resumeButton);
 
     // Once the rejection settles, the button must return to "Resume" (enabled),
     // not stay stuck in "Resuming…" — otherwise the user can't try again.
@@ -694,6 +695,8 @@ describe("MediaDatabaseCard", () => {
       });
       expect(button).not.toBeDisabled();
     });
+    expect(await screen.findByText("error")).toBeInTheDocument();
+    expect(showRateLimitedErrorToast).toHaveBeenCalledWith("error");
   });
 
   it("should not duplicate the global reconnecting status mid-index", () => {

--- a/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
+++ b/src/__tests__/unit/components/MediaDatabaseCard.test.tsx
@@ -9,7 +9,6 @@ import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 vi.mock("../../../lib/coreApi", () => ({
   CoreAPI: {
     mediaGenerate: vi.fn(),
-    mediaGenerateCancel: vi.fn(),
     mediaGenerateResume: vi.fn(),
     mediaCleanOrphans: vi.fn(),
     media: vi.fn(),
@@ -372,36 +371,6 @@ describe("MediaDatabaseCard", () => {
     expect(showRateLimitedErrorToast).toHaveBeenCalledWith("error");
   });
 
-  it("should show expected cancel failures inline and allow retry", async () => {
-    mockStore.gamesIndex = {
-      indexing: true,
-      exists: false,
-      totalFiles: 0,
-      currentStep: 2,
-      totalSteps: 11,
-      currentStepDisplay: "Atari 2600",
-    };
-    vi.mocked(CoreAPI.mediaGenerateCancel).mockRejectedValue(
-      new Error("Method not found"),
-    );
-
-    render(<MediaDatabaseCard />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: /settings\.updateDb\.cancel/i,
-      }),
-    );
-
-    expect(await screen.findByText("error")).toBeInTheDocument();
-    await vi.waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /settings\.updateDb\.cancel/i }),
-      ).not.toBeDisabled();
-    });
-    expect(showRateLimitedErrorToast).not.toHaveBeenCalled();
-  });
-
   it("should show setup errors from clean missing media without a toast", async () => {
     const user = userEvent.setup();
     vi.mocked(CoreAPI.mediaCleanOrphans).mockRejectedValue(
@@ -423,42 +392,6 @@ describe("MediaDatabaseCard", () => {
 
     expect(await screen.findByText("error")).toBeInTheDocument();
     expect(showRateLimitedErrorToast).not.toHaveBeenCalled();
-  });
-
-  it("should clear stale generate errors when cancel is attempted", async () => {
-    vi.mocked(CoreAPI.mediaGenerate).mockRejectedValue(
-      new Error("Method not found"),
-    );
-    const { rerender } = render(<MediaDatabaseCard />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings.updateDb",
-      }),
-    );
-    expect(await screen.findByText("error")).toBeInTheDocument();
-
-    mockStore.gamesIndex = {
-      indexing: true,
-      exists: false,
-      totalFiles: 0,
-      currentStep: 2,
-      totalSteps: 11,
-      currentStepDisplay: "Atari 2600",
-    };
-    vi.mocked(CoreAPI.mediaGenerateCancel).mockResolvedValue(undefined);
-    rerender(<MediaDatabaseCard />);
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: /settings\.updateDb\.cancel/i,
-      }),
-    );
-
-    await vi.waitFor(() => {
-      expect(CoreAPI.mediaGenerateCancel).toHaveBeenCalledOnce();
-    });
-    expect(screen.queryByText("error")).not.toBeInTheDocument();
   });
 
   it("should clear stale generate errors when resume is attempted", async () => {
@@ -787,86 +720,13 @@ describe("MediaDatabaseCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should show cancel button when indexing", () => {
+  it("should hide the cancel button while indexing", () => {
     mockStore.gamesIndex.indexing = true;
 
     render(<MediaDatabaseCard />);
 
-    const cancelButton = screen.getByRole("button", {
-      name: /settings\.updateDb\.cancel/i,
-    });
-    expect(cancelButton).toBeInTheDocument();
-    expect(cancelButton).not.toBeDisabled();
-  });
-
-  it("should call CoreAPI.mediaGenerateCancel when cancel button is clicked", async () => {
-    mockStore.gamesIndex.indexing = true;
-    const { CoreAPI } = await import("../../../lib/coreApi");
-
-    render(<MediaDatabaseCard />);
-
-    const cancelButton = screen.getByRole("button", {
-      name: /settings\.updateDb\.cancel/i,
-    });
-    fireEvent.click(cancelButton);
-
-    expect(CoreAPI.mediaGenerateCancel).toHaveBeenCalledOnce();
-  });
-
-  it("should not show cancel button when not indexing", () => {
-    mockStore.gamesIndex.indexing = false;
-
-    render(<MediaDatabaseCard />);
-
-    const cancelButton = screen.queryByRole("button", {
-      name: /settings\.updateDb\.cancel/i,
-    });
-    expect(cancelButton).not.toBeInTheDocument();
-  });
-
-  it('should keep cancel button in "Cancelling..." state after API call completes (regression test)', async () => {
-    // REGRESSION TEST: This test prevents re-introducing a bug where the cancel button
-    // immediately reverts to "Cancel" state after the API call completes, even though
-    // the actual cancellation is still happening in the background on zaparoo-core.
-    //
-    // The bug was caused by a `finally` block that reset `isCancelling` state immediately
-    // after the API call. The correct behavior is to keep the button in "Cancelling..."
-    // state until a WebSocket notification confirms that indexing has stopped.
-
-    mockStore.gamesIndex.indexing = true;
-    const { CoreAPI } = await import("../../../lib/coreApi");
-
-    // Mock the cancel API to resolve successfully
-    vi.mocked(CoreAPI.mediaGenerateCancel).mockResolvedValue(undefined);
-
-    render(<MediaDatabaseCard />);
-
-    // Find and click the cancel button
-    const cancelButton = screen.getByRole("button", {
-      name: /settings\.updateDb\.cancel/i,
-    });
-    fireEvent.click(cancelButton);
-
-    // Wait for the API call to complete
-    await vi.waitFor(() => {
-      expect(CoreAPI.mediaGenerateCancel).toHaveBeenCalledOnce();
-    });
-
-    // CRITICAL ASSERTION: After the API call completes, the button should STILL
-    // be in the "Cancelling..." state (disabled with "cancelling" text),
-    // NOT reverted back to "Cancel" state.
-    //
-    // This is because the actual cancellation is happening in the background,
-    // and we need to wait for the WebSocket notification (indexing: false) to confirm.
-    const buttonAfterApiCall = screen.getByRole("button", {
-      name: /cancelling/i,
-    });
-    expect(buttonAfterApiCall).toBeInTheDocument();
-    expect(buttonAfterApiCall).toBeDisabled();
-
-    // Verify it's NOT showing the normal "Cancel" text
     expect(
-      screen.queryByRole("button", { name: /^settings\.updateDb\.cancel$/i }),
+      screen.queryByRole("button", { name: /settings\.updateDb\.cancel/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/MediaDatabaseCard.tsx
+++ b/src/components/MediaDatabaseCard.tsx
@@ -152,6 +152,12 @@ export function MediaDatabaseCard({
         return;
       }
 
+      const message =
+        error instanceof Error
+          ? error.message
+          : t("settings.updateDb.startError");
+      setGenerateError(message);
+      showRateLimitedErrorToast(t("error", { msg: message }));
       logger.error("Failed to resume media generation:", error, {
         category: "api",
         action: "mediaGenerateResume",

--- a/src/components/MediaDatabaseCard.tsx
+++ b/src/components/MediaDatabaseCard.tsx
@@ -43,7 +43,6 @@ export function MediaDatabaseCard({
   );
   const cleanOrphansFeature = useCoreFeature("mediaCleanOrphans");
   const isLiveConnected = connectionState === ConnectionState.CONNECTED;
-  const [cancelRequested, setCancelRequested] = useState(false);
   const [resumeRequested, setResumeRequested] = useState(false);
   const [selectedSystems, setSelectedSystems] = useState<string[]>([]);
   const [systemSelectorOpen, setSystemSelectorOpen] = useState(false);
@@ -63,19 +62,10 @@ export function MediaDatabaseCard({
   const mediaGenerateUnsupported =
     coreVersion !== null && !coreVersionPending && !mediaGenerateAvailable;
 
-  // Derive isCancelling: true only if we requested cancel AND indexing is still happening
-  const isCancelling = cancelRequested && gamesIndex.indexing;
   // Derive isResuming: true only if we requested resume AND indexing is still paused
   const isResuming = resumeRequested && isPaused;
 
-  // Reset cancel/resume request when state changes (syncing with external Zustand store state)
-  useEffect(() => {
-    if (!gamesIndex.indexing && cancelRequested) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing local UI state with external store
-      setCancelRequested(false);
-    }
-  }, [gamesIndex.indexing, cancelRequested]);
-
+  // Reset resume request when state changes (syncing with external Zustand store state)
   useEffect(() => {
     if ((!isPaused || !gamesIndex.indexing) && resumeRequested) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: syncing local UI state with external store
@@ -142,35 +132,6 @@ export function MediaDatabaseCard({
           : t("settings.updateDb.startError");
       setGenerateError(message);
       showRateLimitedErrorToast(t("error", { msg: message }));
-    }
-  };
-
-  const handleCancelUpdate = async () => {
-    setGenerateError(null);
-    setCancelRequested(true);
-    try {
-      await CoreAPI.mediaGenerateCancel();
-      // Note: Don't reset cancelRequested here - it resets automatically via effect
-      // when the indexing status updates from the WebSocket notification
-      queryClient.invalidateQueries({ queryKey: ["media"] });
-    } catch (error) {
-      if (isExpectedMediaDatabaseError(error)) {
-        setGenerateError(
-          error instanceof Error
-            ? error.message
-            : t("settings.updateDb.startError"),
-        );
-        setCancelRequested(false);
-        return;
-      }
-
-      logger.error("Failed to cancel media generation:", error, {
-        category: "api",
-        action: "mediaGenerateCancel",
-        severity: "warning",
-      });
-      // Only reset on error, since cancellation request failed
-      setCancelRequested(false);
     }
   };
 
@@ -338,25 +299,15 @@ export function MediaDatabaseCard({
               />
             </div>
           </div>
-          <Button
-            label={
-              isPaused
-                ? isResuming
-                  ? t("resuming")
-                  : t("settings.updateDb.resume")
-                : isCancelling
-                  ? t("cancelling")
-                  : t("settings.updateDb.cancel")
-            }
-            variant="outline"
-            className="w-full"
-            disabled={
-              !connected ||
-              !mediaGenerateAvailable ||
-              (isPaused ? isResuming : isCancelling)
-            }
-            onClick={isPaused ? handleResumeUpdate : handleCancelUpdate}
-          />
+          {isPaused ? (
+            <Button
+              label={isResuming ? t("resuming") : t("settings.updateDb.resume")}
+              variant="outline"
+              className="w-full"
+              disabled={!connected || !mediaGenerateAvailable || isResuming}
+              onClick={handleResumeUpdate}
+            />
+          ) : null}
         </div>
       );
     }


### PR DESCRIPTION
## Summary

- hide the Cancel action while media database indexing is active to prevent partial databases
- preserve Resume for genuinely paused indexing
- replace cancellation-specific tests with coverage for the hidden action

Search during indexing previously shipped in #184.

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Resume** action for paused media indexing, with clearer resume-state UI.
* **Bug Fixes**
  * Removed the cancel action from the indexing status view; the cancel button is now hidden during indexing.
  * Improved resume failure behavior to support retry, including clearer error presentation and rate-limited notifications on unexpected errors.
* **Tests**
  * Updated unit tests to reflect the revised cancel and resume flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->