### PR TITLE
Fix encrypted pairing and honor client capabilities

### DIFF
--- a/src/__tests__/integration/settings-readers.test.tsx
+++ b/src/__tests__/integration/settings-readers.test.tsx
@@ -165,6 +165,11 @@ describe("Settings Readers Integration", () => {
       ...useStatusStore.getInitialState(),
       connected: true,
       connectionState: ConnectionState.CONNECTED,
+      currentClient: {
+        paired: true,
+        role: "admin",
+        capabilities: ["settings.write"],
+      },
     });
     usePreferencesStore.setState({
       ...usePreferencesStore.getInitialState(),

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -16,7 +16,11 @@ import { CoreAPI } from "../../../lib/coreApi";
 import { ConnectionState, useStatusStore } from "@/lib/store";
 import type { TransportState } from "../../../lib/transport/types";
 import type { NotificationRequest } from "../../../lib/coreApi";
-import { InboxSeverity, Notification } from "../../../lib/models";
+import {
+  ClientCapability,
+  InboxSeverity,
+  Notification,
+} from "../../../lib/models";
 
 // Capture event handlers for notification testing
 let capturedEventHandlers: {
@@ -24,6 +28,10 @@ let capturedEventHandlers: {
   onMessage?: (deviceId: string, event: unknown) => void;
   onError?: (deviceId: string, error: Error) => void;
 } = {};
+
+const pairingModalCapture = vi.hoisted(() => ({
+  onSuccess: undefined as (() => void) | undefined,
+}));
 
 // Mock dependencies
 vi.mock("../../../lib/transport", () => {
@@ -55,11 +63,28 @@ vi.mock("../../../lib/transport", () => {
       pauseAll: vi.fn(),
       resumeAll: vi.fn(),
       immediateReconnectActive: vi.fn(),
+      restartActiveConnection: vi.fn(),
+      clearEncryptionBlockActive: vi.fn(),
     },
   };
 });
 
+vi.mock("../../../components/PairingModal", () => ({
+  PairingModal: ({ onSuccess }: { onSuccess?: () => void }) => {
+    pairingModalCapture.onSuccess = onSuccess;
+    return null;
+  },
+}));
+
 vi.mock("../../../lib/coreApi", () => ({
+  CoreApiError: class extends Error {
+    constructor(
+      message: string,
+      readonly code: number,
+    ) {
+      super(message);
+    }
+  },
   CoreAPI: {
     setWsInstance: vi.fn(),
     flushQueue: vi.fn(),
@@ -68,6 +93,11 @@ vi.mock("../../../lib/coreApi", () => ({
     media: vi.fn().mockResolvedValue({ database: {}, active: [] }),
     tokens: vi.fn().mockResolvedValue({ last: null }),
     version: vi.fn().mockResolvedValue({ version: "2.5.0", platform: "test" }),
+    clientsCurrent: vi.fn().mockResolvedValue({
+      paired: true,
+      role: "admin",
+      capabilities: ["profiles.manage", "settings.write"],
+    }),
     inbox: vi.fn().mockResolvedValue({ messages: [] }),
     mediaScrapeStatus: vi.fn().mockResolvedValue({
       processed: 0,
@@ -336,6 +366,21 @@ describe("ConnectionProvider", () => {
 
       expect(connectionManager.setActiveDevice).toHaveBeenCalledWith(
         "192.168.1.100:7497",
+      );
+    });
+
+    it("should restart the active connection after pairing succeeds", () => {
+      render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+
+      expect(pairingModalCapture.onSuccess).toBeDefined();
+      pairingModalCapture.onSuccess?.();
+
+      expect(connectionManager.restartActiveConnection).toHaveBeenCalledTimes(
+        1,
       );
     });
   });
@@ -1214,6 +1259,95 @@ describe("connection event handling", () => {
       expect(useStatusStore.getState().corePlatform).toBe("test");
       expect(useStatusStore.getState().coreVersionPending).toBe(false);
     });
+  });
+
+  it("should preserve legacy capabilities for older Core versions", async () => {
+    render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(useStatusStore.getState().currentClient).toEqual({
+        paired: false,
+        role: null,
+        capabilities: [
+          ClientCapability.ProfilesManage,
+          ClientCapability.SettingsWrite,
+        ],
+      });
+    });
+    expect(CoreAPI.clientsCurrent).not.toHaveBeenCalled();
+  });
+
+  it("should hydrate current client capabilities from supported Core", async () => {
+    vi.mocked(CoreAPI.version).mockResolvedValueOnce({
+      version: "DEVELOPMENT",
+      platform: "test",
+    });
+    vi.mocked(CoreAPI.clientsCurrent).mockResolvedValueOnce({
+      paired: true,
+      role: "member",
+      capabilities: [],
+    });
+
+    render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: false,
+      hasConnectedBefore: false,
+    });
+
+    await waitFor(() => {
+      expect(CoreAPI.clientsCurrent).toHaveBeenCalledTimes(1);
+      expect(useStatusStore.getState().currentClient).toEqual({
+        paired: true,
+        role: "member",
+        capabilities: [],
+      });
+    });
+  });
+
+  it("should clear stale client capabilities while reconnecting", () => {
+    useStatusStore.setState({
+      currentClient: {
+        paired: true,
+        role: "admin",
+        capabilities: [ClientCapability.SettingsWrite],
+      },
+    });
+    render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+    useStatusStore.setState({
+      currentClient: {
+        paired: true,
+        role: "admin",
+        capabilities: [ClientCapability.SettingsWrite],
+      },
+    });
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "reconnecting",
+      hasData: true,
+      hasConnectedBefore: true,
+    });
+
+    expect(useStatusStore.getState().currentClient).toBeNull();
   });
 
   it("should invalidate library queries after reconnecting", async () => {

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Preferences } from "@capacitor/preferences";
 import { QueryClient } from "@tanstack/react-query";
-import { render, screen, waitFor } from "../../../test-utils";
+import { act, render, screen, waitFor } from "../../../test-utils";
 import { ConnectionProvider } from "../../../components/ConnectionProvider";
 import { useConnection } from "../../../hooks/useConnection";
 import { connectionManager } from "../../../lib/transport";
@@ -16,11 +16,7 @@ import { CoreAPI } from "../../../lib/coreApi";
 import { ConnectionState, useStatusStore } from "@/lib/store";
 import type { TransportState } from "../../../lib/transport/types";
 import type { NotificationRequest } from "../../../lib/coreApi";
-import {
-  ClientCapability,
-  InboxSeverity,
-  Notification,
-} from "../../../lib/models";
+import { ClientCapability, InboxSeverity, Notification } from "@/lib/models";
 
 // Capture event handlers for notification testing
 let capturedEventHandlers: {
@@ -1319,6 +1315,61 @@ describe("connection event handling", () => {
       });
     });
   });
+
+  it.each(["resolve", "reject"] as const)(
+    "should ignore stale clients.current %s callbacks after reconnecting",
+    async (outcome) => {
+      vi.mocked(CoreAPI.version).mockResolvedValueOnce({
+        version: "DEVELOPMENT",
+        platform: "test",
+      });
+      type CurrentClient = Awaited<ReturnType<typeof CoreAPI.clientsCurrent>>;
+      let resolveRequest!: (value: CurrentClient) => void;
+      let rejectRequest!: (reason: Error) => void;
+      const deferredRequest = new Promise<CurrentClient>((resolve, reject) => {
+        resolveRequest = resolve;
+        rejectRequest = reject;
+      });
+      vi.mocked(CoreAPI.clientsCurrent).mockReturnValueOnce(deferredRequest);
+
+      render(
+        <ConnectionProvider>
+          <ConnectionConsumer />
+        </ConnectionProvider>,
+      );
+      capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+        state: "connected",
+        hasData: false,
+        hasConnectedBefore: false,
+      });
+      await waitFor(() => {
+        expect(CoreAPI.clientsCurrent).toHaveBeenCalledTimes(1);
+      });
+
+      capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+        state: "reconnecting",
+        hasData: true,
+        hasConnectedBefore: true,
+      });
+      const newerClient: CurrentClient = {
+        paired: true,
+        role: "admin",
+        capabilities: [ClientCapability.SettingsWrite],
+      };
+      useStatusStore.setState({ currentClient: newerClient });
+
+      await act(async () => {
+        if (outcome === "resolve") {
+          resolveRequest({ paired: true, role: "member", capabilities: [] });
+        } else {
+          rejectRequest(new Error("stale request failed"));
+        }
+        await deferredRequest.catch(() => undefined);
+      });
+
+      expect(useStatusStore.getState().currentClient).toEqual(newerClient);
+    },
+  );
 
   it("should clear stale client capabilities while reconnecting", () => {
     useStatusStore.setState({

--- a/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
+++ b/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
@@ -163,6 +163,24 @@ describe("DeviceConnectionCard", () => {
     expect(historyLink).toHaveAttribute("href", "/settings/devices");
   });
 
+  it("should always allow manual pairing", () => {
+    const openPairingModal = vi.fn();
+    mockUseConnection.mockReturnValue({
+      isConnected: true,
+      showConnecting: false,
+      showReconnecting: false,
+      openPairingModal,
+    });
+    useStatusStore.setState({ pairingRequired: false });
+
+    render(<DeviceConnectionCard {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "pairing.openPairing" }),
+    );
+
+    expect(openPairingModal).toHaveBeenCalledTimes(1);
+  });
+
   it("has device address input accessible", () => {
     render(<DeviceConnectionCard {...defaultProps} />);
 

--- a/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
+++ b/src/__tests__/unit/components/DeviceConnectionCard.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
 import { render, screen, fireEvent } from "../../../test-utils";
 import { DeviceConnectionCard } from "@/components/DeviceConnectionCard";
 import { useStatusStore } from "@/lib/store";
@@ -163,7 +164,8 @@ describe("DeviceConnectionCard", () => {
     expect(historyLink).toHaveAttribute("href", "/settings/devices");
   });
 
-  it("should always allow manual pairing", () => {
+  it("should always allow manual pairing", async () => {
+    const user = userEvent.setup();
     const openPairingModal = vi.fn();
     mockUseConnection.mockReturnValue({
       isConnected: true,
@@ -171,10 +173,9 @@ describe("DeviceConnectionCard", () => {
       showReconnecting: false,
       openPairingModal,
     });
-    useStatusStore.setState({ pairingRequired: false });
 
     render(<DeviceConnectionCard {...defaultProps} />);
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: "pairing.openPairing" }),
     );
 

--- a/src/__tests__/unit/hooks/useClientCapability.test.ts
+++ b/src/__tests__/unit/hooks/useClientCapability.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook } from "@/test-utils";
+import { useClientCapability } from "@/hooks/useClientCapability";
+import { ClientCapability } from "@/lib/models";
+import { useStatusStore } from "@/lib/store";
+
+describe("useClientCapability", () => {
+  beforeEach(() => {
+    useStatusStore.setState({ connected: true, currentClient: null });
+  });
+
+  it("should deny capabilities while current client is unknown", () => {
+    const { result } = renderHook(() =>
+      useClientCapability(ClientCapability.SettingsWrite),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should deny cached capabilities while disconnected", () => {
+    useStatusStore.setState({
+      connected: false,
+      currentClient: {
+        paired: true,
+        role: "admin",
+        capabilities: [ClientCapability.SettingsWrite],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useClientCapability(ClientCapability.SettingsWrite),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should report capabilities granted by Core", () => {
+    useStatusStore.setState({
+      currentClient: {
+        paired: true,
+        role: "admin",
+        capabilities: [ClientCapability.SettingsWrite],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useClientCapability(ClientCapability.SettingsWrite),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it("should deny capabilities omitted by Core", () => {
+    useStatusStore.setState({
+      currentClient: {
+        paired: true,
+        role: "member",
+        capabilities: [],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useClientCapability(ClientCapability.ProfilesManage),
+    );
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -193,6 +193,7 @@ describe("CoreAPI", () => {
     ["stop", () => CoreAPI.stop(), "stop"],
     ["mediaActive", () => CoreAPI.mediaActive(), "media.active"],
     ["settingsReload", () => CoreAPI.settingsReload(), "settings.reload"],
+    ["clientsCurrent", () => CoreAPI.clientsCurrent(), "clients.current"],
     [
       "readersWriteCancel",
       () => CoreAPI.readersWriteCancel(),

--- a/src/__tests__/unit/lib/store.test.ts
+++ b/src/__tests__/unit/lib/store.test.ts
@@ -277,6 +277,11 @@ describe("StatusStore", () => {
         mediaName: "Test Game",
         mediaPath: "/path/to/game",
       });
+      store.setCurrentClient({
+        paired: true,
+        role: "admin",
+        capabilities: ["settings.write"],
+      });
 
       // Reset the state
       store.resetConnectionState();
@@ -317,6 +322,7 @@ describe("StatusStore", () => {
         mediaName: "",
         mediaPath: "",
       });
+      expect(resetState.currentClient).toBeNull();
     });
 
     it("should not affect non-connection-related state", () => {

--- a/src/__tests__/unit/lib/transport/ConnectionManager.test.ts
+++ b/src/__tests__/unit/lib/transport/ConnectionManager.test.ts
@@ -16,8 +16,13 @@ vi.mock("../../../../lib/transport/WebSocketTransport", () => {
 
     send = vi.fn();
     immediateReconnect = vi.fn();
+    clearEncryptionBlock = vi.fn();
     pauseHeartbeat = vi.fn();
     resumeHeartbeat = vi.fn();
+    disconnect = vi.fn(() => {
+      this._state = "disconnected";
+      this.handlers.onStateChange?.("disconnected");
+    });
     destroy = vi.fn(() => {
       this._state = "disconnected";
     });
@@ -54,11 +59,6 @@ vi.mock("../../../../lib/transport/WebSocketTransport", () => {
       }, 0);
     }
 
-    disconnect(): void {
-      this._state = "disconnected";
-      this.handlers.onStateChange?.("disconnected");
-    }
-
     // Test helpers
     simulateMessage(data: string): void {
       this.handlers.onMessage?.({ data });
@@ -87,8 +87,10 @@ interface MockTransport {
   isConnected: boolean;
   hasEverConnected: boolean;
   send: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   immediateReconnect: ReturnType<typeof vi.fn>;
+  clearEncryptionBlock: ReturnType<typeof vi.fn>;
   pauseHeartbeat: ReturnType<typeof vi.fn>;
   resumeHeartbeat: ReturnType<typeof vi.fn>;
   simulateMessage: (data: string) => void;
@@ -410,6 +412,49 @@ describe("ConnectionManager", () => {
       // Disconnected transport should get immediateReconnect
       expect(transport2.immediateReconnect).toHaveBeenCalled();
       expect(transport2.resumeHeartbeat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("restartActiveConnection", () => {
+    it("should replace an already-connected active socket", async () => {
+      const transport = manager.addDevice({
+        deviceId: "device-1",
+        type: "websocket",
+        address: "ws://localhost:7497",
+      }) as unknown as MockTransport;
+      manager.setActiveDevice("device-1");
+      await vi.advanceTimersByTimeAsync(10);
+      transport.disconnect.mockClear();
+      transport.immediateReconnect.mockClear();
+
+      manager.restartActiveConnection();
+
+      expect(transport.disconnect).toHaveBeenCalledTimes(1);
+      expect(transport.immediateReconnect).toHaveBeenCalledTimes(1);
+      expect(transport.disconnect.mock.invocationCallOrder[0]!).toBeLessThan(
+        transport.immediateReconnect.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it("should defer reopening the socket while paused", async () => {
+      const transport = manager.addDevice({
+        deviceId: "device-1",
+        type: "websocket",
+        address: "ws://localhost:7497",
+      }) as unknown as MockTransport;
+      manager.setActiveDevice("device-1");
+      await vi.advanceTimersByTimeAsync(10);
+      manager.pauseAll();
+      transport.disconnect.mockClear();
+      transport.immediateReconnect.mockClear();
+
+      manager.restartActiveConnection();
+
+      expect(transport.disconnect).toHaveBeenCalledTimes(1);
+      expect(transport.immediateReconnect).not.toHaveBeenCalled();
+
+      manager.resumeAll();
+      expect(transport.immediateReconnect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/__tests__/unit/routes/settings.advanced.test.tsx
+++ b/src/__tests__/unit/routes/settings.advanced.test.tsx
@@ -82,6 +82,11 @@ describe("Settings Advanced Route", () => {
   const defaultStoreState = {
     connected: true,
     connectionState: ConnectionState.CONNECTED,
+    currentClient: {
+      paired: true,
+      role: "admin",
+      capabilities: ["settings.write"],
+    },
     safeInsets: { top: "0px", bottom: "0px", left: "0px", right: "0px" },
   };
 
@@ -227,6 +232,35 @@ describe("Settings Advanced Route", () => {
       await waitFor(() => {
         expect(mockSettingsUpdate).toHaveBeenCalledWith({ debugLogging: true });
       });
+    });
+
+    it("should disable Core settings for a member client", async () => {
+      mockUseStatusStore.mockImplementation((selector) =>
+        selector({
+          ...defaultStoreState,
+          currentClient: {
+            paired: true,
+            role: "member",
+            capabilities: [],
+          },
+        }),
+      );
+
+      renderComponent();
+
+      const errorReporting = await screen.findByRole("checkbox", {
+        name: /settings.advanced.errorReporting/i,
+      });
+      const debugLogging = screen.getByRole("checkbox", {
+        name: /settings.advanced.debugLogging/i,
+      });
+      const showFilenames = screen.getByRole("checkbox", {
+        name: /settings.advanced.showFilenames/i,
+      });
+
+      expect(errorReporting).toBeDisabled();
+      expect(debugLogging).toBeDisabled();
+      expect(showFilenames).toBeEnabled();
     });
 
     it("should call setShowFilenames when show filenames is toggled", async () => {

--- a/src/__tests__/unit/routes/settings.play-controls.test.tsx
+++ b/src/__tests__/unit/routes/settings.play-controls.test.tsx
@@ -45,6 +45,11 @@ vi.mock("@/lib/store", async (importOriginal) => {
       selector({
         connected: true,
         connectionState: "CONNECTED",
+        currentClient: {
+          paired: true,
+          role: "admin",
+          capabilities: ["settings.write"],
+        },
         safeInsets: { top: "0px", bottom: "0px", left: "0px", right: "0px" },
         gamesIndex: {
           indexing: false,

--- a/src/__tests__/unit/routes/settings.readers.test.tsx
+++ b/src/__tests__/unit/routes/settings.readers.test.tsx
@@ -42,6 +42,11 @@ vi.mock("@/lib/store", async (importOriginal) => {
       selector({
         connected: true,
         connectionState: "CONNECTED",
+        currentClient: {
+          paired: true,
+          role: "admin",
+          capabilities: ["settings.write"],
+        },
         safeInsets: { top: "0px", bottom: "0px", left: "0px", right: "0px" },
         gamesIndex: {
           indexing: false,

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -96,6 +96,12 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   const isInitialized = useRef(false);
   // Track current connection to prevent stale events from old connections
   const currentConnectionId = useRef<string | null>(null);
+  // Monotonically identifies the latest current-client capability request.
+  // Connection transitions invalidate older callbacks before they can write.
+  const currentClientRequestToken = useRef(0);
+  const invalidateCurrentClientRequest = useCallback(() => {
+    currentClientRequestToken.current++;
+  }, []);
   // Pending media-fetch retry; cleared on cleanup so a stale connection
   // can't write its state into the freshly-mounted one.
   const mediaRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -496,6 +502,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
 
   // Handle connection open - fetch initial data
   const handleConnectionOpen = useCallback(() => {
+    const clientRequestToken = ++currentClientRequestToken.current;
     setConnectionError("");
     setInboxMessages([]);
     setInboxModalOpen(false);
@@ -539,6 +546,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
               logger.log("Version request was cancelled, skipping");
               return;
             }
+            if (clientRequestToken !== currentClientRequestToken.current) {
+              return;
+            }
             setCoreVersion(res.version);
             setCorePlatform(res.platform);
             setCoreVersionPending(false);
@@ -551,6 +561,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             if (versionSatisfies(res.version, CLIENT_CAPABILITIES_SINCE)) {
               CoreAPI.clientsCurrent()
                 .then((clientRes) => {
+                  if (
+                    clientRequestToken !== currentClientRequestToken.current
+                  ) {
+                    return;
+                  }
                   if (isCancelled(clientRes)) {
                     logger.log(
                       "Current client request was cancelled, skipping",
@@ -560,6 +575,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
                   setCurrentClient(clientRes);
                 })
                 .catch((err) => {
+                  if (
+                    clientRequestToken !== currentClientRequestToken.current
+                  ) {
+                    return;
+                  }
                   setCurrentClient(null);
                   if (err instanceof CoreApiError && err.code === -32601) {
                     logger.warn(
@@ -627,6 +647,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             }
           })
           .catch((e) => {
+            if (clientRequestToken !== currentClientRequestToken.current) {
+              return;
+            }
             logger.error("Failed to get Core version:", e, {
               category: "api",
               action: "version",
@@ -796,6 +819,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     // Reset local connection state when device changes so UI doesn't show stale data
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: reset state for the newly selected external device.
     setLocalConnection(null);
+    invalidateCurrentClientRequest();
     setCurrentClient(null);
     setEncryptionState("unknown");
     setPairingRequired(false);
@@ -845,10 +869,8 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           // Note: useState always triggers re-render when called with a new object reference
           setLocalConnection(connection);
 
-          if (
-            connection.state === "connecting" ||
-            connection.state === "reconnecting"
-          ) {
+          if (connection.state !== "connected") {
+            invalidateCurrentClientRequest();
             setCurrentClient(null);
           }
 
@@ -1010,11 +1032,13 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       // Reset CoreAPI to clear any pending requests for this connection
       CoreAPI.reset();
       connectionManager.removeDevice(deviceAddress);
+      invalidateCurrentClientRequest();
       setCurrentClient(null);
       setConnectionState(ConnectionState.DISCONNECTED);
     };
   }, [
     targetDeviceAddress,
+    invalidateCurrentClientRequest,
     setConnectionState,
     setConnectionError,
     setCurrentClient,

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/transport";
 import { logger } from "@/lib/logger";
 import {
+  ClientCapability,
   IndexResponse,
   InboxMessage,
   InboxSeverity,
@@ -46,8 +47,10 @@ import {
   TokenResponse,
 } from "@/lib/models";
 import { isCoreFeatureAvailable } from "@/lib/featureGates";
+import { satisfies as versionSatisfies } from "@/lib/coreVersion";
 import {
   CoreAPI,
+  CoreApiError,
   getDeviceAddress,
   isCancelled,
   isExpectedMediaDatabaseError,
@@ -75,6 +78,16 @@ import { PairingModal } from "./PairingModal";
 interface ConnectionProviderProps {
   children: ReactNode;
 }
+
+const CLIENT_CAPABILITIES_SINCE = "2.16.0";
+const LEGACY_CLIENT_ACCESS = {
+  paired: false,
+  role: null,
+  capabilities: [
+    ClientCapability.ProfilesManage,
+    ClientCapability.SettingsWrite,
+  ],
+};
 
 export function ConnectionProvider({ children }: ConnectionProviderProps) {
   const { t } = useTranslation();
@@ -117,6 +130,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setCoreVersion,
     setCorePlatform,
     setCoreVersionPending,
+    setCurrentClient,
     setEncryptionState,
     setPairingRequired,
     addInboxMessage,
@@ -142,6 +156,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       setCoreVersion: state.setCoreVersion,
       setCorePlatform: state.setCorePlatform,
       setCoreVersionPending: state.setCoreVersionPending,
+      setCurrentClient: state.setCurrentClient,
       setEncryptionState: state.setEncryptionState,
       setPairingRequired: state.setPairingRequired,
       addInboxMessage: state.addInboxMessage,
@@ -532,6 +547,42 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
               version: res.version,
               lastConnectedAt: Date.now(),
             });
+
+            if (versionSatisfies(res.version, CLIENT_CAPABILITIES_SINCE)) {
+              CoreAPI.clientsCurrent()
+                .then((clientRes) => {
+                  if (isCancelled(clientRes)) {
+                    logger.log(
+                      "Current client request was cancelled, skipping",
+                    );
+                    return;
+                  }
+                  setCurrentClient(clientRes);
+                })
+                .catch((err) => {
+                  setCurrentClient(null);
+                  if (err instanceof CoreApiError && err.code === -32601) {
+                    logger.warn(
+                      "Current client capabilities are unavailable on this Core build",
+                    );
+                    return;
+                  }
+                  logger.error(
+                    "Failed to fetch current client capabilities:",
+                    err,
+                    {
+                      category: "api",
+                      action: "clientsCurrent",
+                      severity: "warning",
+                    },
+                  );
+                });
+            } else {
+              // Roles did not exist before Core 2.16, so older connections
+              // retain their legacy unrestricted settings access.
+              setCurrentClient(LEGACY_CLIENT_ACCESS);
+            }
+
             if (isCoreFeatureAvailable("mediaScrapers", res.version)) {
               CoreAPI.mediaScrapeStatus()
                 .then((statusRes) => {
@@ -584,6 +635,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             setCoreVersion(null);
             setCorePlatform(null);
             setCoreVersionPending(false);
+            setCurrentClient(null);
           });
       });
 
@@ -695,6 +747,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setCoreVersion,
     setCorePlatform,
     setCoreVersionPending,
+    setCurrentClient,
     setScrapingStatus,
     setInboxMessages,
     setInboxModalOpen,
@@ -743,6 +796,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     // Reset local connection state when device changes so UI doesn't show stale data
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: reset state for the newly selected external device.
     setLocalConnection(null);
+    setCurrentClient(null);
     setEncryptionState("unknown");
     setPairingRequired(false);
     setPairingOpen(false);
@@ -790,6 +844,13 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           // Update local connection state for context consumers
           // Note: useState always triggers re-render when called with a new object reference
           setLocalConnection(connection);
+
+          if (
+            connection.state === "connecting" ||
+            connection.state === "reconnecting"
+          ) {
+            setCurrentClient(null);
+          }
 
           // Each new connect attempt starts unverified — clear stale signals
           // from a prior attempt so the UI gate in ConnectionStatusDisplay shows
@@ -949,12 +1010,14 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       // Reset CoreAPI to clear any pending requests for this connection
       CoreAPI.reset();
       connectionManager.removeDevice(deviceAddress);
+      setCurrentClient(null);
       setConnectionState(ConnectionState.DISCONNECTED);
     };
   }, [
     targetDeviceAddress,
     setConnectionState,
     setConnectionError,
+    setCurrentClient,
     setEncryptionState,
     setPairingRequired,
     setDeviceHistory,
@@ -1076,7 +1139,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         isOpen={pairingOpen}
         close={() => setPairingOpen(false)}
         address={targetDeviceAddress}
-        onSuccess={() => connectionManager.immediateReconnectActive()}
+        onSuccess={() => connectionManager.restartActiveConnection()}
       />
     </ConnectionContext.Provider>
   );

--- a/src/components/DeviceConnectionCard.tsx
+++ b/src/components/DeviceConnectionCard.tsx
@@ -37,7 +37,6 @@ export function DeviceConnectionCard({
   const coreVersionPending = useStatusStore(
     (state) => state.coreVersionPending,
   );
-  const pairingRequired = useStatusStore((state) => state.pairingRequired);
   const deviceHistory = useStatusStore((state) => state.deviceHistory);
 
   const savedKey = savedAddress ? normalizeDeviceKey(savedAddress) : "";
@@ -84,14 +83,12 @@ export function DeviceConnectionCard({
             connectedName={currentEntry?.name}
             action={
               <div className="flex items-center gap-1">
-                {pairingRequired && (
-                  <Button
-                    icon={<KeyRoundIcon size="24" />}
-                    variant="text"
-                    onClick={openPairingModal}
-                    aria-label={t("pairing.openPairing")}
-                  />
-                )}
+                <Button
+                  icon={<KeyRoundIcon size="24" />}
+                  variant="text"
+                  onClick={openPairingModal}
+                  aria-label={t("pairing.openPairing")}
+                />
                 {/* Network scan button - only on native platforms */}
                 {Capacitor.isNativePlatform() && onScanClick && (
                   <Button

--- a/src/hooks/useClientCapability.ts
+++ b/src/hooks/useClientCapability.ts
@@ -1,0 +1,10 @@
+import { ClientCapability } from "@/lib/models";
+import { useStatusStore } from "@/lib/store";
+
+export function useClientCapability(capability: ClientCapability): boolean {
+  return useStatusStore(
+    (state) =>
+      state.connected &&
+      (state.currentClient?.capabilities.includes(capability) ?? false),
+  );
+}

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -7,6 +7,7 @@ import {
   AddMappingRequest,
   AllMappingsParams,
   AllMappingsResponse,
+  ClientsCurrentResponse,
   DeleteInboxRequest,
   HistoryResponse,
   InboxResponse,
@@ -832,6 +833,12 @@ class CoreApi {
           reject(error);
         });
     });
+  }
+
+  clientsCurrent(): Promise<ClientsCurrentResponse> {
+    return this.call(Method.ClientsCurrent).then(
+      (result) => result as ClientsCurrentResponse,
+    );
   }
 
   run(params: LaunchRequest): Promise<void> {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -34,6 +34,7 @@ export enum Method {
   Inbox = "inbox",
   InboxDelete = "inbox.delete",
   InboxClear = "inbox.clear",
+  ClientsCurrent = "clients.current",
   Scrapers = "scrapers",
   MediaScrape = "media.scrape",
   MediaScrapeStatus = "media.scrape.status",
@@ -65,6 +66,19 @@ export enum Notification {
 export interface VersionResponse {
   version: string;
   platform: string;
+}
+
+export type ClientRole = "admin" | "member";
+
+export enum ClientCapability {
+  ProfilesManage = "profiles.manage",
+  SettingsWrite = "settings.write",
+}
+
+export interface ClientsCurrentResponse {
+  paired: boolean;
+  role: ClientRole | null;
+  capabilities: string[];
 }
 
 export interface LaunchRequest {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -4,6 +4,7 @@ import { Preferences } from "@capacitor/preferences";
 import { credentialStore, normalizeDeviceKey } from "@/lib/crypto/credentials";
 import { logger } from "@/lib/logger";
 import {
+  ClientsCurrentResponse,
   IndexResponse,
   InboxMessage,
   PlayingResponse,
@@ -133,6 +134,9 @@ interface StatusState {
   setCorePlatform: (platform: string | null) => void;
   coreVersionPending: boolean;
   setCoreVersionPending: (pending: boolean) => void;
+
+  currentClient: ClientsCurrentResponse | null;
+  setCurrentClient: (client: ClientsCurrentResponse | null) => void;
 
   encryptionState: EncryptionState;
   setEncryptionState: (state: EncryptionState) => void;
@@ -381,6 +385,9 @@ export const useStatusStore = create<StatusState>()((set) => ({
   coreVersionPending: false,
   setCoreVersionPending: (pending) => set({ coreVersionPending: pending }),
 
+  currentClient: null,
+  setCurrentClient: (client) => set({ currentClient: client }),
+
   encryptionState: "unknown",
   setEncryptionState: (state) => set({ encryptionState: state }),
 
@@ -435,6 +442,7 @@ export const useStatusStore = create<StatusState>()((set) => ({
       coreVersion: null,
       corePlatform: null,
       coreVersionPending: false,
+      currentClient: null,
       encryptionState: "unknown",
       pairingRequired: false,
       inboxMessages: [],

--- a/src/lib/transport/ConnectionManager.ts
+++ b/src/lib/transport/ConnectionManager.ts
@@ -316,9 +316,25 @@ export class ConnectionManager {
   }
 
   /**
+   * Replace the active device's socket, even when it is currently connected.
+   * Used after pairing so an optional plaintext connection immediately reloads
+   * the newly stored credentials. While paused, disconnect now and let
+   * resumeAll() open the replacement socket in the foreground.
+   */
+  restartActiveConnection(): void {
+    const transport = this.getActiveTransport();
+    if (!transport) return;
+
+    transport.disconnect();
+    if (!this.isPaused) {
+      transport.immediateReconnect();
+    }
+  }
+
+  /**
    * Clear the encryption-blocked state on the active device. Call this after
-   * resolving the encryption issue (e.g. successful pairing) before invoking
-   * immediateReconnectActive() so the reconnect actually proceeds.
+   * resolving the encryption issue (e.g. successful pairing) before restarting
+   * the connection so the reconnect actually proceeds.
    */
   clearEncryptionBlockActive(): void {
     this.getActiveTransport()?.clearEncryptionBlock();

--- a/src/routes/settings.advanced.tsx
+++ b/src/routes/settings.advanced.tsx
@@ -16,8 +16,10 @@ import { BackIcon, NextIcon } from "@/lib/images";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { RestorePuchasesButton } from "@/components/ProPurchase";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
+import { useClientCapability } from "@/hooks/useClientCapability";
 import { SlideModal } from "@/components/SlideModal";
 import { Button } from "@/components/wui/Button";
+import { ClientCapability } from "@/lib/models";
 
 export const Route = createFileRoute("/settings/advanced")({
   component: AdvancedSettings,
@@ -28,6 +30,9 @@ export function AdvancedSettings() {
   usePageHeadingFocus(t("settings.advanced.title"));
   const connected = useStatusStore((state) => state.connected);
   const connectionState = useStatusStore((state) => state.connectionState);
+  const canWriteCoreSettings = useClientCapability(
+    ClientCapability.SettingsWrite,
+  );
   const showFilenames = usePreferencesStore((s) => s.showFilenames);
   const setShowFilenames = usePreferencesStore((s) => s.setShowFilenames);
 
@@ -50,6 +55,7 @@ export function AdvancedSettings() {
   });
 
   const handleErrorReportingToggle = (value: boolean) => {
+    if (!canWriteCoreSettings) return;
     if (value) {
       setShowErrorReportingModal(true);
     } else {
@@ -58,6 +64,7 @@ export function AdvancedSettings() {
   };
 
   const confirmEnableErrorReporting = () => {
+    if (!canWriteCoreSettings) return;
     update.mutate({ errorReporting: true });
     setShowErrorReportingModal(false);
   };
@@ -101,7 +108,7 @@ export function AdvancedSettings() {
           }
           value={data?.errorReporting ?? false}
           setValue={handleErrorReportingToggle}
-          disabled={!connected}
+          disabled={!canWriteCoreSettings}
           loading={isLoading}
         />
 
@@ -117,7 +124,7 @@ export function AdvancedSettings() {
           }
           value={data?.debugLogging ?? false}
           setValue={(v) => update.mutate({ debugLogging: v })}
-          disabled={!connected}
+          disabled={!canWriteCoreSettings}
           loading={isLoading}
         />
 
@@ -176,6 +183,7 @@ export function AdvancedSettings() {
               label={t("yes")}
               intent="primary"
               onClick={confirmEnableErrorReporting}
+              disabled={!canWriteCoreSettings}
             />
           </div>
         </div>

--- a/src/routes/settings.play-controls.tsx
+++ b/src/routes/settings.play-controls.tsx
@@ -20,7 +20,8 @@ import {
   parseDuration,
 } from "@/lib/utils";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
-import { type UpdateSettingsRequest } from "@/lib/models";
+import { useClientCapability } from "@/hooks/useClientCapability";
+import { ClientCapability, type UpdateSettingsRequest } from "@/lib/models";
 
 export const Route = createFileRoute("/settings/play-controls")({
   component: PlayControlsSettings,
@@ -31,6 +32,9 @@ export function PlayControlsSettings() {
   usePageHeadingFocus(t("settings.playControls.title"));
   const connected = useStatusStore((state) => state.connected);
   const connectionState = useStatusStore((state) => state.connectionState);
+  const canWriteCoreSettings = useClientCapability(
+    ClientCapability.SettingsWrite,
+  );
 
   const isConnecting =
     connectionState === ConnectionState.CONNECTING ||
@@ -134,7 +138,7 @@ export function PlayControlsSettings() {
   }, [coreSettings]);
 
   useEffect(() => {
-    if (!limitsConfig) return;
+    if (!limitsConfig || !canWriteCoreSettings) return;
 
     if (dailyTimeoutRef.current) {
       clearTimeout(dailyTimeoutRef.current);
@@ -158,10 +162,10 @@ export function PlayControlsSettings() {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dailyHours, dailyMinutes]);
+  }, [dailyHours, dailyMinutes, canWriteCoreSettings]);
 
   useEffect(() => {
-    if (!limitsConfig) return;
+    if (!limitsConfig || !canWriteCoreSettings) return;
 
     if (sessionTimeoutRef.current) {
       clearTimeout(sessionTimeoutRef.current);
@@ -185,10 +189,10 @@ export function PlayControlsSettings() {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionHours, sessionMinutes]);
+  }, [sessionHours, sessionMinutes, canWriteCoreSettings]);
 
   useEffect(() => {
-    if (!limitsConfig) return;
+    if (!limitsConfig || !canWriteCoreSettings) return;
 
     if (resetTimeoutRef.current) {
       clearTimeout(resetTimeoutRef.current);
@@ -216,10 +220,10 @@ export function PlayControlsSettings() {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resetMinutes]);
+  }, [resetMinutes, canWriteCoreSettings]);
 
   useEffect(() => {
-    if (!coreSettings) return;
+    if (!coreSettings || !canWriteCoreSettings) return;
 
     const timeout = parseFloat(launchGuardTimeout) || 0;
     if (timeout === (coreSettings.launchGuardTimeout ?? 15)) return;
@@ -238,10 +242,10 @@ export function PlayControlsSettings() {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [launchGuardTimeout]);
+  }, [launchGuardTimeout, canWriteCoreSettings]);
 
   useEffect(() => {
-    if (!coreSettings) return;
+    if (!coreSettings || !canWriteCoreSettings) return;
 
     const delay = parseFloat(launchGuardDelay) || 0;
     if (delay === (coreSettings.launchGuardDelay ?? 0)) return;
@@ -260,10 +264,12 @@ export function PlayControlsSettings() {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [launchGuardDelay]);
+  }, [launchGuardDelay, canWriteCoreSettings]);
 
   const handleEnabledToggle = (enabled: boolean) => {
-    updateMutation.mutate({ enabled });
+    if (canWriteCoreSettings) {
+      updateMutation.mutate({ enabled });
+    }
   };
 
   const launchGuardEnabled = coreSettings?.launchGuardEnabled ?? false;
@@ -326,7 +332,7 @@ export function PlayControlsSettings() {
             }
             value={limitsConfig?.enabled ?? false}
             setValue={handleEnabledToggle}
-            disabled={!connected}
+            disabled={!canWriteCoreSettings}
             loading={isConnecting || (connected && isPending)}
           />
 
@@ -465,7 +471,7 @@ export function PlayControlsSettings() {
                   value={dailyHours}
                   setValue={setDailyHours}
                   label={t("settings.core.playtime.hours")}
-                  disabled={!connected || !limitsConfig?.enabled}
+                  disabled={!canWriteCoreSettings || !limitsConfig?.enabled}
                 />
                 <TextInput
                   type="number"
@@ -473,7 +479,7 @@ export function PlayControlsSettings() {
                   value={dailyMinutes}
                   setValue={setDailyMinutes}
                   label={t("settings.core.playtime.minutes")}
-                  disabled={!connected || !limitsConfig?.enabled}
+                  disabled={!canWriteCoreSettings || !limitsConfig?.enabled}
                 />
               </div>
             </div>
@@ -489,7 +495,7 @@ export function PlayControlsSettings() {
                   value={sessionHours}
                   setValue={setSessionHours}
                   label={t("settings.core.playtime.hours")}
-                  disabled={!connected || !limitsConfig?.enabled}
+                  disabled={!canWriteCoreSettings || !limitsConfig?.enabled}
                 />
                 <TextInput
                   type="number"
@@ -497,7 +503,7 @@ export function PlayControlsSettings() {
                   value={sessionMinutes}
                   setValue={setSessionMinutes}
                   label={t("settings.core.playtime.minutes")}
-                  disabled={!connected || !limitsConfig?.enabled}
+                  disabled={!canWriteCoreSettings || !limitsConfig?.enabled}
                 />
               </div>
             </div>
@@ -513,7 +519,7 @@ export function PlayControlsSettings() {
                   value={resetMinutes}
                   setValue={setResetMinutes}
                   label={t("settings.core.playtime.minutes")}
-                  disabled={!connected || !limitsConfig?.enabled}
+                  disabled={!canWriteCoreSettings || !limitsConfig?.enabled}
                   className="max-w-[calc(50%-0.25rem)]"
                 />
               </div>
@@ -543,7 +549,7 @@ export function PlayControlsSettings() {
             setValue={(launchGuardEnabled) => {
               updateCoreSetting.mutate({ launchGuardEnabled });
             }}
-            disabled={!connected}
+            disabled={!canWriteCoreSettings}
             loading={isConnecting || (connected && !coreSettings)}
           />
 
@@ -563,7 +569,7 @@ export function PlayControlsSettings() {
             setValue={(launchGuardRequireConfirm) => {
               updateCoreSetting.mutate({ launchGuardRequireConfirm });
             }}
-            disabled={!connected || !launchGuardEnabled}
+            disabled={!canWriteCoreSettings || !launchGuardEnabled}
             loading={isConnecting || (connected && !coreSettings)}
           />
 
@@ -579,7 +585,7 @@ export function PlayControlsSettings() {
                   value={launchGuardTimeout}
                   setValue={setLaunchGuardTimeout}
                   label={t("settings.core.launchGuard.seconds")}
-                  disabled={!connected || !launchGuardEnabled}
+                  disabled={!canWriteCoreSettings || !launchGuardEnabled}
                   className="max-w-[calc(50%-0.25rem)]"
                 />
               </div>
@@ -596,7 +602,7 @@ export function PlayControlsSettings() {
                   value={launchGuardDelay}
                   setValue={setLaunchGuardDelay}
                   label={t("settings.core.launchGuard.seconds")}
-                  disabled={!connected || !launchGuardEnabled}
+                  disabled={!canWriteCoreSettings || !launchGuardEnabled}
                   className="max-w-[calc(50%-0.25rem)]"
                 />
               </div>

--- a/src/routes/settings.readers.tsx
+++ b/src/routes/settings.readers.tsx
@@ -25,8 +25,9 @@ import { useProPurchase } from "@/components/ProPurchase";
 import { ProBadge } from "@/components/ProBadge";
 import { ZapScriptInput } from "@/components/ZapScriptInput";
 import { CoreAPI } from "@/lib/coreApi";
-import { UpdateSettingsRequest } from "@/lib/models.ts";
+import { ClientCapability, UpdateSettingsRequest } from "@/lib/models.ts";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
+import { useClientCapability } from "@/hooks/useClientCapability";
 
 export const Route = createFileRoute("/settings/readers")({
   component: ReadersSettings,
@@ -37,6 +38,9 @@ export function ReadersSettings() {
   usePageHeadingFocus(t("settings.readers.title"));
   const connected = useStatusStore((state) => state.connected);
   const connectionState = useStatusStore((state) => state.connectionState);
+  const canWriteCoreSettings = useClientCapability(
+    ClientCapability.SettingsWrite,
+  );
   const [systemPickerOpen, setSystemPickerOpen] = useState(false);
 
   // Determine if we're in a loading state (connecting or reconnecting)
@@ -227,7 +231,7 @@ export function ReadersSettings() {
                 onClick={() =>
                   updateCoreSetting.mutate({ readersScanMode: "tap" })
                 }
-                disabled={!connected}
+                disabled={!canWriteCoreSettings}
               >
                 {coreSettings?.readersScanMode === "tap" && connected && (
                   <span aria-hidden="true">
@@ -270,7 +274,7 @@ export function ReadersSettings() {
                 onClick={() =>
                   updateCoreSetting.mutate({ readersScanMode: "hold" })
                 }
-                disabled={!connected}
+                disabled={!canWriteCoreSettings}
               >
                 {coreSettings?.readersScanMode === "hold" && connected && (
                   <span aria-hidden="true">
@@ -496,7 +500,7 @@ export function ReadersSettings() {
           }
           value={coreSettings?.audioScanFeedback ?? false}
           setValue={(v) => updateCoreSetting.mutate({ audioScanFeedback: v })}
-          disabled={!connected}
+          disabled={!canWriteCoreSettings}
           loading={isLoading}
         />
 
@@ -513,7 +517,7 @@ export function ReadersSettings() {
           }
           value={coreSettings?.readersAutoDetect ?? false}
           setValue={(v) => updateCoreSetting.mutate({ readersAutoDetect: v })}
-          disabled={!connected}
+          disabled={!canWriteCoreSettings}
           loading={isLoading}
         />
       </div>


### PR DESCRIPTION
## Summary

- always expose manual pairing and replace the active socket after pairing so saved encryption credentials take effect immediately
- hydrate role and effective capabilities from Core `clients.current`, with legacy access for pre-2.16 Core versions
- disable Core-backed settings writes when the current client lacks `settings.write` while preserving App-local controls

Closes #185
Closes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client capability detection to determine available settings permissions.
  * Restricted core settings controls to clients with the required write capability.
  * Added client pairing details and refreshed connection state after successful pairing.
  * Pairing can now be opened manually at any time from the device connection card.
  * Improved compatibility with older Core versions.

* **Bug Fixes**
  * Cleared stale client information during reconnects, device changes, and connection resets.
  * Prevented unauthorized settings updates from being submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->