### PR TITLE
fix: redact sensitive values from logs

### DIFF
--- a/src/__tests__/unit/lib/coreApi.test.ts
+++ b/src/__tests__/unit/lib/coreApi.test.ts
@@ -10,7 +10,7 @@ import {
   isUnsupportedMediaApiError,
 } from "@/lib/coreApi";
 import { Capacitor } from "@capacitor/core";
-import { Notification } from "@/lib/models.ts";
+import { Method, Notification } from "@/lib/models.ts";
 
 // Mock Capacitor
 vi.mock("@capacitor/core");
@@ -128,6 +128,44 @@ describe("CoreAPI", () => {
     expect(sentData.method).toBe("version");
     expect(sentData.id).toBeDefined();
     expect(sentData.timestamp).toBeDefined();
+  });
+
+  it("should log request metadata without JSON-RPC params", () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    CoreAPI.call(Method.Run, { text: "plain-private-request-value" }).catch(
+      () => {},
+    );
+
+    const logCall = debugSpy.mock.calls.find(
+      ([message]) => message === "Sending request",
+    );
+    expect(logCall).toBeDefined();
+    expect(logCall?.[1]).toEqual(
+      expect.objectContaining({ method: Method.Run }),
+    );
+    expect(logCall?.[1]).not.toHaveProperty("params");
+    expect(JSON.stringify(logCall)).not.toContain(
+      "plain-private-request-value",
+    );
+
+    debugSpy.mockRestore();
+  });
+
+  it("should log tracked request metadata without JSON-RPC params", () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    CoreAPI.write({ text: "plain-private-write-value" }).catch(() => {});
+
+    const logCall = debugSpy.mock.calls.find(
+      ([message]) => message === "Sending tracked request",
+    );
+    expect(logCall).toBeDefined();
+    expect(logCall?.[1]).toEqual(
+      expect.objectContaining({ method: Method.ReadersWrite }),
+    );
+    expect(logCall?.[1]).not.toHaveProperty("params");
+    expect(JSON.stringify(logCall)).not.toContain("plain-private-write-value");
+
+    debugSpy.mockRestore();
   });
 
   it("should timeout requests after 30 seconds", async () => {

--- a/src/__tests__/unit/lib/logger.test.ts
+++ b/src/__tests__/unit/lib/logger.test.ts
@@ -236,6 +236,30 @@ describe("Logger Rate Limiting", () => {
     expect(output).not.toContain("ABCD1234");
   });
 
+  it("should redact API keys and verification URLs in embedded JSON", () => {
+    const sanitized = sanitizeLogValue(
+      '{"apiKey":"camel-secret","API_KEY":"upper-secret","api-key":"hyphen-secret","verification_url_complete":"snake-secret","VerificationUrlComplete":"camel-verification-secret","safe":"kept"}',
+    );
+
+    expect(sanitized).toBe(
+      '{"apiKey":"[REDACTED]","API_KEY":"[REDACTED]","api-key":"[REDACTED]","verification_url_complete":"[REDACTED]","VerificationUrlComplete":"[REDACTED]","safe":"kept"}',
+    );
+  });
+
+  it("should sanitize shared objects on each branch and mark cycles", () => {
+    const shared = { token: "shared-secret", safe: "kept" };
+    const cyclic: Record<string, unknown> = { safe: "kept" };
+    cyclic.self = cyclic;
+
+    expect(sanitizeLogValue({ first: shared, second: shared, cyclic })).toEqual(
+      {
+        first: { token: "[REDACTED]", safe: "kept" },
+        second: { token: "[REDACTED]", safe: "kept" },
+        cyclic: { safe: "kept", self: "[Circular]" },
+      },
+    );
+  });
+
   it("should strip Axios error config before console and Rollbar logging", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const axiosError = Object.assign(

--- a/src/__tests__/unit/lib/logger.test.ts
+++ b/src/__tests__/unit/lib/logger.test.ts
@@ -59,6 +59,7 @@ const PAST_THROTTLE_WINDOW_MS = THROTTLE_WINDOW_MS + 1_000;
 describe("Logger Rate Limiting", () => {
   let logger: typeof import("../../../lib/logger").logger;
   let rollbarPromise: typeof import("../../../lib/logger").rollbarPromise;
+  let sanitizeLogValue: typeof import("../../../lib/logger").sanitizeLogValue;
 
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -69,6 +70,7 @@ describe("Logger Rate Limiting", () => {
 
     logger = loggerModule.logger;
     rollbarPromise = loggerModule.rollbarPromise;
+    sanitizeLogValue = loggerModule.sanitizeLogValue;
 
     // Wait for rollbar to be loaded
     await rollbarPromise;
@@ -212,5 +214,72 @@ describe("Logger Rate Limiting", () => {
         action: "test",
       }),
     );
+  });
+
+  it("should redact auth secrets from nested log values and strings", () => {
+    const sanitized = sanitizeLogValue({
+      headers: { Authorization: "Bearer firebase-secret" },
+      token: "zpc1_claim-secret",
+      nested: {
+        device_code: "device-secret",
+        safe: "kept",
+      },
+      payload:
+        '{"token":"zpd1_device-secret","url":"https://example.com/link?code=ABCD1234"}',
+    });
+    const output = JSON.stringify(sanitized);
+
+    expect(output).toContain("kept");
+    expect(output).not.toContain("firebase-secret");
+    expect(output).not.toContain("zpc1_claim-secret");
+    expect(output).not.toContain("zpd1_device-secret");
+    expect(output).not.toContain("ABCD1234");
+  });
+
+  it("should strip Axios error config before console and Rollbar logging", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const axiosError = Object.assign(
+      new Error("Claim failed for zpc1_claim-secret"),
+      {
+        name: "AxiosError",
+        code: "ERR_BAD_REQUEST",
+        config: {
+          headers: { Authorization: "Bearer firebase-secret" },
+          data: { token: "zpc1_claim-secret" },
+        },
+        response: { data: { bearer: "zpd1_device-secret" } },
+      },
+    );
+
+    logger.error("Device claim failed", axiosError, {
+      category: "api",
+      action: "claim-redaction-test",
+      idToken: "eyJhbGciOi.payload.signature",
+    });
+
+    const [, safeConsoleError, safeConsoleMetadata] =
+      consoleSpy.mock.calls.at(-1) ?? [];
+    expect(safeConsoleError).toBeInstanceOf(Error);
+    expect(safeConsoleError).not.toBe(axiosError);
+    expect((safeConsoleError as Error).message).not.toContain(
+      "zpc1_claim-secret",
+    );
+    expect(Reflect.has(safeConsoleError as object, "config")).toBe(false);
+    expect(safeConsoleMetadata).toEqual(
+      expect.objectContaining({ idToken: "[REDACTED]" }),
+    );
+
+    const [safeRollbarError, safeRollbarMetadata] =
+      mockRollbar.error.mock.calls.at(-1) ?? [];
+    expect(safeRollbarError).toBeInstanceOf(Error);
+    expect((safeRollbarError as Error).message).not.toContain(
+      "zpc1_claim-secret",
+    );
+    expect(Reflect.has(safeRollbarError as object, "config")).toBe(false);
+    expect(safeRollbarMetadata).toEqual(
+      expect.objectContaining({ idToken: "[REDACTED]" }),
+    );
+
+    consoleSpy.mockRestore();
   });
 });

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -491,7 +491,7 @@ class CoreApi {
       if (this.transport?.isConnected) {
         // Connection is open, send immediately
         const payload = JSON.stringify(req);
-        logger.debug("Sending request", payload);
+        logger.debug("Sending request", { id, method });
 
         let poolEntry: ResponsePromise | undefined;
         const promise = new Promise<unknown>((resolve, reject) => {
@@ -611,7 +611,7 @@ class CoreApi {
       };
 
       const payload = JSON.stringify(req);
-      logger.debug("Sending tracked request", payload);
+      logger.debug("Sending tracked request", { id, method });
 
       // Check if already aborted
       if (signal?.aborted) {
@@ -652,8 +652,6 @@ class CoreApi {
 
         signal.addEventListener("abort", abortHandler, { once: true });
       }
-
-      logger.debug(payload);
 
       // Add safe send
       try {
@@ -750,9 +748,9 @@ class CoreApi {
         }
 
         if (!res.id) {
-          logger.log("Received notification", res);
           try {
             const req = res as ApiRequest;
+            logger.log("Received notification", { method: req.method });
             resolve({
               method: req.method as Notification,
               params: req.params,
@@ -770,7 +768,11 @@ class CoreApi {
 
         const promise = this.responsePool[res.id];
         if (!promise) {
-          logger.log("Response ID does not exist:", msg.data);
+          logger.log("Response ID does not exist", {
+            id: res.id,
+            hasError: res.error !== undefined,
+            dataLength: rawData.length,
+          });
           resolve(null); // Changed from reject(null) to resolve(null) to prevent unhandled rejection
           return;
         }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -50,7 +50,7 @@ function redactSensitiveString(value: string): string {
     .replace(/\b(?:zpc1|zpd1|zpk1)_[A-Za-z0-9._~-]+\b/g, REDACTED)
     .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, REDACTED)
     .replace(
-      /"([^"]*(?:token|password|secret|authorization|credential|device[_-]?code|user[_-]?code|bearer)[^"]*)"\s*:\s*"[^"]*"/gi,
+      /"([^"]*(?:token|password|secret|authorization|credential|device[_-]?code|user[_-]?code|bearer)[^"]*|api[^a-z0-9"]*key|verification[^a-z0-9"]*url[^a-z0-9"]*complete)"\s*:\s*"[^"]*"/gi,
       (_match, key: string) => `"${key}":"${REDACTED}"`,
     )
     .replace(
@@ -96,17 +96,21 @@ export function sanitizeLogValue(
   if (seen.has(value)) return "[Circular]";
 
   seen.add(value);
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeLogValue(item, seen, depth + 1));
-  }
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => sanitizeLogValue(item, seen, depth + 1));
+    }
 
-  const result: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value)) {
-    result[key] = isSensitiveLogKey(key)
-      ? REDACTED
-      : sanitizeLogValue(item, seen, depth + 1);
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      result[key] = isSensitiveLogKey(key)
+        ? REDACTED
+        : sanitizeLogValue(item, seen, depth + 1);
+    }
+    return result;
+  } finally {
+    seen.delete(value);
   }
-  return result;
 }
 
 function sanitizeLogArgs(args: unknown[]): unknown[] {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -25,6 +25,93 @@ const rollbarPromise = isRollbarEnabled
   : Promise.resolve(null);
 
 const isDev = import.meta.env.DEV;
+const REDACTED = "[REDACTED]";
+const MAX_LOG_VALUE_DEPTH = 6;
+
+function isSensitiveLogKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return (
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("authorization") ||
+    normalized.includes("credential") ||
+    normalized === "bearer" ||
+    normalized === "apikey" ||
+    normalized === "devicecode" ||
+    normalized === "usercode" ||
+    normalized === "verificationurlcomplete"
+  );
+}
+
+function redactSensitiveString(value: string): string {
+  return value
+    .replace(/\bBearer\s+[^\s"',;}]+/gi, `Bearer ${REDACTED}`)
+    .replace(/\b(?:zpc1|zpd1|zpk1)_[A-Za-z0-9._~-]+\b/g, REDACTED)
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, REDACTED)
+    .replace(
+      /"([^"]*(?:token|password|secret|authorization|credential|device[_-]?code|user[_-]?code|bearer)[^"]*)"\s*:\s*"[^"]*"/gi,
+      (_match, key: string) => `"${key}":"${REDACTED}"`,
+    )
+    .replace(
+      /([?&](?:access_token|refresh_token|id_token|token|device_code|user_code|code|secret)=)[^&#\s]+/gi,
+      `$1${REDACTED}`,
+    )
+    .replace(/:\/\/([^:/@\s]+):([^@\s]+)@/g, `://$1:${REDACTED}@`);
+}
+
+function sanitizeError(error: Error): Error {
+  const safeError = new Error(redactSensitiveString(error.message));
+  safeError.name = error.name;
+  if (error.stack) {
+    safeError.stack = redactSensitiveString(error.stack);
+  }
+
+  const code = Reflect.get(error, "code");
+  if (typeof code === "string" || typeof code === "number") {
+    Reflect.set(safeError, "code", code);
+  }
+  return safeError;
+}
+
+export function sanitizeLogValue(
+  value: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): unknown {
+  if (typeof value === "string") return redactSensitiveString(value);
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return value;
+  }
+  if (value instanceof Error) return sanitizeError(value);
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value !== "object") return String(value);
+  if (depth >= MAX_LOG_VALUE_DEPTH) return "[Object]";
+  if (seen.has(value)) return "[Circular]";
+
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeLogValue(item, seen, depth + 1));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    result[key] = isSensitiveLogKey(key)
+      ? REDACTED
+      : sanitizeLogValue(item, seen, depth + 1);
+  }
+  return result;
+}
+
+function sanitizeLogArgs(args: unknown[]): unknown[] {
+  return args.map((arg) => sanitizeLogValue(arg));
+}
 
 /**
  * Rate limiting for Rollbar error reporting.
@@ -162,17 +249,17 @@ function isErrorMetadata(arg: unknown): arg is ErrorMetadata {
 export const logger = {
   /** Log general information (dev only) */
   log: (...args: unknown[]): void => {
-    if (isDev) console.log(...args);
+    if (isDev) console.log(...sanitizeLogArgs(args));
   },
 
   /** Log debug information (dev only) */
   debug: (...args: unknown[]): void => {
-    if (isDev) console.debug(...args);
+    if (isDev) console.debug(...sanitizeLogArgs(args));
   },
 
   /** Log warnings (dev only) */
   warn: (...args: unknown[]): void => {
-    if (isDev) console.warn(...args);
+    if (isDev) console.warn(...sanitizeLogArgs(args));
   },
 
   /**
@@ -185,7 +272,7 @@ export const logger = {
    * logger.error("Something failed"); // basic usage still works
    */
   error: (...args: unknown[]): void => {
-    console.error(...args);
+    console.error(...sanitizeLogArgs(args));
 
     // Only report to Rollbar on native platforms in production
     if (!isRollbarEnabled) return;
@@ -193,13 +280,19 @@ export const logger = {
     // Check if last argument is metadata
     const lastArg = args[args.length - 1];
     const metadata = isErrorMetadata(lastArg) ? lastArg : undefined;
+    const safeMetadata = metadata
+      ? (sanitizeLogValue(metadata) as ErrorMetadata)
+      : undefined;
     const logArgs = metadata ? args.slice(0, -1) : args;
 
     // Find error object in args
     const error = logArgs.find((a): a is Error => a instanceof Error);
+    const safeError = error ? sanitizeError(error) : undefined;
 
-    // Build message from non-error args
-    const messageArgs = logArgs.filter((a) => !(a instanceof Error));
+    // Build message from sanitized non-error args
+    const messageArgs = logArgs
+      .filter((a) => !(a instanceof Error))
+      .map((a) => sanitizeLogValue(a));
     const message =
       messageArgs.length > 0
         ? messageArgs
@@ -208,30 +301,30 @@ export const logger = {
         : undefined;
 
     // Rate limit: create fingerprint from category + action + message
-    const fingerprint = `${metadata?.category || "general"}:${metadata?.action || "unknown"}:${error?.message || message || ""}`;
+    const fingerprint = `${safeMetadata?.category || "general"}:${safeMetadata?.action || "unknown"}:${safeError?.message || message || ""}`;
     if (!shouldReportError(fingerprint)) {
       return;
     }
 
     // Prepare custom data for Rollbar (include base context, exclude severity)
     const customData: Record<string, unknown> = buildBaseContext();
-    if (metadata) {
+    if (safeMetadata) {
       // Copy all metadata except severity (which is used for method selection)
-      for (const [key, value] of Object.entries(metadata)) {
+      for (const [key, value] of Object.entries(safeMetadata)) {
         if (key !== "severity") {
           customData[key] = value;
         }
       }
     }
-    if (message && error) {
+    if (message && safeError) {
       customData.message = message;
     }
 
-    // Use error if available, otherwise create one from message
-    const errorToReport = error || new Error(message || "Unknown error");
+    // Use sanitized error if available, otherwise create one from sanitized message
+    const errorToReport = safeError || new Error(message || "Unknown error");
 
     // Report with appropriate severity (always include customData with base context)
-    const severity = metadata?.severity || "error";
+    const severity = safeMetadata?.severity || "error";
     const rollbar = rollbarModule?.rollbar;
     if (!rollbar) return;
 

--- a/src/lib/onlineApi.ts
+++ b/src/lib/onlineApi.ts
@@ -2,6 +2,7 @@ import axios, { type InternalAxiosRequestConfig } from "axios";
 import { FirebaseAuthentication } from "@capacitor-firebase/authentication";
 import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import { useStatusStore } from "@/lib/store";
+import { logger } from "@/lib/logger";
 import type {
   RequirementsResponse,
   UpdateRequirementsRequest,
@@ -56,11 +57,18 @@ client.interceptors.response.use(
 
 if (import.meta.env.DEV) {
   client.interceptors.request.use((config) => {
-    console.log("Request", config);
+    logger.debug("Online API request", {
+      method: config.method,
+      url: config.url,
+    });
     return config;
   });
   client.interceptors.response.use((res) => {
-    console.log("Response", res);
+    logger.debug("Online API response", {
+      method: res.config.method,
+      url: res.config.url,
+      status: res.status,
+    });
     return res;
   });
 }


### PR DESCRIPTION
## Summary

- redact secrets, credentials, auth headers, and device-link codes from console and Rollbar logs
- log only safe request and response metadata for Core and Online API traffic
- add regression coverage for nested values, Axios errors, and JSON-RPC parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log privacy by redacting authentication secrets, tokens, credentials, sensitive URLs, and error details.
  - Prevented request, response, and notification payload contents from appearing in logs.
  - Added safeguards for deeply nested and circular log data.

- **Refactor**
  - Standardized API logging with structured metadata, including request methods, response statuses, and payload sizes.
  - Improved error reporting sanitization for console and Rollbar output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->