### PR TITLE
fix: preserve encrypted WebSocket notification order

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -1343,7 +1343,7 @@ describe("notification processing", () => {
 
     it("should reconcile until authoritative media status is terminal", async () => {
       vi.useFakeTimers();
-      vi.mocked(CoreAPI.processReceived).mockResolvedValueOnce({
+      const messagePromise = Promise.resolve<NotificationRequest>({
         method: Notification.MediaIndexing,
         params: {
           indexing: true,
@@ -1352,6 +1352,7 @@ describe("notification processing", () => {
           currentStepDisplay: "Finding media folders",
         },
       });
+      vi.mocked(CoreAPI.processReceived).mockReturnValueOnce(messagePromise);
       vi.mocked(CoreAPI.media)
         .mockResolvedValueOnce({
           database: {
@@ -1371,6 +1372,10 @@ describe("notification processing", () => {
           active: [],
         });
 
+      const invalidateSpy = vi.spyOn(
+        QueryClient.prototype,
+        "invalidateQueries",
+      );
       const view = render(
         <ConnectionProvider>
           <div>Test</div>
@@ -1383,35 +1388,45 @@ describe("notification processing", () => {
 
       try {
         await act(async () => {
-          await capturedEventHandlers.onMessage!("test-device", {});
-          await vi.advanceTimersByTimeAsync(0);
+          capturedEventHandlers.onMessage!("test-device", {});
+          await messagePromise;
         });
         expect(useStatusStore.getState().gamesIndex.indexing).toBe(true);
 
         await act(async () => {
-          await vi.advanceTimersByTimeAsync(2000);
+          await vi.advanceTimersToNextTimerAsync();
         });
         expect(CoreAPI.media).toHaveBeenCalledTimes(1);
         expect(useStatusStore.getState().gamesIndex).toMatchObject({
           indexing: true,
           currentStepDisplay: "Super Nintendo",
         });
+        invalidateSpy.mockClear();
 
         await act(async () => {
-          await vi.advanceTimersByTimeAsync(2000);
+          await vi.advanceTimersToNextTimerAsync();
         });
         expect(CoreAPI.media).toHaveBeenCalledTimes(2);
         expect(useStatusStore.getState().gamesIndex).toMatchObject({
           indexing: false,
           totalMedia: 150,
         });
-
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(4000);
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["media"] });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["systems"] });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["tags"] });
+        expect(invalidateSpy).toHaveBeenCalledWith({
+          queryKey: ["infiniteMediaSearch"],
         });
+
+        while (vi.getTimerCount() > 0) {
+          await act(async () => {
+            await vi.advanceTimersToNextTimerAsync();
+          });
+        }
         expect(CoreAPI.media).toHaveBeenCalledTimes(2);
       } finally {
         view.unmount();
+        invalidateSpy.mockRestore();
         vi.useRealTimers();
       }
     });

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -1340,6 +1340,81 @@ describe("notification processing", () => {
         });
       });
     });
+
+    it("should reconcile until authoritative media status is terminal", async () => {
+      vi.useFakeTimers();
+      vi.mocked(CoreAPI.processReceived).mockResolvedValueOnce({
+        method: Notification.MediaIndexing,
+        params: {
+          indexing: true,
+          optimizing: false,
+          exists: true,
+          currentStepDisplay: "Finding media folders",
+        },
+      });
+      vi.mocked(CoreAPI.media)
+        .mockResolvedValueOnce({
+          database: {
+            exists: true,
+            indexing: true,
+            currentStepDisplay: "Super Nintendo",
+          },
+          active: [],
+        })
+        .mockResolvedValueOnce({
+          database: {
+            exists: true,
+            indexing: false,
+            optimizing: false,
+            totalMedia: 150,
+          },
+          active: [],
+        });
+
+      const view = render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+      useStatusStore.setState({
+        connected: true,
+        connectionState: ConnectionState.CONNECTED,
+      });
+
+      try {
+        await act(async () => {
+          await capturedEventHandlers.onMessage!("test-device", {});
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(useStatusStore.getState().gamesIndex.indexing).toBe(true);
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2000);
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+        expect(useStatusStore.getState().gamesIndex).toMatchObject({
+          indexing: true,
+          currentStepDisplay: "Super Nintendo",
+        });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2000);
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(2);
+        expect(useStatusStore.getState().gamesIndex).toMatchObject({
+          indexing: false,
+          totalMedia: 150,
+        });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(4000);
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(2);
+      } finally {
+        view.unmount();
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("media.scraping", () => {

--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -12,11 +12,12 @@ import { act, render, screen, waitFor } from "../../../test-utils";
 import { ConnectionProvider } from "../../../components/ConnectionProvider";
 import { useConnection } from "../../../hooks/useConnection";
 import { connectionManager } from "../../../lib/transport";
-import { CoreAPI } from "../../../lib/coreApi";
+import { CoreAPI, isCancelled } from "../../../lib/coreApi";
 import { ConnectionState, useStatusStore } from "@/lib/store";
 import type { TransportState } from "../../../lib/transport/types";
 import type { NotificationRequest } from "../../../lib/coreApi";
 import { ClientCapability, InboxSeverity, Notification } from "@/lib/models";
+import { logger } from "@/lib/logger";
 
 // Capture event handlers for notification testing
 let capturedEventHandlers: {
@@ -1430,6 +1431,218 @@ describe("notification processing", () => {
         vi.useRealTimers();
       }
     });
+
+    it.each(["resolve", "reject"] as const)(
+      "should ignore stale reconciliation %s after a terminal notification",
+      async (outcome) => {
+        vi.useFakeTimers();
+        const progressPromise = Promise.resolve<NotificationRequest>({
+          method: Notification.MediaIndexing,
+          params: {
+            indexing: true,
+            optimizing: false,
+            exists: true,
+            currentStepDisplay: "Finding media folders",
+          },
+        });
+        const terminalPromise = Promise.resolve<NotificationRequest>({
+          method: Notification.MediaIndexing,
+          params: {
+            indexing: false,
+            optimizing: false,
+            exists: true,
+            totalMedia: 150,
+          },
+        });
+        vi.mocked(CoreAPI.processReceived)
+          .mockReturnValueOnce(progressPromise)
+          .mockReturnValueOnce(terminalPromise);
+
+        type MediaResponse = Awaited<ReturnType<typeof CoreAPI.media>>;
+        let resolveReconciliation!: (response: MediaResponse) => void;
+        let rejectReconciliation!: (error: Error) => void;
+        vi.mocked(CoreAPI.media).mockReturnValueOnce(
+          new Promise((resolve, reject) => {
+            resolveReconciliation = resolve;
+            rejectReconciliation = reject;
+          }),
+        );
+        const loggerSpy = vi
+          .spyOn(logger, "error")
+          .mockImplementation(() => {});
+
+        const view = render(
+          <ConnectionProvider>
+            <div>Test</div>
+          </ConnectionProvider>,
+        );
+        useStatusStore.setState({
+          connected: true,
+          connectionState: ConnectionState.CONNECTED,
+        });
+
+        try {
+          await act(async () => {
+            capturedEventHandlers.onMessage!("test-device", {});
+            await progressPromise;
+            await vi.advanceTimersToNextTimerAsync();
+          });
+          expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+
+          await act(async () => {
+            capturedEventHandlers.onMessage!("test-device", {});
+            await terminalPromise;
+          });
+          expect(useStatusStore.getState().gamesIndex.indexing).toBe(false);
+
+          await act(async () => {
+            if (outcome === "resolve") {
+              resolveReconciliation({
+                database: {
+                  exists: true,
+                  indexing: true,
+                  currentStepDisplay: "Stale progress",
+                },
+                active: [],
+              });
+            } else {
+              rejectReconciliation(new Error("Stale media status failure"));
+            }
+            await Promise.resolve();
+          });
+
+          expect(useStatusStore.getState().gamesIndex).toMatchObject({
+            indexing: false,
+            totalMedia: 150,
+          });
+          expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+          expect(loggerSpy).not.toHaveBeenCalled();
+          expect(vi.getTimerCount()).toBe(0);
+        } finally {
+          view.unmount();
+          loggerSpy.mockRestore();
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it("should skip reconciliation after connection loss", async () => {
+      vi.useFakeTimers();
+      const messagePromise = Promise.resolve<NotificationRequest>({
+        method: Notification.MediaIndexing,
+        params: {
+          indexing: true,
+          optimizing: false,
+          exists: true,
+        },
+      });
+      vi.mocked(CoreAPI.processReceived).mockReturnValueOnce(messagePromise);
+
+      const view = render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+      useStatusStore.setState({
+        connected: true,
+        connectionState: ConnectionState.CONNECTED,
+      });
+
+      try {
+        await act(async () => {
+          capturedEventHandlers.onMessage!("test-device", {});
+          await messagePromise;
+        });
+        useStatusStore.setState({
+          connected: false,
+          connectionState: ConnectionState.RECONNECTING,
+        });
+
+        await act(async () => {
+          await vi.advanceTimersToNextTimerAsync();
+        });
+
+        expect(CoreAPI.media).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        view.unmount();
+        vi.useRealTimers();
+      }
+    });
+
+    it("should retry reconciliation after cancelled and failed status attempts", async () => {
+      vi.useFakeTimers();
+      const messagePromise = Promise.resolve<NotificationRequest>({
+        method: Notification.MediaIndexing,
+        params: {
+          indexing: true,
+          optimizing: false,
+          exists: true,
+        },
+      });
+      vi.mocked(CoreAPI.processReceived).mockReturnValueOnce(messagePromise);
+      vi.mocked(isCancelled).mockReturnValueOnce(true);
+      vi.mocked(CoreAPI.media)
+        .mockResolvedValueOnce({
+          database: { exists: true, indexing: true },
+          active: [],
+        })
+        .mockRejectedValueOnce(new Error("Temporary media status failure"))
+        .mockResolvedValueOnce({
+          database: {
+            exists: true,
+            indexing: false,
+            optimizing: false,
+            totalMedia: 150,
+          },
+          active: [],
+        });
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      const view = render(
+        <ConnectionProvider>
+          <div>Test</div>
+        </ConnectionProvider>,
+      );
+      useStatusStore.setState({
+        connected: true,
+        connectionState: ConnectionState.CONNECTED,
+      });
+
+      try {
+        await act(async () => {
+          capturedEventHandlers.onMessage!("test-device", {});
+          await messagePromise;
+          await vi.advanceTimersToNextTimerAsync();
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+        expect(loggerSpy).not.toHaveBeenCalled();
+
+        await act(async () => {
+          await vi.advanceTimersToNextTimerAsync();
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(2);
+        expect(loggerSpy).toHaveBeenCalledWith(
+          "Failed to reconcile media indexing status",
+          expect.any(Error),
+          expect.objectContaining({ action: "media-index-reconcile" }),
+        );
+
+        await act(async () => {
+          await vi.advanceTimersToNextTimerAsync();
+        });
+        expect(CoreAPI.media).toHaveBeenCalledTimes(3);
+        expect(useStatusStore.getState().gamesIndex).toMatchObject({
+          indexing: false,
+          totalMedia: 150,
+        });
+      } finally {
+        view.unmount();
+        loggerSpy.mockRestore();
+        vi.mocked(isCancelled).mockReturnValue(false);
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("media.scraping", () => {
@@ -1618,6 +1831,62 @@ describe("connection event handling", () => {
       expect(useStatusStore.getState().corePlatform).toBe("test");
       expect(useStatusStore.getState().coreVersionPending).toBe(false);
     });
+  });
+
+  it("should reconcile indexing discovered during connection hydration", async () => {
+    vi.useFakeTimers();
+    vi.mocked(CoreAPI.media)
+      .mockReset()
+      .mockResolvedValueOnce({
+        database: {
+          exists: true,
+          indexing: true,
+          currentStepDisplay: "Finding media folders",
+        },
+        active: [],
+      })
+      .mockResolvedValueOnce({
+        database: {
+          exists: true,
+          indexing: false,
+          optimizing: false,
+          totalMedia: 150,
+        },
+        active: [],
+      });
+
+    const view = render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+
+    try {
+      await act(async () => {
+        capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+          state: "connected",
+          hasData: false,
+          hasConnectedBefore: false,
+        });
+        await Promise.resolve();
+      });
+
+      expect(CoreAPI.media).toHaveBeenCalledTimes(1);
+      expect(useStatusStore.getState().gamesIndex.indexing).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersToNextTimerAsync();
+      });
+
+      expect(CoreAPI.media).toHaveBeenCalledTimes(2);
+      expect(useStatusStore.getState().gamesIndex).toMatchObject({
+        indexing: false,
+        totalMedia: 150,
+      });
+    } finally {
+      view.unmount();
+      vi.useRealTimers();
+    }
   });
 
   it("should hydrate both media slots regardless of response order", async () => {

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
@@ -203,6 +203,51 @@ describe("WebSocketTransport encryption", () => {
       transport.destroy();
     });
 
+    it("should preserve arrival order while decrypting incoming frames", async () => {
+      let resolveFirst!: (plaintext: string) => void;
+      const decrypt = vi.fn((ciphertext: string): Promise<string> => {
+        if (ciphertext === "first-frame") {
+          return new Promise<string>((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        return Promise.resolve("second");
+      });
+      vi.mocked(EncryptedSession.create).mockResolvedValue({
+        ...makeMockSession(),
+        decrypt,
+      } as unknown as EncryptedSession);
+
+      const onMessage = vi.fn();
+      const transport = makeTransport();
+      transport.setEventHandlers({ onMessage });
+      transport.connect();
+
+      const ws = MockWebSocket.getLatest()!;
+      ws.simulateOpen();
+      await flushPromises();
+
+      ws.simulateMessage(JSON.stringify({ e: "first-frame" }));
+      ws.simulateMessage(JSON.stringify({ e: "second-frame" }));
+      await flushPromises();
+
+      expect(decrypt).toHaveBeenCalledTimes(1);
+      expect(onMessage).not.toHaveBeenCalled();
+
+      resolveFirst("first");
+      await flushPromises();
+
+      expect(decrypt).toHaveBeenCalledTimes(2);
+      expect(onMessage).toHaveBeenCalledTimes(2);
+      expect(
+        onMessage.mock.calls.map(
+          ([message]) => (message as MessageEvent).data as string,
+        ),
+      ).toEqual(["first", "second"]);
+
+      transport.destroy();
+    });
+
     it("should not fire onEncryptedHandshakeOk twice", async () => {
       const onEncryptedHandshakeOk = vi.fn();
       const transport = makeTransport();
@@ -323,6 +368,7 @@ describe("WebSocketTransport encryption", () => {
       ws.simulateMessage(
         JSON.stringify({ jsonrpc: "2.0", error: { code: -32002 } }),
       );
+      await flushPromises();
 
       expect(onCredentialsRevoked).toHaveBeenCalledTimes(1);
       expect(transport.state).toBe("disconnected");

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WebSocketTransport } from "@/lib/transport/WebSocketTransport";
 import { EncryptedSession } from "@/lib/crypto/session";
+import { logger } from "@/lib/logger";
 
 vi.mock("@/lib/crypto/session", () => ({
   EncryptedSession: {
@@ -248,20 +249,60 @@ describe("WebSocketTransport encryption", () => {
       transport.destroy();
     });
 
-    it("should discard an in-flight encrypted frame after reset", async () => {
-      let resolveDecrypt!: (plaintext: string) => void;
-      const decrypt = vi.fn(
-        () =>
-          new Promise<string>((resolve) => {
-            resolveDecrypt = resolve;
-          }),
-      );
-      vi.mocked(EncryptedSession.create).mockResolvedValue({
-        ...makeMockSession(),
-        decrypt,
-      } as unknown as EncryptedSession);
+    it.each(["resolve", "reject"] as const)(
+      "should discard queued encrypted frames when stale decryption %s after reset",
+      async (outcome) => {
+        let resolveDecrypt!: (plaintext: string) => void;
+        let rejectDecrypt!: (error: Error) => void;
+        const decrypt = vi.fn(
+          () =>
+            new Promise<string>((resolve, reject) => {
+              resolveDecrypt = resolve;
+              rejectDecrypt = reject;
+            }),
+        );
+        vi.mocked(EncryptedSession.create).mockResolvedValue({
+          ...makeMockSession(),
+          decrypt,
+        } as unknown as EncryptedSession);
 
-      const onMessage = vi.fn();
+        const onMessage = vi.fn();
+        const onError = vi.fn();
+        const transport = makeTransport();
+        transport.setEventHandlers({ onMessage, onError });
+        transport.connect();
+
+        const ws = MockWebSocket.getLatest()!;
+        ws.simulateOpen();
+        await flushPromises();
+
+        ws.simulateMessage(JSON.stringify({ e: "in-flight-frame" }));
+        ws.simulateMessage(JSON.stringify({ e: "queued-frame" }));
+        await flushPromises();
+        expect(decrypt).toHaveBeenCalledTimes(1);
+
+        transport.destroy();
+        if (outcome === "resolve") {
+          resolveDecrypt("stale");
+        } else {
+          rejectDecrypt(new Error("Stale decrypt failure"));
+        }
+        await flushPromises();
+
+        expect(decrypt).toHaveBeenCalledTimes(1);
+        expect(onMessage).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should continue processing after a message handler throws", async () => {
+      const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const onMessage = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("Consumer failure");
+        })
+        .mockImplementation(() => undefined);
       const transport = makeTransport();
       transport.setEventHandlers({ onMessage });
       transport.connect();
@@ -270,15 +311,19 @@ describe("WebSocketTransport encryption", () => {
       ws.simulateOpen();
       await flushPromises();
 
-      ws.simulateMessage(JSON.stringify({ e: "stale-frame" }));
+      ws.simulateMessage(JSON.stringify({ e: btoa("first") }));
+      ws.simulateMessage(JSON.stringify({ e: btoa("second") }));
       await flushPromises();
-      expect(decrypt).toHaveBeenCalledTimes(1);
 
+      expect(onMessage).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to process encrypted frame"),
+        expect.any(Error),
+        expect.objectContaining({ action: "inbound-processing-failed" }),
+      );
+
+      loggerSpy.mockRestore();
       transport.destroy();
-      resolveDecrypt("stale");
-      await flushPromises();
-
-      expect(onMessage).not.toHaveBeenCalled();
     });
 
     it("should not fire onEncryptedHandshakeOk twice", async () => {

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
@@ -248,6 +248,39 @@ describe("WebSocketTransport encryption", () => {
       transport.destroy();
     });
 
+    it("should discard an in-flight encrypted frame after reset", async () => {
+      let resolveDecrypt!: (plaintext: string) => void;
+      const decrypt = vi.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveDecrypt = resolve;
+          }),
+      );
+      vi.mocked(EncryptedSession.create).mockResolvedValue({
+        ...makeMockSession(),
+        decrypt,
+      } as unknown as EncryptedSession);
+
+      const onMessage = vi.fn();
+      const transport = makeTransport();
+      transport.setEventHandlers({ onMessage });
+      transport.connect();
+
+      const ws = MockWebSocket.getLatest()!;
+      ws.simulateOpen();
+      await flushPromises();
+
+      ws.simulateMessage(JSON.stringify({ e: "stale-frame" }));
+      await flushPromises();
+      expect(decrypt).toHaveBeenCalledTimes(1);
+
+      transport.destroy();
+      resolveDecrypt("stale");
+      await flushPromises();
+
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
     it("should not fire onEncryptedHandshakeOk twice", async () => {
       const onEncryptedHandshakeOk = vi.fn();
       const transport = makeTransport();

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -352,6 +352,38 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     }, MEDIA_INDEX_RECONCILE_MS);
   }, []);
 
+  const applyGamesIndexState = useCallback(
+    (nextState: IndexResponse) => {
+      const currentState = useStatusStore.getState().gamesIndex;
+      setGamesIndex(nextState);
+
+      const mediaStateChanged =
+        currentState.indexing !== nextState.indexing ||
+        currentState.optimizing !== nextState.optimizing ||
+        currentState.exists !== nextState.exists ||
+        currentState.totalMedia !== nextState.totalMedia;
+      if (mediaStateChanged) {
+        logger.log("Database state changed, invalidating media query");
+        queryClient.invalidateQueries({ queryKey: ["media"] });
+      }
+
+      // Latest Core increments systemsCompleted after each durable system
+      // commit. Older Core omits it but flips indexing/exists at completion.
+      const libraryContentChanged =
+        currentState.indexing !== nextState.indexing ||
+        currentState.exists !== nextState.exists ||
+        currentState.totalMedia !== nextState.totalMedia ||
+        currentState.systemsCompleted !== nextState.systemsCompleted;
+      if (libraryContentChanged) {
+        logger.log("Media library changed, invalidating cached lists");
+        queryClient.invalidateQueries({ queryKey: ["systems"] });
+        queryClient.invalidateQueries({ queryKey: ["tags"] });
+        queryClient.invalidateQueries({ queryKey: ["infiniteMediaSearch"] });
+      }
+    },
+    [queryClient, setGamesIndex],
+  );
+
   useEffect(() => {
     runMediaIndexReconciliationRef.current = () => {
       if (
@@ -380,7 +412,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             return;
           }
 
-          setGamesIndex(response.database);
+          applyGamesIndexState(response.database);
           if (response.database.indexing) {
             scheduleMediaIndexReconciliation();
           }
@@ -404,7 +436,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           }
         });
     };
-  }, [scheduleMediaIndexReconciliation, setGamesIndex]);
+  }, [applyGamesIndexState, scheduleMediaIndexReconciliation]);
 
   useEffect(
     () => () => {
@@ -456,39 +488,12 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             const params = notification.params as IndexResponse;
             logger.log("mediaIndexing", params);
 
-            const currentState = useStatusStore.getState().gamesIndex;
-            setGamesIndex(params);
+            applyGamesIndexState(params);
             if (params.indexing) {
               cancelMediaIndexReconciliation();
               scheduleMediaIndexReconciliation();
             } else {
               cancelMediaIndexReconciliation();
-            }
-
-            const mediaStateChanged =
-              currentState.indexing !== params.indexing ||
-              currentState.optimizing !== params.optimizing ||
-              currentState.exists !== params.exists ||
-              currentState.totalMedia !== params.totalMedia;
-            if (mediaStateChanged) {
-              logger.log("Database state changed, invalidating media query");
-              queryClient.invalidateQueries({ queryKey: ["media"] });
-            }
-
-            // Latest Core increments systemsCompleted after each durable system
-            // commit. Older Core omits it but flips indexing/exists at completion.
-            const libraryContentChanged =
-              currentState.indexing !== params.indexing ||
-              currentState.exists !== params.exists ||
-              currentState.totalMedia !== params.totalMedia ||
-              currentState.systemsCompleted !== params.systemsCompleted;
-            if (libraryContentChanged) {
-              logger.log("Media library changed, invalidating cached lists");
-              queryClient.invalidateQueries({ queryKey: ["systems"] });
-              queryClient.invalidateQueries({ queryKey: ["tags"] });
-              queryClient.invalidateQueries({
-                queryKey: ["infiniteMediaSearch"],
-              });
             }
             break;
           }
@@ -700,11 +705,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     },
     [
       refreshMediaState,
+      applyGamesIndexState,
       cancelMediaIndexReconciliation,
       cancelMediaStopReconciliation,
       scheduleMediaIndexReconciliation,
       scheduleMediaStopReconciliation,
-      setGamesIndex,
       setScrapingStatus,
       setLastToken,
       setActiveTokens,

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -84,6 +84,7 @@ interface ConnectionProviderProps {
 
 const CLIENT_CAPABILITIES_SINCE = "2.16.0";
 const MEDIA_TRANSITION_GRACE_MS = 250;
+const MEDIA_INDEX_RECONCILE_MS = 2000;
 const LEGACY_CLIENT_ACCESS = {
   paired: false,
   role: null,
@@ -143,6 +144,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   const mediaStopTimers = useRef<
     Record<MediaSlot, ReturnType<typeof setTimeout> | null>
   >({ primary: null, background: null });
+  const mediaIndexReconcileTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const mediaIndexReconcileToken = useRef(0);
+  const runMediaIndexReconciliationRef = useRef<() => void>(() => {});
   const mediaStateRequestToken = useRef(0);
   const invalidateMediaStateRequest = useCallback(() => {
     mediaStateRequestToken.current++;
@@ -328,13 +334,90 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     [cancelMediaStopReconciliation, refreshMediaState],
   );
 
+  const cancelMediaIndexReconciliation = useCallback(() => {
+    if (mediaIndexReconcileTimer.current) {
+      clearTimeout(mediaIndexReconcileTimer.current);
+      mediaIndexReconcileTimer.current = null;
+    }
+    mediaIndexReconcileToken.current++;
+  }, []);
+
+  const scheduleMediaIndexReconciliation = useCallback(() => {
+    if (mediaIndexReconcileTimer.current) {
+      clearTimeout(mediaIndexReconcileTimer.current);
+    }
+    mediaIndexReconcileTimer.current = setTimeout(() => {
+      mediaIndexReconcileTimer.current = null;
+      runMediaIndexReconciliationRef.current();
+    }, MEDIA_INDEX_RECONCILE_MS);
+  }, []);
+
+  useEffect(() => {
+    runMediaIndexReconciliationRef.current = () => {
+      if (
+        useStatusStore.getState().connectionState !== ConnectionState.CONNECTED
+      ) {
+        return;
+      }
+
+      const requestToken = ++mediaIndexReconcileToken.current;
+      const connectionId = currentConnectionId.current;
+
+      void CoreAPI.media()
+        .then((response) => {
+          if (
+            requestToken !== mediaIndexReconcileToken.current ||
+            connectionId !== currentConnectionId.current ||
+            useStatusStore.getState().connectionState !==
+              ConnectionState.CONNECTED
+          ) {
+            return;
+          }
+          if (isCancelled(response)) {
+            if (useStatusStore.getState().gamesIndex.indexing) {
+              scheduleMediaIndexReconciliation();
+            }
+            return;
+          }
+
+          setGamesIndex(response.database);
+          if (response.database.indexing) {
+            scheduleMediaIndexReconciliation();
+          }
+        })
+        .catch((error) => {
+          if (
+            requestToken !== mediaIndexReconcileToken.current ||
+            connectionId !== currentConnectionId.current ||
+            useStatusStore.getState().connectionState !==
+              ConnectionState.CONNECTED
+          ) {
+            return;
+          }
+          logger.error("Failed to reconcile media indexing status", error, {
+            category: "api",
+            action: "media-index-reconcile",
+            severity: "warning",
+          });
+          if (useStatusStore.getState().gamesIndex.indexing) {
+            scheduleMediaIndexReconciliation();
+          }
+        });
+    };
+  }, [scheduleMediaIndexReconciliation, setGamesIndex]);
+
   useEffect(
     () => () => {
       cancelMediaStopReconciliation("primary");
       cancelMediaStopReconciliation("background");
+      cancelMediaIndexReconciliation();
       invalidateMediaStateRequest();
     },
-    [cancelMediaStopReconciliation, invalidateMediaStateRequest],
+    [
+      cancelMediaIndexReconciliation,
+      cancelMediaStopReconciliation,
+      invalidateMediaStateRequest,
+    ],
   );
 
   // Process notifications from WebSocket messages
@@ -375,6 +458,12 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
 
             const currentState = useStatusStore.getState().gamesIndex;
             setGamesIndex(params);
+            if (params.indexing) {
+              cancelMediaIndexReconciliation();
+              scheduleMediaIndexReconciliation();
+            } else {
+              cancelMediaIndexReconciliation();
+            }
 
             const mediaStateChanged =
               currentState.indexing !== params.indexing ||
@@ -611,7 +700,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     },
     [
       refreshMediaState,
+      cancelMediaIndexReconciliation,
       cancelMediaStopReconciliation,
+      scheduleMediaIndexReconciliation,
       scheduleMediaStopReconciliation,
       setGamesIndex,
       setScrapingStatus,
@@ -827,6 +918,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           }
           try {
             setGamesIndex(v.database);
+            if (v.database.indexing) {
+              scheduleMediaIndexReconciliation();
+            } else {
+              cancelMediaIndexReconciliation();
+            }
             applyMediaState(v);
           } catch (e) {
             logger.error("Error processing media data:", e);
@@ -838,6 +934,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
             return;
           }
           if (isExpectedMediaDatabaseError(e)) {
+            cancelMediaIndexReconciliation();
             setGamesIndex(DEFAULT_GAMES_INDEX);
             return;
           }
@@ -891,6 +988,8 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         }
       });
   }, [
+    cancelMediaIndexReconciliation,
+    scheduleMediaIndexReconciliation,
     setConnectionError,
     setDeviceHistory,
     addDeviceHistory,
@@ -1163,6 +1262,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       }
       cancelMediaStopReconciliation("primary");
       cancelMediaStopReconciliation("background");
+      cancelMediaIndexReconciliation();
       invalidateMediaStateRequest();
       // Reset CoreAPI to clear any pending requests for this connection
       CoreAPI.reset();
@@ -1175,6 +1275,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     targetDeviceAddress,
     invalidateCurrentClientRequest,
     invalidateMediaStateRequest,
+    cancelMediaIndexReconciliation,
     cancelMediaStopReconciliation,
     setConnectionState,
     setConnectionError,

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -76,6 +76,8 @@ export class WebSocketTransport implements Transport {
   private session: EncryptedSession | null = null;
   private outboundQueue: string[] = [];
   private drainInFlight = false;
+  private inboundMessageChain: Promise<void> = Promise.resolve();
+  private inboundGeneration = 0;
   // True once the server has answered a plaintext request without a -32002/-32001
   // error. Until then we keep the consumer's encryption-state UI in "unknown" so
   // it can avoid the green-flash before -32002 arrives on encryption-required cores.
@@ -307,6 +309,8 @@ export class WebSocketTransport implements Transport {
   }
 
   private createWebSocket(): void {
+    // Invalidate queued work from the previous socket before creating another.
+    this.resetEncryptedInbound();
     // Close any existing WebSocket to prevent stale handlers from corrupting state
     this.closeWebSocket();
 
@@ -413,7 +417,7 @@ export class WebSocketTransport implements Transport {
         this.encMode === "trying-encrypted" ||
         this.encMode === "encrypted-verified"
       ) {
-        void this.handleEncryptedMessage(event);
+        this.enqueueEncryptedMessage(event);
       } else {
         this.handlePlaintextMessage(event);
       }
@@ -541,7 +545,44 @@ export class WebSocketTransport implements Transport {
     this.handlers.onOpen?.();
   }
 
-  private async handleEncryptedMessage(event: MessageEvent): Promise<void> {
+  private enqueueEncryptedMessage(event: MessageEvent): void {
+    const generation = this.inboundGeneration;
+    const session = this.session;
+
+    this.inboundMessageChain = this.inboundMessageChain
+      .then(async () => {
+        if (
+          generation !== this.inboundGeneration ||
+          session === null ||
+          session !== this.session
+        ) {
+          return;
+        }
+        await this.handleEncryptedMessage(event, session, generation);
+      })
+      .catch((err: unknown) => {
+        logger.error(
+          `[Transport:${this.deviceId}] Failed to process encrypted frame:`,
+          err,
+          {
+            category: "crypto",
+            action: "inbound-processing-failed",
+            severity: "error",
+          },
+        );
+      });
+  }
+
+  private resetEncryptedInbound(): void {
+    this.inboundGeneration++;
+    this.inboundMessageChain = Promise.resolve();
+  }
+
+  private async handleEncryptedMessage(
+    event: MessageEvent,
+    session: EncryptedSession,
+    generation: number,
+  ): Promise<void> {
     const raw = event.data as string;
     let parsed: Record<string, unknown>;
     try {
@@ -583,11 +624,14 @@ export class WebSocketTransport implements Transport {
     }
 
     // Decrypt the frame.
-    if (typeof parsed.e === "string" && this.session) {
+    if (typeof parsed.e === "string") {
       let plaintext: string;
       try {
-        plaintext = await this.session.decrypt(parsed.e);
+        plaintext = await session.decrypt(parsed.e);
       } catch (err) {
+        if (generation !== this.inboundGeneration || session !== this.session) {
+          return;
+        }
         logger.warn(`[Transport:${this.deviceId}] Decryption failed:`, err, {
           category: "crypto",
           action: "decrypt-failed",
@@ -596,6 +640,10 @@ export class WebSocketTransport implements Transport {
         // produced a bad frame — both are fatal in the binary model.
         this.handlers.onError?.(new Error("Encrypted handshake failed"));
         this.failConnectionForEncryption("decrypt failure");
+        return;
+      }
+
+      if (generation !== this.inboundGeneration || session !== this.session) {
         return;
       }
 
@@ -888,6 +936,7 @@ export class WebSocketTransport implements Transport {
     }
 
     this.closeWebSocket();
+    this.resetEncryptedInbound();
 
     // Reset encryption state for next connect cycle.
     this.session = null;


### PR DESCRIPTION
## Summary

- serialize encrypted inbound frame decryption and dispatch in WebSocket arrival order
- prevent stale encrypted frames from dispatching after connection replacement
- reconcile media indexing status until Core reports a terminal state
- cover transport ordering and missed-terminal recovery

Closes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media indexing status updates while indexing is in progress.
  * Stopped status checks when indexing completes, fails, or the connection ends.
  * Refreshed affected media and library data after indexing changes.
  * Ensured encrypted WebSocket messages are processed in arrival order.
  * Prevented stale messages from being processed after reconnects or session changes.
  * Improved handling of encrypted message-processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->