### PR TITLE
fix: reuse pairing via mDNS hostname

### DIFF
--- a/src/__tests__/integration/network-scan-modal.test.tsx
+++ b/src/__tests__/integration/network-scan-modal.test.tsx
@@ -184,6 +184,7 @@ describe("NetworkScanModal", () => {
         __simulateDeviceDiscovered(
           createMockService({
             name: "MiSTer FPGA",
+            hostname: "mister.local",
             ipv4Addresses: ["192.168.1.100"],
             txtRecord: { version: "1.5.0", platform: "linux" },
           }),
@@ -194,6 +195,7 @@ describe("NetworkScanModal", () => {
         __simulateDeviceDiscovered(
           createMockService({
             name: "Raspberry Pi",
+            hostname: "raspberry-pi.local",
             ipv4Addresses: ["192.168.1.101"],
             txtRecord: { version: "1.4.0", platform: "linux" },
           }),

--- a/src/__tests__/integration/network-scan-modal.test.tsx
+++ b/src/__tests__/integration/network-scan-modal.test.tsx
@@ -207,7 +207,7 @@ describe("NetworkScanModal", () => {
       });
     });
 
-    it("should display device address", async () => {
+    it("should display device hostname", async () => {
       // Arrange
       render(
         <NetworkScanModal
@@ -234,9 +234,9 @@ describe("NetworkScanModal", () => {
         );
       });
 
-      // Assert - default port is hidden in connection string
+      // Assert - mDNS hostname is preferred and default port is hidden
       await waitFor(() => {
-        expect(screen.getByText("192.168.1.100")).toBeInTheDocument();
+        expect(screen.getByText("test-device.local")).toBeInTheDocument();
       });
     });
 
@@ -267,9 +267,9 @@ describe("NetworkScanModal", () => {
         );
       });
 
-      // Assert - non-default port is shown
+      // Assert - non-default port is shown with the hostname
       await waitFor(() => {
-        expect(screen.getByText("192.168.1.100:8080")).toBeInTheDocument();
+        expect(screen.getByText("test-device.local:8080")).toBeInTheDocument();
       });
     });
 
@@ -341,7 +341,7 @@ describe("NetworkScanModal", () => {
   });
 
   describe("device selection", () => {
-    it("should call onSelectDevice with address when device clicked", async () => {
+    it("should select normalized hostname when device clicked", async () => {
       // Arrange
       const user = userEvent.setup();
       const onSelectDevice = vi.fn();
@@ -364,6 +364,7 @@ describe("NetworkScanModal", () => {
         __simulateDeviceDiscovered(
           createMockService({
             name: "MiSTer",
+            hostname: "mister.local.",
             ipv4Addresses: ["192.168.1.100"],
             port: 7497,
           }),
@@ -379,7 +380,7 @@ describe("NetworkScanModal", () => {
 
       // Assert
       expect(onSelectDevice).toHaveBeenCalledWith(
-        expect.objectContaining({ address: "192.168.1.100", name: "MiSTer" }),
+        expect.objectContaining({ address: "mister.local", name: "MiSTer" }),
       );
     });
 
@@ -422,8 +423,47 @@ describe("NetworkScanModal", () => {
       // Assert
       expect(onSelectDevice).toHaveBeenCalledWith(
         expect.objectContaining({
-          address: "192.168.1.100:9000",
+          address: "test-device.local:9000",
           name: "Custom Device",
+        }),
+      );
+    });
+
+    it("should fall back to IP when hostname is unavailable", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const onSelectDevice = vi.fn();
+
+      render(
+        <NetworkScanModal
+          isOpen={true}
+          onClose={vi.fn()}
+          onSelectDevice={onSelectDevice}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("settings.networkScan.searching"),
+        ).toBeInTheDocument();
+      });
+
+      act(() => {
+        __simulateDeviceDiscovered(
+          createMockService({
+            name: "Fallback Device",
+            hostname: "",
+            ipv4Addresses: ["192.168.1.100"],
+          }),
+        );
+      });
+
+      await user.click(await screen.findByText("Fallback Device"));
+
+      expect(onSelectDevice).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: "192.168.1.100",
+          name: "Fallback Device",
         }),
       );
     });

--- a/src/__tests__/unit/hooks/useNetworkScan.test.ts
+++ b/src/__tests__/unit/hooks/useNetworkScan.test.ts
@@ -430,6 +430,49 @@ describe("useNetworkScan", () => {
       });
     });
 
+    it("should update address for duplicate normalized hostname", async () => {
+      const { useNetworkScan: hook } =
+        await import("../../../hooks/useNetworkScan");
+      const { result } = renderHook(() => hook());
+
+      await act(async () => {
+        await result.current.startScan();
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "ethernet",
+            hostname: "Zaparoo.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "wifi",
+            hostname: "zaparoo.LOCAL",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.101"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      expect(result.current.devices).toHaveLength(1);
+      expect(result.current.devices[0]).toMatchObject({
+        name: "wifi",
+        address: "192.168.1.101",
+        hostname: "zaparoo.local",
+      });
+    });
+
     it("should update hostname identity when later result only has address", async () => {
       const { useNetworkScan: hook } =
         await import("../../../hooks/useNetworkScan");

--- a/src/__tests__/unit/hooks/useNetworkScan.test.ts
+++ b/src/__tests__/unit/hooks/useNetworkScan.test.ts
@@ -351,7 +351,7 @@ describe("useNetworkScan", () => {
       expect(result.current.devices).toHaveLength(0);
     });
 
-    it("should avoid duplicate devices by address", async () => {
+    it("should update duplicate devices matched by address", async () => {
       const { useNetworkScan: hook } =
         await import("../../../hooks/useNetworkScan");
       const { result } = renderHook(() => hook());
@@ -360,7 +360,6 @@ describe("useNetworkScan", () => {
         await result.current.startScan();
       });
 
-      // Add same device twice
       act(() => {
         watchCallback?.({
           action: "resolved",
@@ -377,7 +376,7 @@ describe("useNetworkScan", () => {
         watchCallback?.({
           action: "resolved",
           service: {
-            name: "device-1-copy",
+            name: "device-1-updated",
             port: 7497,
             ipv4Addresses: ["192.168.1.100"],
             ipv6Addresses: [],
@@ -386,8 +385,138 @@ describe("useNetworkScan", () => {
       });
 
       expect(result.current.devices).toHaveLength(1);
-      const device = result.current.devices[0];
-      expect(device?.name).toBe("device-1");
+      expect(result.current.devices[0]?.name).toBe("device-1-updated");
+    });
+
+    it("should replace address identity when hostname becomes available", async () => {
+      const { useNetworkScan: hook } =
+        await import("../../../hooks/useNetworkScan");
+      const { result } = renderHook(() => hook());
+
+      await act(async () => {
+        await result.current.startScan();
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "address-only",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "hostname-added",
+            hostname: "Zaparoo.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      expect(result.current.devices).toHaveLength(1);
+      expect(result.current.devices[0]).toMatchObject({
+        name: "hostname-added",
+        address: "192.168.1.100",
+        hostname: "zaparoo.local",
+      });
+    });
+
+    it("should update hostname identity when later result only has address", async () => {
+      const { useNetworkScan: hook } =
+        await import("../../../hooks/useNetworkScan");
+      const { result } = renderHook(() => hook());
+
+      await act(async () => {
+        await result.current.startScan();
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "hostname-first",
+            hostname: "zaparoo.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "address-update",
+            port: 9000,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      expect(result.current.devices).toHaveLength(1);
+      expect(result.current.devices[0]).toMatchObject({
+        name: "address-update",
+        address: "192.168.1.100",
+        hostname: "zaparoo.local",
+        port: 9000,
+      });
+    });
+
+    it("should match devices by device ID before hostname or address", async () => {
+      const { useNetworkScan: hook } =
+        await import("../../../hooks/useNetworkScan");
+      const { result } = renderHook(() => hook());
+
+      await act(async () => {
+        await result.current.startScan();
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "ethernet",
+            hostname: "ethernet.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+            txtRecord: { id: "DEVICE-123" },
+          },
+        });
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "wifi",
+            hostname: "wifi.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.101"],
+            ipv6Addresses: [],
+            txtRecord: { id: "device-123" },
+          },
+        });
+      });
+
+      expect(result.current.devices).toHaveLength(1);
+      expect(result.current.devices[0]).toMatchObject({
+        name: "wifi",
+        address: "192.168.1.101",
+        hostname: "wifi.local",
+        deviceId: "device-123",
+      });
     });
 
     it("should remove device on removed event", async () => {
@@ -470,7 +599,45 @@ describe("useNetworkScan", () => {
       expect(result.current.devices).toHaveLength(0);
     });
 
-    it("should ignore removed event with no address", async () => {
+    it("should remove device by hostname when removed event has no address", async () => {
+      const { useNetworkScan: hook } =
+        await import("../../../hooks/useNetworkScan");
+      const { result } = renderHook(() => hook());
+
+      await act(async () => {
+        await result.current.startScan();
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "resolved",
+          service: {
+            name: "test-device",
+            hostname: "zaparoo.local.",
+            port: 7497,
+            ipv4Addresses: ["192.168.1.100"],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      act(() => {
+        watchCallback?.({
+          action: "removed",
+          service: {
+            name: "test-device",
+            hostname: "ZAPAROO.LOCAL",
+            port: 7497,
+            ipv4Addresses: [],
+            ipv6Addresses: [],
+          },
+        });
+      });
+
+      expect(result.current.devices).toHaveLength(0);
+    });
+
+    it("should ignore removed event with no identity", async () => {
       const { useNetworkScan: hook } =
         await import("../../../hooks/useNetworkScan");
       const { result } = renderHook(() => hook());
@@ -492,7 +659,7 @@ describe("useNetworkScan", () => {
         });
       });
 
-      // Try to remove with no address
+      // Try to remove with no stable identity
       act(() => {
         watchCallback?.({
           action: "removed",

--- a/src/__tests__/unit/hooks/useNetworkScan.test.ts
+++ b/src/__tests__/unit/hooks/useNetworkScan.test.ts
@@ -13,6 +13,7 @@ let watchCallback:
       action: "added" | "removed" | "resolved";
       service: {
         name: string;
+        hostname?: string;
         port: number;
         ipv4Addresses: string[];
         ipv6Addresses: string[];
@@ -275,6 +276,7 @@ describe("useNetworkScan", () => {
           action: "resolved",
           service: {
             name: "test-device",
+            hostname: "test-device.local.",
             port: 7497,
             ipv4Addresses: ["192.168.1.100"],
             ipv6Addresses: [],
@@ -291,6 +293,7 @@ describe("useNetworkScan", () => {
       expect(result.current.devices[0]).toEqual({
         name: "test-device",
         address: "192.168.1.100",
+        hostname: "test-device.local",
         port: 7497,
         deviceId: "device-123",
         version: "1.0.0",

--- a/src/components/NetworkScanModal.tsx
+++ b/src/components/NetworkScanModal.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
-import { useNetworkScan, DiscoveredDevice } from "@/hooks/useNetworkScan";
+import {
+  getDiscoveredDeviceIdentity,
+  useNetworkScan,
+  type DiscoveredDevice,
+} from "@/hooks/useNetworkScan";
 import { EmptyState } from "@/components/wui/EmptyState";
 import { SlideModal } from "./SlideModal";
 import { DeviceRow } from "./DeviceRow";
@@ -91,7 +95,7 @@ export function NetworkScanModal({
           <div className="flex flex-col gap-2">
             {devices.map((device) => (
               <DeviceRow
-                key={device.address}
+                key={getDiscoveredDeviceIdentity(device)}
                 entry={{
                   address: buildConnectionString(device),
                   name: device.name,

--- a/src/components/NetworkScanModal.tsx
+++ b/src/components/NetworkScanModal.tsx
@@ -20,10 +20,13 @@ interface NetworkScanModalProps {
 }
 
 function buildConnectionString(device: DiscoveredDevice): string {
-  // Default Zaparoo port — drop it from the displayed/connect string.
+  // Prefer the DNS-SD hostname so one saved pairing survives interface and
+  // DHCP address changes. Services without a hostname still connect by IP.
+  const host = device.hostname || device.address;
+  const formattedHost = host.includes(":") ? `[${host}]` : host;
   return device.port === 7497
-    ? device.address
-    : `${device.address}:${device.port}`;
+    ? formattedHost
+    : `${formattedHost}:${device.port}`;
 }
 
 export function NetworkScanModal({

--- a/src/hooks/useNetworkScan.ts
+++ b/src/hooks/useNetworkScan.ts
@@ -167,6 +167,10 @@ export function useNetworkScan(): UseNetworkScanResult {
 
   const isScanningRef = useRef(false);
 
+  useEffect(() => {
+    deviceCache = devices;
+  }, [devices]);
+
   const stopScan = useCallback(() => {
     // Update UI state immediately
     const wasScanning = isScanningRef.current;
@@ -231,7 +235,6 @@ export function useNetworkScan(): UseNetworkScanResult {
                     ...device,
                   };
                 }
-                deviceCache = updated;
                 return updated;
               });
             }
@@ -243,11 +246,9 @@ export function useNetworkScan(): UseNetworkScanResult {
               removedIdentity.address
             ) {
               setDevices((prev) => {
-                const updated = prev.filter(
+                return prev.filter(
                   (device) => !isSameDiscoveredDevice(device, removedIdentity),
                 );
-                deviceCache = updated;
-                return updated;
               });
             }
           }

--- a/src/hooks/useNetworkScan.ts
+++ b/src/hooks/useNetworkScan.ts
@@ -34,6 +34,52 @@ export interface DiscoveredDevice {
   platform?: string;
 }
 
+interface DeviceIdentity {
+  address?: string;
+  hostname?: string;
+  deviceId?: string;
+}
+
+function normalizeIdentityValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function normalizeHostname(hostname: string | undefined): string | undefined {
+  return normalizeIdentityValue(hostname?.replace(/\.+$/, ""));
+}
+
+export function getDiscoveredDeviceIdentity(device: DiscoveredDevice): string {
+  const deviceId = normalizeIdentityValue(device.deviceId);
+  if (deviceId) return `id:${deviceId}`;
+
+  const hostname = normalizeHostname(device.hostname);
+  if (hostname) return `hostname:${hostname}`;
+
+  return `address:${normalizeIdentityValue(device.address)}`;
+}
+
+function isSameDiscoveredDevice(
+  left: DeviceIdentity,
+  right: DeviceIdentity,
+): boolean {
+  const leftDeviceId = normalizeIdentityValue(left.deviceId);
+  const rightDeviceId = normalizeIdentityValue(right.deviceId);
+  if (leftDeviceId && rightDeviceId) {
+    return leftDeviceId === rightDeviceId;
+  }
+
+  const leftHostname = normalizeHostname(left.hostname);
+  const rightHostname = normalizeHostname(right.hostname);
+  if (leftHostname && rightHostname) {
+    return leftHostname === rightHostname;
+  }
+
+  const leftAddress = normalizeIdentityValue(left.address);
+  const rightAddress = normalizeIdentityValue(right.address);
+  return Boolean(leftAddress && leftAddress === rightAddress);
+}
+
 interface UseNetworkScanResult {
   /** List of discovered devices */
   devices: DiscoveredDevice[];
@@ -69,23 +115,30 @@ function parseTxtRecord(txtRecord: Record<string, string> | undefined): {
  * Convert a ZeroConfService to our DiscoveredDevice format.
  * Returns null if the service doesn't have a valid IP address.
  */
-function serviceToDevice(service: ZeroConfService): DiscoveredDevice | null {
-  // Get the first IPv4 address, fall back to IPv6
+function serviceToIdentity(service: ZeroConfService): DeviceIdentity {
   const address = service.ipv4Addresses?.[0] || service.ipv6Addresses?.[0];
+  const hostname = normalizeHostname(service.hostname);
+  const deviceId = normalizeIdentityValue(service.txtRecord?.["id"]);
 
-  if (!address) {
+  return {
+    ...(address ? { address } : {}),
+    ...(hostname ? { hostname } : {}),
+    ...(deviceId ? { deviceId } : {}),
+  };
+}
+
+function serviceToDevice(service: ZeroConfService): DiscoveredDevice | null {
+  const identity = serviceToIdentity(service);
+  if (!identity.address) {
     return null;
   }
 
   const txtData = parseTxtRecord(service.txtRecord);
-  // DNS-SD hostnames are commonly returned as absolute names with a trailing
-  // dot. Device address validation expects the equivalent user-facing form.
-  const hostname = service.hostname?.trim().replace(/\.+$/, "");
 
   return {
     name: service.name,
-    address,
-    ...(hostname ? { hostname } : {}),
+    address: identity.address,
+    ...(identity.hostname ? { hostname: identity.hostname } : {}),
     port: service.port,
     ...txtData,
   };
@@ -166,25 +219,33 @@ export function useNetworkScan(): UseNetworkScanResult {
             const device = serviceToDevice(result.service);
             if (device) {
               setDevices((prev) => {
-                // Avoid duplicates by address
-                if (prev.some((d) => d.address === device.address)) {
-                  return prev;
+                const existingIndex = prev.findIndex((existing) =>
+                  isSameDiscoveredDevice(existing, device),
+                );
+                const updated = [...prev];
+                if (existingIndex === -1) {
+                  updated.push(device);
+                } else {
+                  updated[existingIndex] = {
+                    ...updated[existingIndex],
+                    ...device,
+                  };
                 }
-                const updated = [...prev, device];
-                // Update session cache
                 deviceCache = updated;
                 return updated;
               });
             }
           } else if (result.action === "removed") {
-            // Remove device if it goes away
-            const address =
-              result.service.ipv4Addresses?.[0] ||
-              result.service.ipv6Addresses?.[0];
-            if (address) {
+            const removedIdentity = serviceToIdentity(result.service);
+            if (
+              removedIdentity.deviceId ||
+              removedIdentity.hostname ||
+              removedIdentity.address
+            ) {
               setDevices((prev) => {
-                const updated = prev.filter((d) => d.address !== address);
-                // Update session cache
+                const updated = prev.filter(
+                  (device) => !isSameDiscoveredDevice(device, removedIdentity),
+                );
                 deviceCache = updated;
                 return updated;
               });

--- a/src/hooks/useNetworkScan.ts
+++ b/src/hooks/useNetworkScan.ts
@@ -20,8 +20,10 @@ export function __resetDeviceCache(): void {
 export interface DiscoveredDevice {
   /** Instance name (usually hostname) */
   name: string;
-  /** IP address to connect to */
+  /** IP address to use when no service hostname is available */
   address: string;
+  /** mDNS hostname shared across the device's network interfaces */
+  hostname?: string;
   /** Port number */
   port: number;
   /** Device ID from TXT record */
@@ -76,10 +78,14 @@ function serviceToDevice(service: ZeroConfService): DiscoveredDevice | null {
   }
 
   const txtData = parseTxtRecord(service.txtRecord);
+  // DNS-SD hostnames are commonly returned as absolute names with a trailing
+  // dot. Device address validation expects the equivalent user-facing form.
+  const hostname = service.hostname?.trim().replace(/\.+$/, "");
 
   return {
     name: service.name,
     address,
+    ...(hostname ? { hostname } : {}),
     port: service.port,
     ...txtData,
   };


### PR DESCRIPTION
## Summary

- prefer normalized DNS-SD hostnames when selecting discovered Core devices so saved pairing credentials survive interface and DHCP address changes
- preserve custom ports and fall back to IP addresses when no hostname is available
- cover hostname normalization, selection, and fallback behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network scans now display and use device hostnames when available.
  - Device selection preserves non-default ports and falls back to IP addresses when no hostname is available.
  - Devices are matched more reliably across hostname, address, and device ID updates.
- **Bug Fixes**
  - Hostnames are normalized for consistent display and matching, including whitespace, case, and trailing dots.
  - Device updates and removals now remain synchronized as identifying details change.
- **Tests**
  - Added coverage for hostname selection, identity changes, removals, fallback addresses, and non-default ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->