### PR TITLE
Add respectful native app review prompts

### DIFF
--- a/__mocks__/@capawesome/capacitor-app-review.ts
+++ b/__mocks__/@capawesome/capacitor-app-review.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+
+export const AppReview = {
+  requestReview: vi.fn().mockResolvedValue(undefined),
+  openAppStore: vi.fn().mockResolvedValue(undefined),
+};

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':capacitor-status-bar')
     implementation project(':capacitor-text-zoom')
     implementation project(':capawesome-team-capacitor-nfc')
+    implementation project(':capawesome-capacitor-app-review')
     implementation project(':capawesome-capacitor-live-update')
     implementation project(':capgo-capacitor-shake')
     implementation project(':revenuecat-purchases-capacitor')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -53,6 +53,9 @@ project(':capacitor-text-zoom').projectDir = new File('../node_modules/@capacito
 include ':capawesome-team-capacitor-nfc'
 project(':capawesome-team-capacitor-nfc').projectDir = new File('../node_modules/@capawesome-team/capacitor-nfc/android')
 
+include ':capawesome-capacitor-app-review'
+project(':capawesome-capacitor-app-review').projectDir = new File('../node_modules/@capawesome/capacitor-app-review/android')
+
 include ':capawesome-capacitor-live-update'
 project(':capawesome-capacitor-live-update').projectDir = new File('../node_modules/@capawesome/capacitor-live-update/android')
 

--- a/docs/capacitor.md
+++ b/docs/capacitor.md
@@ -46,6 +46,7 @@ const platform = Capacitor.getPlatform(); // 'ios' | 'android' | 'web'
 | `@capacitor-firebase/authentication` | Firebase auth                        |
 | `@capacitor-mlkit/barcode-scanning`  | Camera barcode scanning              |
 | `@capawesome-team/capacitor-nfc`     | NFC reading/writing                  |
+| `@capawesome/capacitor-app-review`   | Native app store review prompts      |
 | `@capawesome/capacitor-live-update`  | OTA live updates                     |
 | `@capgo/capacitor-shake`             | Shake gesture detection              |
 | `capacitor-plugin-safe-area`         | Safe area insets for notched devices |

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -28,6 +28,7 @@ def capacitor_pods
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
   pod 'CapacitorTextZoom', :path => '../../node_modules/@capacitor/text-zoom'
   pod 'CapawesomeTeamCapacitorNfc', :path => '../../node_modules/@capawesome-team/capacitor-nfc'
+  pod 'CapawesomeCapacitorAppReview', :path => '../../node_modules/@capawesome/capacitor-app-review'
   pod 'CapawesomeCapacitorLiveUpdate', :path => '../../node_modules/@capawesome/capacitor-live-update'
   pod 'CapgoCapacitorShake', :path => '../../node_modules/@capgo/capacitor-shake'
   pod 'RevenuecatPurchasesCapacitor', :path => '../../node_modules/@revenuecat/purchases-capacitor'

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@capacitor/status-bar": "^8.0.2",
         "@capacitor/text-zoom": "^8.0.1",
         "@capawesome-team/capacitor-nfc": "^8.1.0",
+        "@capawesome/capacitor-app-review": "^8.0.1",
         "@capawesome/capacitor-live-update": "^8.3.0",
         "@capgo/capacitor-shake": "^8.0.27",
         "@noble/curves": "^2.2.0",
@@ -2042,6 +2043,25 @@
       "version": "8.1.0",
       "resolved": "https://npm.pkg.github.com/download/@capawesome-team/capacitor-nfc/8.1.0/993b1a27a6670852a80d4c2a7fb87a9796c9beb9",
       "integrity": "sha512-STd40BJbM6z3OXTudPrJ871f963pTJhmy0Tvq0RE87GNxC5Z6xBfTHl27Hy9N4XKRwLXlloO0OnMMJQhYos5GA==",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capawesome/capacitor-app-review": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capawesome/capacitor-app-review/-/capacitor-app-review-8.0.1.tgz",
+      "integrity": "sha512-l81Wrke2G+3uW1RqD58B2fsHcqMGiZ3FGqFTiK5r8mPMYAiR/qsExGOG1/6KYFanKZCMq+nOpnwicXeDlaYt+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@capacitor/status-bar": "^8.0.2",
     "@capacitor/text-zoom": "^8.0.1",
     "@capawesome-team/capacitor-nfc": "^8.1.0",
+    "@capawesome/capacitor-app-review": "^8.0.1",
     "@capawesome/capacitor-live-update": "^8.3.0",
     "@capgo/capacitor-shake": "^8.0.27",
     "@noble/curves": "^2.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { useProAccessCheck } from "./hooks/useProAccessCheck";
 import { useNfcAvailabilityCheck } from "./hooks/useNfcAvailabilityCheck";
 import { useCameraAvailabilityCheck } from "./hooks/useCameraAvailabilityCheck";
 import { useAccelerometerAvailabilityCheck } from "./hooks/useAccelerometerAvailabilityCheck";
+import { useAppReviewPrompt } from "./hooks/useAppReviewPrompt";
 import { useRunQueueProcessor } from "./hooks/useRunQueueProcessor";
 import { useWriteQueueProcessor } from "./hooks/useWriteQueueProcessor";
 import { WriteModal } from "./components/WriteModal";
@@ -318,6 +319,7 @@ export default function App() {
   useNfcAvailabilityCheck();
   useCameraAvailabilityCheck();
   useAccelerometerAvailabilityCheck();
+  useAppReviewPrompt();
   // Initialize live updates - must be called after app renders successfully
   useLiveUpdate();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ErrorComponent } from "@/components/ErrorComponent.tsx";
 import { InboxModal } from "@/components/InboxModal";
 import { PAGE_SCROLL_RESTORATION_SELECTOR } from "@/components/PageFrame";
 import { StagedTokenModal } from "@/components/home/StagedTokenModal";
+import { useAppReviewPrompt } from "@/hooks/useAppReviewPrompt";
 import {
   isNativePluginAvailable,
   isPluginAvailable,
@@ -33,7 +34,6 @@ import { useProAccessCheck } from "./hooks/useProAccessCheck";
 import { useNfcAvailabilityCheck } from "./hooks/useNfcAvailabilityCheck";
 import { useCameraAvailabilityCheck } from "./hooks/useCameraAvailabilityCheck";
 import { useAccelerometerAvailabilityCheck } from "./hooks/useAccelerometerAvailabilityCheck";
-import { useAppReviewPrompt } from "./hooks/useAppReviewPrompt";
 import { useRunQueueProcessor } from "./hooks/useRunQueueProcessor";
 import { useWriteQueueProcessor } from "./hooks/useWriteQueueProcessor";
 import { WriteModal } from "./components/WriteModal";

--- a/src/__tests__/unit/hooks/useAppReviewPrompt.test.ts
+++ b/src/__tests__/unit/hooks/useAppReviewPrompt.test.ts
@@ -1,0 +1,276 @@
+import { act, renderHook } from "@/test-utils";
+import { AppReview } from "@capawesome/capacitor-app-review";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  APP_REVIEW_SETTLE_DELAY_MS,
+  DEFAULT_APP_REVIEW_CADENCE,
+} from "@/lib/appReview";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
+import { logger } from "@/lib/logger";
+import type { PlayingResponse } from "@/lib/models";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+import { emptyPlaying, useStatusStore } from "@/lib/store";
+import { useAppReviewPrompt } from "@/hooks/useAppReviewPrompt";
+
+vi.mock("@/lib/capacitorBridge", () => ({
+  isCapacitorPluginUnavailableError: vi.fn(() => false),
+  isNativePluginAvailable: vi.fn(() => true),
+  isPluginAvailable: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const NOW = new Date(2026, 0, 3, 12).getTime();
+
+function playing(
+  mediaName: string,
+  mediaPath = `/media/${mediaName}.zip`,
+): PlayingResponse {
+  return {
+    systemId: "SNES",
+    systemName: "Super Nintendo",
+    mediaName,
+    mediaPath,
+  };
+}
+
+function makeNextLaunchEligible(): void {
+  usePreferencesStore.setState({
+    appReviewCadence: {
+      successfulLaunchCount: 4,
+      distinctSuccessfulDayCount: 2,
+      lastSuccessfulDay: "2026-01-02",
+      lastAttemptAt: null,
+    },
+  });
+}
+
+async function advanceToPrompt(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(APP_REVIEW_SETTLE_DELAY_MS);
+  });
+}
+
+describe("useAppReviewPrompt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    vi.mocked(isNativePluginAvailable).mockReturnValue(true);
+    vi.mocked(AppReview.requestReview).mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+
+    usePreferencesStore.setState({
+      _hasHydrated: true,
+      appReviewCadence: { ...DEFAULT_APP_REVIEW_CADENCE },
+    });
+    useStatusStore.setState({
+      connected: true,
+      playing: emptyPlaying(),
+      cameraOpen: false,
+      writeOpen: false,
+      proPurchaseModalOpen: false,
+      inboxModalOpen: false,
+      stagedToken: null,
+    });
+  });
+
+  it("should count only new non-empty primary media", () => {
+    const { rerender } = renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    rerender();
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    rerender();
+    act(() => {
+      useStatusStore.setState({ playing: emptyPlaying() });
+    });
+    rerender();
+
+    expect(
+      usePreferencesStore.getState().appReviewCadence.successfulLaunchCount,
+    ).toBe(1);
+  });
+
+  it("should persist attempt before requesting one native review", async () => {
+    makeNextLaunchEligible();
+    vi.mocked(AppReview.requestReview).mockImplementationOnce(async () => {
+      expect(usePreferencesStore.getState().appReviewCadence).toEqual({
+        successfulLaunchCount: 0,
+        distinctSuccessfulDayCount: 0,
+        lastSuccessfulDay: null,
+        lastAttemptAt: NOW + APP_REVIEW_SETTLE_DELAY_MS,
+      });
+    });
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip when native plugin is unavailable", async () => {
+    makeNextLaunchEligible();
+    vi.mocked(isNativePluginAvailable).mockReturnValue(false);
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).not.toHaveBeenCalled();
+    expect(
+      usePreferencesStore.getState().appReviewCadence.lastAttemptAt,
+    ).toBeNull();
+  });
+
+  it("should skip while app is backgrounded", async () => {
+    makeNextLaunchEligible();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).not.toHaveBeenCalled();
+    expect(
+      usePreferencesStore.getState().appReviewCadence.lastAttemptAt,
+    ).toBeNull();
+  });
+
+  it.each([
+    ["disconnected", () => useStatusStore.setState({ connected: false })],
+    ["camera", () => useStatusStore.setState({ cameraOpen: true })],
+    ["write", () => useStatusStore.setState({ writeOpen: true })],
+    [
+      "Pro purchase",
+      () => useStatusStore.setState({ proPurchaseModalOpen: true }),
+    ],
+    ["inbox", () => useStatusStore.setState({ inboxModalOpen: true })],
+    [
+      "staged token",
+      () =>
+        useStatusStore.setState({
+          stagedToken: {
+            token: {
+              type: "nfc",
+              uid: "1234",
+              text: "**launch.system:SNES",
+              data: "",
+              scanTime: "2026-01-03T12:00:00Z",
+            },
+            ready: true,
+          },
+        }),
+    ],
+  ])("should skip while %s state blocks interruption", async (_, block) => {
+    makeNextLaunchEligible();
+    block();
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).not.toHaveBeenCalled();
+    expect(
+      usePreferencesStore.getState().appReviewCadence.lastAttemptAt,
+    ).toBeNull();
+  });
+
+  it("should wait for a later successful launch after a blocked opportunity", async () => {
+    makeNextLaunchEligible();
+    useStatusStore.setState({ connected: false });
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+    expect(AppReview.requestReview).not.toHaveBeenCalled();
+
+    act(() => {
+      useStatusStore.setState({ playing: emptyPlaying(), connected: true });
+    });
+    act(() => {
+      useStatusStore.setState({ playing: playing("EarthBound") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("should cancel a pending prompt when primary media stops", async () => {
+    makeNextLaunchEligible();
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(APP_REVIEW_SETTLE_DELAY_MS - 1);
+    });
+    act(() => {
+      useStatusStore.setState({ playing: emptyPlaying() });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(AppReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it("should log rejection without retrying or restoring counters", async () => {
+    const error = new Error("StoreKit unavailable");
+    makeNextLaunchEligible();
+    vi.mocked(AppReview.requestReview).mockRejectedValueOnce(error);
+    renderHook(() => useAppReviewPrompt());
+
+    act(() => {
+      useStatusStore.setState({ playing: playing("Chrono Trigger") });
+    });
+    await advanceToPrompt();
+
+    expect(AppReview.requestReview).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      "App review request failed",
+      error,
+      {
+        category: "general",
+        action: "requestAppReview",
+        severity: "warning",
+      },
+    );
+    expect(
+      usePreferencesStore.getState().appReviewCadence.successfulLaunchCount,
+    ).toBe(0);
+  });
+});

--- a/src/__tests__/unit/lib/appReview.test.ts
+++ b/src/__tests__/unit/lib/appReview.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_REVIEW_COOLDOWN_MS,
+  DEFAULT_APP_REVIEW_CADENCE,
+  isAppReviewEligible,
+  recordAppReviewAttempt,
+  recordSuccessfulAppReviewLaunch,
+  type AppReviewCadenceState,
+} from "@/lib/appReview";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const JANUARY_1 = new Date(2026, 0, 1, 12).getTime();
+
+function eligibleCadence(
+  overrides: Partial<AppReviewCadenceState> = {},
+): AppReviewCadenceState {
+  return {
+    successfulLaunchCount: 5,
+    distinctSuccessfulDayCount: 3,
+    lastSuccessfulDay: "2026-01-03",
+    lastAttemptAt: null,
+    ...overrides,
+  };
+}
+
+describe("app review cadence", () => {
+  it("should count launches while counting each active day once", () => {
+    const firstLaunch = recordSuccessfulAppReviewLaunch(
+      DEFAULT_APP_REVIEW_CADENCE,
+      JANUARY_1,
+    );
+    const secondLaunch = recordSuccessfulAppReviewLaunch(
+      firstLaunch,
+      JANUARY_1 + 60_000,
+    );
+    const nextDayLaunch = recordSuccessfulAppReviewLaunch(
+      secondLaunch,
+      JANUARY_1 + DAY_MS,
+    );
+
+    expect(nextDayLaunch).toMatchObject({
+      successfulLaunchCount: 3,
+      distinctSuccessfulDayCount: 2,
+      lastSuccessfulDay: "2026-01-02",
+    });
+  });
+
+  it.each([
+    { successfulLaunchCount: 4, distinctSuccessfulDayCount: 3 },
+    { successfulLaunchCount: 5, distinctSuccessfulDayCount: 2 },
+  ])("should reject cadence below either threshold", (cadence) => {
+    expect(isAppReviewEligible(eligibleCadence(cadence), JANUARY_1)).toBe(
+      false,
+    );
+  });
+
+  it("should allow first request at launch and active-day thresholds", () => {
+    expect(isAppReviewEligible(eligibleCadence(), JANUARY_1)).toBe(true);
+  });
+
+  it("should enforce cooldown until its exact boundary", () => {
+    const cadence = eligibleCadence({ lastAttemptAt: JANUARY_1 });
+
+    expect(
+      isAppReviewEligible(cadence, JANUARY_1 + APP_REVIEW_COOLDOWN_MS - 1),
+    ).toBe(false);
+    expect(
+      isAppReviewEligible(cadence, JANUARY_1 + APP_REVIEW_COOLDOWN_MS),
+    ).toBe(true);
+  });
+
+  it("should not count an earlier calendar day after device clock rollback", () => {
+    const cadence = recordSuccessfulAppReviewLaunch(
+      {
+        ...DEFAULT_APP_REVIEW_CADENCE,
+        distinctSuccessfulDayCount: 1,
+        lastSuccessfulDay: "2026-01-02",
+      },
+      JANUARY_1,
+    );
+
+    expect(cadence).toMatchObject({
+      successfulLaunchCount: 1,
+      distinctSuccessfulDayCount: 1,
+      lastSuccessfulDay: "2026-01-02",
+    });
+  });
+
+  it("should not bypass cooldown when device clock moves backward", () => {
+    expect(
+      isAppReviewEligible(
+        eligibleCadence({ lastAttemptAt: JANUARY_1 }),
+        JANUARY_1 - 1,
+      ),
+    ).toBe(false);
+  });
+
+  it("should reset activity counters after a request attempt", () => {
+    expect(recordAppReviewAttempt(JANUARY_1)).toEqual({
+      successfulLaunchCount: 0,
+      distinctSuccessfulDayCount: 0,
+      lastSuccessfulDay: null,
+      lastAttemptAt: JANUARY_1,
+    });
+  });
+});

--- a/src/__tests__/unit/lib/preferencesStore.test.ts
+++ b/src/__tests__/unit/lib/preferencesStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Preferences } from "@capacitor/preferences";
+import { DEFAULT_APP_REVIEW_CADENCE } from "@/lib/appReview";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { act, renderHook, waitFor } from "@/test-utils";
 import { isPluginAvailable } from "@/lib/capacitorBridge";
@@ -44,6 +45,7 @@ describe("usePreferencesStore", () => {
       shakeEnabled: false,
       shakeMode: "random",
       shakeZapscript: "",
+      appReviewCadence: { ...DEFAULT_APP_REVIEW_CADENCE },
       _hasHydrated: true, // Pretend it's hydrated for tests
     });
   });
@@ -78,6 +80,52 @@ describe("usePreferencesStore", () => {
         expect(result.current.showFilenames).toBe(true);
       });
       expect(Preferences.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("app review cadence persistence", () => {
+    it("should merge defaults into preferences saved before review tracking", async () => {
+      vi.mocked(Preferences.get).mockResolvedValueOnce({
+        value: JSON.stringify({
+          state: { showFilenames: true },
+          version: 0,
+        }),
+      });
+
+      await usePreferencesStore.persist.rehydrate();
+
+      expect(usePreferencesStore.getState().appReviewCadence).toEqual(
+        DEFAULT_APP_REVIEW_CADENCE,
+      );
+    });
+
+    it("should record launches and reset counters after an attempt", () => {
+      const { result } = renderHook(() => usePreferencesStore());
+      const firstDay = new Date(2026, 0, 1, 12).getTime();
+      const secondDay = new Date(2026, 0, 2, 12).getTime();
+
+      act(() => {
+        result.current.recordAppReviewSuccessfulLaunch(firstDay);
+        result.current.recordAppReviewSuccessfulLaunch(firstDay + 1_000);
+        result.current.recordAppReviewSuccessfulLaunch(secondDay);
+      });
+
+      expect(result.current.appReviewCadence).toMatchObject({
+        successfulLaunchCount: 3,
+        distinctSuccessfulDayCount: 2,
+        lastSuccessfulDay: "2026-01-02",
+      });
+
+      act(() => {
+        result.current.recordAppReviewAttempt(secondDay + 1_000);
+      });
+
+      expect(result.current.appReviewCadence).toEqual({
+        successfulLaunchCount: 0,
+        distinctSuccessfulDayCount: 0,
+        lastSuccessfulDay: null,
+        lastAttemptAt: secondDay + 1_000,
+      });
     });
   });
 

--- a/src/hooks/useAppReviewPrompt.ts
+++ b/src/hooks/useAppReviewPrompt.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from "react";
+import { AppReview } from "@capawesome/capacitor-app-review";
+import {
+  APP_REVIEW_SETTLE_DELAY_MS,
+  isAppReviewEligible,
+} from "@/lib/appReview";
+import { isNativePluginAvailable } from "@/lib/capacitorBridge";
+import { logger } from "@/lib/logger";
+import type { PlayingResponse } from "@/lib/models";
+import { usePreferencesStore } from "@/lib/preferencesStore";
+import { useStatusStore } from "@/lib/store";
+
+function getPrimaryMediaIdentity(playing: PlayingResponse): string | null {
+  if (!playing.mediaName) return null;
+
+  return `${playing.systemId}\u0000${playing.mediaPath || playing.mediaName}`;
+}
+
+function isReviewPromptBlocked(): boolean {
+  const status = useStatusStore.getState();
+
+  return (
+    !status.connected ||
+    status.cameraOpen ||
+    status.writeOpen ||
+    status.proPurchaseModalOpen ||
+    status.inboxModalOpen ||
+    status.stagedToken !== null
+  );
+}
+
+export function useAppReviewPrompt(): void {
+  const hasHydrated = usePreferencesStore((state) => state._hasHydrated);
+  const playing = useStatusStore((state) => state.playing);
+  const previousMediaIdentityRef = useRef<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+
+    const mediaIdentity = getPrimaryMediaIdentity(playing);
+    if (mediaIdentity === previousMediaIdentityRef.current) return;
+
+    previousMediaIdentityRef.current = mediaIdentity;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    if (mediaIdentity === null) return;
+
+    const now = Date.now();
+    const preferences = usePreferencesStore.getState();
+    preferences.recordAppReviewSuccessfulLaunch(now);
+
+    if (
+      !isAppReviewEligible(usePreferencesStore.getState().appReviewCadence, now)
+    ) {
+      return;
+    }
+
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+
+      const requestTimestamp = Date.now();
+      const latestPreferences = usePreferencesStore.getState();
+      const latestPlaying = useStatusStore.getState().playing;
+
+      if (
+        getPrimaryMediaIdentity(latestPlaying) !== mediaIdentity ||
+        !isAppReviewEligible(
+          latestPreferences.appReviewCadence,
+          requestTimestamp,
+        ) ||
+        document.visibilityState !== "visible" ||
+        isReviewPromptBlocked() ||
+        !isNativePluginAvailable("AppReview")
+      ) {
+        return;
+      }
+
+      latestPreferences.recordAppReviewAttempt(requestTimestamp);
+      void AppReview.requestReview().catch((error: unknown) => {
+        logger.error("App review request failed", error, {
+          category: "general",
+          action: "requestAppReview",
+          severity: "warning",
+        });
+      });
+    }, APP_REVIEW_SETTLE_DELAY_MS);
+  }, [hasHydrated, playing]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+}

--- a/src/lib/appReview.ts
+++ b/src/lib/appReview.ts
@@ -1,0 +1,75 @@
+export const APP_REVIEW_REQUIRED_LAUNCHES = 5;
+export const APP_REVIEW_REQUIRED_ACTIVE_DAYS = 3;
+export const APP_REVIEW_COOLDOWN_MS = 180 * 24 * 60 * 60 * 1000;
+export const APP_REVIEW_SETTLE_DELAY_MS = 5_000;
+
+export interface AppReviewCadenceState {
+  successfulLaunchCount: number;
+  distinctSuccessfulDayCount: number;
+  lastSuccessfulDay: string | null;
+  lastAttemptAt: number | null;
+}
+
+export const DEFAULT_APP_REVIEW_CADENCE: AppReviewCadenceState = {
+  successfulLaunchCount: 0,
+  distinctSuccessfulDayCount: 0,
+  lastSuccessfulDay: null,
+  lastAttemptAt: null,
+};
+
+function toLocalDayKey(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function recordSuccessfulAppReviewLaunch(
+  state: AppReviewCadenceState,
+  timestamp: number,
+): AppReviewCadenceState {
+  const successfulDay = toLocalDayKey(timestamp);
+  const isNewSuccessfulDay =
+    state.lastSuccessfulDay === null || successfulDay > state.lastSuccessfulDay;
+
+  return {
+    ...state,
+    successfulLaunchCount: state.successfulLaunchCount + 1,
+    distinctSuccessfulDayCount:
+      state.distinctSuccessfulDayCount + (isNewSuccessfulDay ? 1 : 0),
+    lastSuccessfulDay: isNewSuccessfulDay
+      ? successfulDay
+      : state.lastSuccessfulDay,
+  };
+}
+
+export function recordAppReviewAttempt(
+  timestamp: number,
+): AppReviewCadenceState {
+  return {
+    successfulLaunchCount: 0,
+    distinctSuccessfulDayCount: 0,
+    lastSuccessfulDay: null,
+    lastAttemptAt: timestamp,
+  };
+}
+
+export function isAppReviewEligible(
+  state: AppReviewCadenceState,
+  timestamp: number,
+): boolean {
+  if (
+    state.successfulLaunchCount < APP_REVIEW_REQUIRED_LAUNCHES ||
+    state.distinctSuccessfulDayCount < APP_REVIEW_REQUIRED_ACTIVE_DAYS
+  ) {
+    return false;
+  }
+
+  if (state.lastAttemptAt === null) return true;
+
+  const elapsedSinceAttempt = timestamp - state.lastAttemptAt;
+  return (
+    elapsedSinceAttempt >= 0 && elapsedSinceAttempt >= APP_REVIEW_COOLDOWN_MS
+  );
+}

--- a/src/lib/preferencesStore.ts
+++ b/src/lib/preferencesStore.ts
@@ -2,13 +2,13 @@ import { create } from "zustand";
 import { persist, createJSONStorage, StateStorage } from "zustand/middleware";
 import { Preferences } from "@capacitor/preferences";
 import { TextZoom } from "@capacitor/text-zoom";
-import { sessionManager } from "./nfc";
 import {
   DEFAULT_APP_REVIEW_CADENCE,
   recordAppReviewAttempt,
   recordSuccessfulAppReviewLaunch,
   type AppReviewCadenceState,
-} from "./appReview";
+} from "@/lib/appReview";
+import { sessionManager } from "./nfc";
 import {
   isCapacitorPluginUnavailableError,
   isNativePluginAvailable,

--- a/src/lib/preferencesStore.ts
+++ b/src/lib/preferencesStore.ts
@@ -4,6 +4,12 @@ import { Preferences } from "@capacitor/preferences";
 import { TextZoom } from "@capacitor/text-zoom";
 import { sessionManager } from "./nfc";
 import {
+  DEFAULT_APP_REVIEW_CADENCE,
+  recordAppReviewAttempt,
+  recordSuccessfulAppReviewLaunch,
+  type AppReviewCadenceState,
+} from "./appReview";
+import {
   isCapacitorPluginUnavailableError,
   isNativePluginAvailable,
   isPluginAvailable,
@@ -79,6 +85,9 @@ export interface PreferencesState {
   // Tour completion tracking
   tourCompleted: boolean;
 
+  // Native app-review prompt cadence
+  appReviewCadence: AppReviewCadenceState;
+
   // What's new tracking
   whatsNewInitialized: boolean;
   lastWhatsNewRuntimeKey: string | null;
@@ -146,6 +155,8 @@ export interface PreferencesActions {
   setShakeZapscript: (value: string) => void;
   setCustomText: (value: string) => void;
   setTourCompleted: (value: boolean) => void;
+  recordAppReviewSuccessfulLaunch: (timestamp: number) => void;
+  recordAppReviewAttempt: (timestamp: number) => void;
   initializeWhatsNew: (
     runtimeKey: string,
     announcementId: string | null,
@@ -191,6 +202,7 @@ const DEFAULT_PREFERENCES: Omit<
   shakeZapscript: "",
   customText: "",
   tourCompleted: false,
+  appReviewCadence: DEFAULT_APP_REVIEW_CADENCE,
   whatsNewInitialized: false,
   lastWhatsNewRuntimeKey: null,
   seenWhatsNewAnnouncementIds: [],
@@ -295,6 +307,15 @@ export const usePreferencesStore = create<PreferencesStore>()(
       setShakeZapscript: (value) => set({ shakeZapscript: value }),
       setCustomText: (value) => set({ customText: value }),
       setTourCompleted: (value) => set({ tourCompleted: value }),
+      recordAppReviewSuccessfulLaunch: (timestamp) =>
+        set((state) => ({
+          appReviewCadence: recordSuccessfulAppReviewLaunch(
+            state.appReviewCadence,
+            timestamp,
+          ),
+        })),
+      recordAppReviewAttempt: (timestamp) =>
+        set({ appReviewCadence: recordAppReviewAttempt(timestamp) }),
       initializeWhatsNew: (runtimeKey, announcementId) =>
         set({
           whatsNewInitialized: true,
@@ -332,6 +353,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
         shakeZapscript: state.shakeZapscript,
         customText: state.customText,
         tourCompleted: state.tourCompleted,
+        appReviewCadence: state.appReviewCadence,
         whatsNewInitialized: state.whatsNewInitialized,
         lastWhatsNewRuntimeKey: state.lastWhatsNewRuntimeKey,
         seenWhatsNewAnnouncementIds: state.seenWhatsNewAnnouncementIds,
@@ -369,6 +391,10 @@ export const usePreferencesStore = create<PreferencesStore>()(
         return {
           ...currentState,
           ...persisted,
+          appReviewCadence: {
+            ...currentState.appReviewCadence,
+            ...persisted.appReviewCadence,
+          },
           // Never persist the hydration flags or runtime-checked values
           _hasHydrated: currentState._hasHydrated,
           _proAccessHydrated: currentState._proAccessHydrated,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -27,6 +27,7 @@ vi.mock("@revenuecat/purchases-capacitor");
 vi.mock("capacitor-plugin-safe-area");
 vi.mock("capacitor-zeroconf");
 vi.mock("@capacitor/network");
+vi.mock("@capawesome/capacitor-app-review");
 vi.mock("@capawesome/capacitor-live-update");
 vi.mock("@aparajita/capacitor-secure-storage");
 


### PR DESCRIPTION
## Summary

- add Capacitor 8 native App Store and Google Play review integration
- request reviews only after five confirmed media launches across three active days
- skip background and busy states, then enforce a 180-day cooldown
- persist cadence safely and cover policy, store, and prompt behavior with tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native in-app review prompts on supported devices.
  * Prompts appear after qualifying activity and respect launch thresholds, cooldowns, visibility, connectivity, and playback state.
  * Review activity is persisted across launches, with interrupted or unavailable prompts handled safely.
* **Tests**
  * Added coverage for review eligibility, timing, persistence, retries, interruptions, and unavailable platforms.
* **Documentation**
  * Added the app review integration to the Capacitor plugin reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->