### PR TITLE
Customize ZapScript tags from search results

### DIFF
--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -72,6 +72,93 @@ describe("MediaDetailsModal", () => {
     ).toBeChecked();
   });
 
+  it("should select and remove Core ZapScript tags", async () => {
+    const user = userEvent.setup();
+    renderModal({
+      media: {
+        ...mediaWithZapScript,
+        zapScript: "@SNES/Super Mario World (year:1990)",
+      },
+    });
+
+    const selectedTag = screen.getByRole("button", { name: "year 1990" });
+    expect(selectedTag).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "genre platformer" }),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(selectedTag);
+
+    expect(selectedTag).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText("@SNES/Super Mario World")).toBeInTheDocument();
+  });
+
+  it("should rebuild grouped ZapScript tags for every action", async () => {
+    const user = userEvent.setup();
+    const onWrite = vi.fn();
+    const onCopy = vi.fn();
+    const onPreview = vi.fn();
+    renderModal({
+      media: {
+        ...mediaWithZapScript,
+        zapScript: "@SNES/Super Mario World (year:1990)",
+        tags: [
+          ...mediaWithZapScript.tags,
+          { type: "region", tag: "us" },
+          { type: "region", tag: "eu" },
+        ],
+      },
+      onWrite,
+      onCopy,
+      onPreview,
+    });
+
+    await user.click(screen.getByRole("button", { name: "region us" }));
+    await user.click(screen.getByRole("button", { name: "region eu" }));
+
+    const customizedZapScript =
+      "@SNES/Super Mario World (year:1990) (region:us, region:eu)";
+    expect(screen.getByText(customizedZapScript)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.writeLabel/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.copyLabel/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.playLabel/i }),
+    );
+
+    expect(onWrite).toHaveBeenCalledWith(customizedZapScript);
+    expect(onCopy).toHaveBeenCalledWith(customizedZapScript);
+    expect(onPreview).toHaveBeenCalledWith(customizedZapScript);
+  });
+
+  it("should leave tags read-only for unsupported ZapScript", async () => {
+    const user = userEvent.setup();
+    const onWrite = vi.fn();
+    renderModal({
+      media: {
+        ...mediaWithZapScript,
+        zapScript: "**launch:/games/snes/Super Mario World.sfc",
+      },
+      onWrite,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "genre platformer" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("genre platformer")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /create\.search\.writeLabel/i }),
+    );
+    expect(onWrite).toHaveBeenCalledWith(
+      "**launch:/games/snes/Super Mario World.sfc",
+    );
+  });
+
   it("should default to path when ZapScript is unavailable", () => {
     renderModal({
       media: {

--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -54,8 +54,12 @@ describe("MediaDetailsModal", () => {
       screen.getByRole("dialog", { name: "Super Mario World" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
-    expect(screen.getByLabelText("genre platformer")).toBeInTheDocument();
-    expect(screen.getByLabelText("year 1990")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "genre platformer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "year 1990" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("/games/snes/Super Mario World.sfc"),
     ).toBeInTheDocument();

--- a/src/__tests__/unit/lib/titleZapScript.test.ts
+++ b/src/__tests__/unit/lib/titleZapScript.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildTitleZapScript, parseTitleZapScript } from "@/lib/titleZapScript";
+
+describe("titleZapScript", () => {
+  describe("parseTitleZapScript", () => {
+    it("should parse Core title tags and preserve their order", () => {
+      expect(
+        parseTitleZapScript("@Genesis/Sonic (region:eu, region:us) (lang:en)"),
+      ).toEqual({
+        base: "@Genesis/Sonic",
+        suffix: "",
+        tags: [
+          { type: "region", tag: "eu" },
+          { type: "region", tag: "us" },
+          { type: "lang", tag: "en" },
+        ],
+      });
+    });
+
+    it("should preserve title parentheses and advanced arguments", () => {
+      expect(
+        parseTitleZapScript(
+          "@PSX/Formula One (1997) (region:eu)?launcher=retroarch",
+        ),
+      ).toEqual({
+        base: "@PSX/Formula One (1997)",
+        suffix: "?launcher=retroarch",
+        tags: [{ type: "region", tag: "eu" }],
+      });
+    });
+
+    it("should parse a title command without default tags", () => {
+      expect(parseTitleZapScript("@SNES/Super Mario World")).toEqual({
+        base: "@SNES/Super Mario World",
+        suffix: "",
+        tags: [],
+      });
+    });
+
+    it.each([
+      "SNES/Super Mario World",
+      "**launch:SNES/Super Mario World.sfc",
+      "@SNES/Super Mario World||**delay:1s",
+      "@SNES/Super Mario World?tags=region:us",
+      "@SNES/Super Mario World (-unfinished:beta)",
+    ])("should reject unsupported script %s", (zapScript) => {
+      expect(parseTitleZapScript(zapScript)).toBeNull();
+    });
+  });
+
+  describe("buildTitleZapScript", () => {
+    it("should group values by type in first-seen order", () => {
+      const parsed = parseTitleZapScript("@SNES/Game");
+      expect(parsed).not.toBeNull();
+
+      expect(
+        buildTitleZapScript(parsed!, [
+          { type: "region", tag: "us" },
+          { type: "rev", tag: "a" },
+          { type: "region", tag: "eu" },
+          { type: "lang", tag: "en" },
+        ]),
+      ).toBe("@SNES/Game (region:us, region:eu) (rev:a) (lang:en)");
+    });
+
+    it("should preserve suffix and remove all tags when none are selected", () => {
+      const parsed = parseTitleZapScript(
+        "@SNES/Game (region:us)?launcher=custom",
+      );
+      expect(parsed).not.toBeNull();
+
+      expect(buildTitleZapScript(parsed!, [])).toBe(
+        "@SNES/Game?launcher=custom",
+      );
+    });
+
+    it("should ignore duplicate and unsafe tags", () => {
+      const parsed = parseTitleZapScript("@SNES/Game");
+      expect(parsed).not.toBeNull();
+
+      expect(
+        buildTitleZapScript(parsed!, [
+          { type: "region", tag: "us" },
+          { type: "region", tag: "us" },
+          { type: "bad type", tag: "value" },
+          { type: "lang", tag: "en) (-region:us" },
+        ]),
+      ).toBe("@SNES/Game (region:us)");
+    });
+
+    it("should round trip Core grouped output", () => {
+      const zapScript =
+        "@GBA/Game (unfinished:beta) (region:us) (lang:en, lang:fr)";
+      const parsed = parseTitleZapScript(zapScript);
+      expect(parsed).not.toBeNull();
+
+      expect(buildTitleZapScript(parsed!, parsed!.tags)).toBe(zapScript);
+    });
+  });
+});

--- a/src/__tests__/unit/lib/titleZapScript.test.ts
+++ b/src/__tests__/unit/lib/titleZapScript.test.ts
@@ -43,6 +43,7 @@ describe("titleZapScript", () => {
       "@SNES/Super Mario World||**delay:1s",
       "@SNES/Super Mario World?tags=region:us",
       "@SNES/Super Mario World (-unfinished:beta)",
+      "@SNES/Super Mario World (region:us) (USA)",
     ])("should reject unsupported script %s", (zapScript) => {
       expect(parseTitleZapScript(zapScript)).toBeNull();
     });

--- a/src/components/MediaDetailsModal.tsx
+++ b/src/components/MediaDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useId, useState } from "react";
+import { type ReactElement, useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { Copy, FileCode, Folder, Tag } from "lucide-react";
@@ -10,6 +10,11 @@ import { usePreferencesStore } from "@/lib/preferencesStore";
 import { SlideModal } from "@/components/SlideModal";
 import { TagBadge } from "@/components/TagBadge";
 import { Button } from "@/components/wui/Button";
+import {
+  buildTitleZapScript,
+  parseTitleZapScript,
+  titleTagKey,
+} from "@/lib/titleZapScript";
 
 type MediaDetailsAction = (value: string) => void | Promise<void>;
 
@@ -43,17 +48,40 @@ export function MediaDetailsModal({
   const pathInputId = `${radioGroupName}-path`;
   const zapScriptInputId = `${radioGroupName}-zapscript`;
   const [writeMode, setWriteMode] = useState<"path" | "zapScript">("path");
+  const [selectedTagKeys, setSelectedTagKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const parsedZapScript = useMemo(
+    () => (media?.zapScript ? parseTitleZapScript(media.zapScript) : null),
+    [media],
+  );
 
   useEffect(() => {
     if (media) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize mode from newly selected external media.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize state from newly selected external media.
       setWriteMode(media.zapScript ? "zapScript" : "path");
+      setSelectedTagKeys(new Set(parsedZapScript?.tags.map(titleTagKey) ?? []));
     }
-  }, [media]);
+  }, [media, parsedZapScript]);
 
+  const selectedZapScriptTags = useMemo(() => {
+    if (!media || !parsedZapScript) return [];
+
+    const orderedTags = [...parsedZapScript.tags, ...media.tags];
+    const seenTags = new Set<string>();
+    return orderedTags.filter((tag) => {
+      const key = titleTagKey(tag);
+      if (!selectedTagKeys.has(key) || seenTags.has(key)) return false;
+      seenTags.add(key);
+      return true;
+    });
+  }, [media, parsedZapScript, selectedTagKeys]);
+  const customizedZapScript = parsedZapScript
+    ? buildTitleZapScript(parsedZapScript, selectedZapScriptTags)
+    : media?.zapScript;
   const selectedValue =
-    writeMode === "zapScript" && media?.zapScript
-      ? media.zapScript
+    writeMode === "zapScript" && customizedZapScript
+      ? customizedZapScript
       : (media?.path ?? "");
   const title = media
     ? showFilenames
@@ -84,13 +112,46 @@ export function MediaDetailsModal({
                   </span>
                 </div>
                 <div className="flex flex-1 flex-wrap gap-1.5">
-                  {media.tags.map((tag, index) => (
-                    <TagBadge
-                      key={`${tag.type}:${tag.tag}:${index}`}
-                      type={tag.type}
-                      tag={tag.tag}
-                    />
-                  ))}
+                  {media.tags.map((tag, index) => {
+                    const key = titleTagKey(tag);
+                    const selected = selectedTagKeys.has(key);
+
+                    return parsedZapScript ? (
+                      <button
+                        key={`${key}:${index}`}
+                        type="button"
+                        aria-label={`${tag.type} ${tag.tag}`}
+                        aria-pressed={selected}
+                        className={classNames(
+                          "rounded-full transition-opacity focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none",
+                          { "opacity-40": !selected },
+                        )}
+                        onClick={() => {
+                          impact("light");
+                          setSelectedTagKeys((current) => {
+                            const next = new Set(current);
+                            if (next.has(key)) {
+                              next.delete(key);
+                            } else {
+                              next.add(key);
+                            }
+                            return next;
+                          });
+                          setWriteMode("zapScript");
+                        }}
+                      >
+                        <span aria-hidden="true">
+                          <TagBadge type={tag.type} tag={tag.tag} />
+                        </span>
+                      </button>
+                    ) : (
+                      <TagBadge
+                        key={`${key}:${index}`}
+                        type={tag.type}
+                        tag={tag.tag}
+                      />
+                    );
+                  })}
                 </div>
               </div>
             )}
@@ -161,7 +222,7 @@ export function MediaDetailsModal({
               </label>
             </div>
 
-            {media.zapScript && (
+            {customizedZapScript && (
               <div className="flex items-center gap-2">
                 <input
                   type="radio"
@@ -177,7 +238,7 @@ export function MediaDetailsModal({
                 />
                 <label
                   htmlFor={zapScriptInputId}
-                  aria-label={`${t("create.search.zapscriptLabel")}: ${media.zapScript}${writeMode === "zapScript" ? `, ${t("selected")}` : ""}`}
+                  aria-label={`${t("create.search.zapscriptLabel")}: ${customizedZapScript}${writeMode === "zapScript" ? `, ${t("selected")}` : ""}`}
                   className={classNames(
                     "flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2.5 transition-all duration-200 peer-focus-visible:ring-2 peer-focus-visible:ring-white/50",
                     {
@@ -200,8 +261,8 @@ export function MediaDetailsModal({
                         {t("create.search.zapscriptLabel")}
                       </span>
                     </div>
-                    <code className="flex-1 text-left font-mono text-sm break-words text-white/90">
-                      {media.zapScript}
+                    <code className="min-h-10 flex-1 text-left font-mono text-sm break-words text-white/90">
+                      {customizedZapScript}
                     </code>
                   </div>
                   <div

--- a/src/lib/titleZapScript.ts
+++ b/src/lib/titleZapScript.ts
@@ -1,0 +1,131 @@
+import type { TagInfo } from "@/lib/models";
+
+export interface ParsedTitleZapScript {
+  base: string;
+  suffix: string;
+  tags: TagInfo[];
+}
+
+const TAG_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const TAG_VALUE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_-]*$/;
+const TRAILING_GROUP_PATTERN = /\s+\(([^()]*)\)/g;
+
+export function titleTagKey(tag: TagInfo): string {
+  return `${tag.type}\u0000${tag.tag}`;
+}
+
+function isValidTag(tag: TagInfo): boolean {
+  return TAG_TYPE_PATTERN.test(tag.type) && TAG_VALUE_PATTERN.test(tag.tag);
+}
+
+function parseTagGroup(value: string): TagInfo[] | null {
+  const tags: TagInfo[] = [];
+
+  for (const entry of value.split(",")) {
+    const trimmed = entry.trim();
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex <= 0) return null;
+
+    const rawType = trimmed.slice(0, separatorIndex);
+    const type = rawType.startsWith("+") ? rawType.slice(1) : rawType;
+    const tag = trimmed.slice(separatorIndex + 1);
+    const parsedTag = { type, tag };
+
+    if (!isValidTag(parsedTag)) return null;
+    tags.push(parsedTag);
+  }
+
+  return tags.length > 0 ? tags : null;
+}
+
+function findUnescapedCharacter(value: string, character: string): number {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] === "^") {
+      index += 1;
+      continue;
+    }
+    if (value[index] === character) return index;
+  }
+  return -1;
+}
+
+export function parseTitleZapScript(
+  zapScript: string,
+): ParsedTitleZapScript | null {
+  if (!zapScript.startsWith("@") || zapScript.includes("||")) return null;
+
+  const queryIndex = findUnescapedCharacter(zapScript, "?");
+  const command =
+    queryIndex === -1 ? zapScript : zapScript.slice(0, queryIndex);
+  const suffix = queryIndex === -1 ? "" : zapScript.slice(queryIndex);
+
+  // Advanced tag arguments have their own precedence rules and cannot be
+  // represented safely by the modal's simple on/off tag controls.
+  if (/(?:^\?|&)tags=/i.test(suffix)) return null;
+
+  const matches = Array.from(command.matchAll(TRAILING_GROUP_PATTERN));
+  const parsedGroups: TagInfo[][] = [];
+  let groupStart = command.length;
+  let cursor = command.length;
+
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const match = matches[index];
+    if (!match) continue;
+
+    const matchIndex = match.index;
+    const groupValue = match[1];
+    if (matchIndex === undefined || groupValue === undefined) continue;
+
+    const matchEnd = matchIndex + match[0].length;
+    if (command.slice(matchEnd, cursor).trim().length > 0) break;
+
+    const tags = parseTagGroup(groupValue);
+    if (!tags) break;
+
+    parsedGroups.unshift(tags);
+    groupStart = matchIndex;
+    cursor = matchIndex;
+  }
+
+  const base = command.slice(0, groupStart).trimEnd();
+  const separatorIndex = findUnescapedCharacter(base, "/");
+  if (
+    separatorIndex <= 1 ||
+    base.slice(separatorIndex + 1).trim().length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    base,
+    suffix,
+    tags: parsedGroups.flat(),
+  };
+}
+
+export function buildTitleZapScript(
+  parsed: ParsedTitleZapScript,
+  tags: TagInfo[],
+): string {
+  const valuesByType = new Map<string, string[]>();
+  const seenTags = new Set<string>();
+
+  for (const tag of tags) {
+    if (!isValidTag(tag)) continue;
+
+    const key = titleTagKey(tag);
+    if (seenTags.has(key)) continue;
+    seenTags.add(key);
+
+    const values = valuesByType.get(tag.type) ?? [];
+    values.push(tag.tag);
+    valuesByType.set(tag.type, values);
+  }
+
+  const groups = Array.from(valuesByType, ([type, values]) =>
+    values.map((value) => `${type}:${value}`).join(", "),
+  );
+  const tagSuffix = groups.length > 0 ? ` (${groups.join(") (")})` : "";
+
+  return `${parsed.base}${tagSuffix}${parsed.suffix}`;
+}

--- a/src/lib/titleZapScript.ts
+++ b/src/lib/titleZapScript.ts
@@ -80,7 +80,10 @@ export function parseTitleZapScript(
     if (command.slice(matchEnd, cursor).trim().length > 0) break;
 
     const tags = parseTagGroup(groupValue);
-    if (!tags) break;
+    if (!tags) {
+      if (parsedGroups.length === 0) return null;
+      break;
+    }
 
     parsedGroups.unshift(tags);
     groupStart = matchIndex;


### PR DESCRIPTION
## Summary

- make media detail tags toggleable while preserving Core-selected defaults
- rebuild title ZapScript with readable same-type tag grouping and safe fallback for unsupported scripts
- stabilize snippet height and cover parser, builder, and modal interactions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive ZapScript tag selection in media details.
  * Select or remove supported tags and preview customized title scripts.
  * Preserves title text, query suffixes, tag order, and unique tag values when rebuilding scripts.

* **Improvements**
  * Unsupported ZapScript formats remain safely read-only instead of being modified.
  * Improved handling of grouped tags, empty selections, and invalid tag values.
  * Added more reliable validation when reading and rebuilding title scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->