### PR TITLE
Add scan history replay action

### DIFF
--- a/src/__tests__/integration/home-page.test.tsx
+++ b/src/__tests__/integration/home-page.test.tsx
@@ -380,14 +380,18 @@ describe("Home Page Integration", () => {
         entries: [
           {
             time: new Date().toISOString(),
+            type: "nfc",
             uid: "abc123def456ab",
             text: "Super Mario Bros",
+            data: "",
             success: true,
           },
           {
             time: new Date(Date.now() - 60000).toISOString(),
+            type: "nfc",
             uid: "def456abc12345",
             text: "Zelda",
+            data: "",
             success: true,
           },
         ],

--- a/src/__tests__/unit/components/home/HistoryModal.test.tsx
+++ b/src/__tests__/unit/components/home/HistoryModal.test.tsx
@@ -2,13 +2,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "../../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import { HistoryModal } from "@/components/home/HistoryModal";
+import { CoreAPI } from "@/lib/coreApi";
+import { useStatusStore } from "@/lib/store";
 
 // Note: CopyButton uses Clipboard and Haptics plugins which are already
 // mocked globally in test-setup.ts. No additional mocking needed.
 
 interface HistoryEntry {
+  type: string;
   uid: string;
   text: string;
+  data: string;
   time: string;
   success: boolean;
 }
@@ -16,8 +20,10 @@ interface HistoryEntry {
 const createHistoryEntry = (
   overrides: Partial<HistoryEntry> = {},
 ): HistoryEntry => ({
+  type: "nfc",
   uid: "04abc123def456",
   text: "game:mario",
+  data: "",
   time: new Date().toISOString(),
   success: true,
   ...overrides,
@@ -32,6 +38,8 @@ describe("HistoryModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(CoreAPI, "run").mockResolvedValue(undefined);
+    useStatusStore.setState({ connected: true });
   });
 
   describe("rendering", () => {
@@ -153,6 +161,66 @@ describe("HistoryModal", () => {
       // Assert - Should have 3 time labels (one per entry)
       const timeLabels = screen.getAllByText(/scan\.lastScannedTime/);
       expect(timeLabels).toHaveLength(3);
+    });
+  });
+
+  describe("replay", () => {
+    it("should replay a history entry when play is clicked", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const historyData = {
+        entries: [
+          createHistoryEntry({
+            type: "nfc",
+            uid: "test-uid",
+            text: "game:zelda",
+            data: "raw-data",
+          }),
+        ],
+      };
+      render(<HistoryModal {...defaultProps} historyData={historyData} />);
+
+      // Act
+      await user.click(
+        screen.getByRole("button", { name: "scan.historyReplay" }),
+      );
+
+      // Assert
+      expect(CoreAPI.run).toHaveBeenCalledWith({
+        type: "nfc",
+        uid: "test-uid",
+        text: "game:zelda",
+        data: "raw-data",
+      });
+    });
+
+    it("should disable replay when disconnected", () => {
+      // Arrange
+      useStatusStore.setState({ connected: false });
+      const historyData = { entries: [createHistoryEntry()] };
+
+      // Act
+      render(<HistoryModal {...defaultProps} historyData={historyData} />);
+
+      // Assert
+      expect(
+        screen.getByRole("button", { name: "scan.historyReplay" }),
+      ).toBeDisabled();
+    });
+
+    it("should disable replay when an entry has no scan data", () => {
+      // Arrange
+      const historyData = {
+        entries: [createHistoryEntry({ uid: "", text: "", data: "" })],
+      };
+
+      // Act
+      render(<HistoryModal {...defaultProps} historyData={historyData} />);
+
+      // Assert
+      expect(
+        screen.getByRole("button", { name: "scan.historyReplay" }),
+      ).toBeDisabled();
     });
   });
 

--- a/src/components/home/HistoryModal.tsx
+++ b/src/components/home/HistoryModal.tsx
@@ -2,25 +2,21 @@ import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { memo } from "react";
 import { EmptyState } from "@/components/wui/EmptyState";
+import { Button } from "@/components/wui/Button";
+import { CoreAPI } from "@/lib/coreApi";
+import { RepeatIcon } from "@/lib/images";
+import { logger } from "@/lib/logger";
+import type { HistoryResponse, HistoryResponseEntry } from "@/lib/models";
+import { useStatusStore } from "@/lib/store";
+import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 import { SlideModal } from "../SlideModal";
 import { CopyButton } from "../CopyButton";
 import { errorColor } from "../ScanSpinner";
 
-interface HistoryEntry {
-  uid: string;
-  text: string;
-  time: string;
-  success: boolean;
-}
-
-interface HistoryData {
-  entries: HistoryEntry[];
-}
-
 interface HistoryModalProps {
   isOpen: boolean;
   onClose: () => void;
-  historyData: HistoryData | undefined;
+  historyData: HistoryResponse | undefined;
 }
 
 export const HistoryModal = memo(function HistoryModal({
@@ -29,6 +25,23 @@ export const HistoryModal = memo(function HistoryModal({
   historyData,
 }: HistoryModalProps) {
   const { t } = useTranslation();
+  const connected = useStatusStore((state) => state.connected);
+
+  const replayScan = (item: HistoryResponseEntry) => {
+    void CoreAPI.run({
+      type: item.type,
+      uid: item.uid,
+      text: item.text,
+      data: item.data,
+    }).catch((error) => {
+      logger.error("Failed to replay scan", error, {
+        category: "api",
+        action: "replayScan",
+        severity: "error",
+      });
+      showRateLimitedErrorToast(t("scan.historyReplayError"));
+    });
+  };
 
   const isEmpty =
     !!historyData && (!historyData.entries || historyData.entries.length === 0);
@@ -52,33 +65,48 @@ export const HistoryModal = memo(function HistoryModal({
                   padding: "0.5rem",
                 }}
               >
-                <p>
-                  {t("scan.lastScannedTime", {
-                    time:
-                      item.uid === "" && item.text === ""
-                        ? "-"
-                        : new Date(item.time).toLocaleString(),
-                  })}
-                </p>
-                <p style={{ wordBreak: "break-all" }}>
-                  {t("scan.lastScannedUid", {
-                    uid:
-                      item.uid === "" || item.uid === "__api__"
-                        ? "-"
-                        : item.uid,
-                  })}
-                  {item.uid !== "" && item.uid !== "__api__" && (
-                    <CopyButton text={item.uid} className="ml-1" />
-                  )}
-                </p>
-                <p style={{ wordBreak: "break-all" }}>
-                  {t("scan.lastScannedText", {
-                    text: item.text === "" ? "-" : item.text,
-                  })}
-                  {item.text !== "" && (
-                    <CopyButton text={item.text} className="ml-1" />
-                  )}
-                </p>
+                <div className="flex items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p>
+                      {t("scan.lastScannedTime", {
+                        time:
+                          item.uid === "" && item.text === ""
+                            ? "-"
+                            : new Date(item.time).toLocaleString(),
+                      })}
+                    </p>
+                    <p style={{ wordBreak: "break-all" }}>
+                      {t("scan.lastScannedUid", {
+                        uid:
+                          item.uid === "" || item.uid === "__api__"
+                            ? "-"
+                            : item.uid,
+                      })}
+                      {item.uid !== "" && item.uid !== "__api__" && (
+                        <CopyButton text={item.uid} className="ml-1" />
+                      )}
+                    </p>
+                    <p style={{ wordBreak: "break-all" }}>
+                      {t("scan.lastScannedText", {
+                        text: item.text === "" ? "-" : item.text,
+                      })}
+                      {item.text !== "" && (
+                        <CopyButton text={item.text} className="ml-1" />
+                      )}
+                    </p>
+                  </div>
+                  <Button
+                    icon={<RepeatIcon size="20" />}
+                    variant="outline"
+                    size="sm"
+                    aria-label={t("scan.historyReplay")}
+                    disabled={
+                      !connected ||
+                      (item.uid === "" && item.text === "" && item.data === "")
+                    }
+                    onClick={() => replayScan(item)}
+                  />
+                </div>
               </div>
             ))}
         </div>

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -132,6 +132,8 @@
       "lastScannedUid": "ID: {{uid}}",
       "lastScannedText": "Value: {{text}}",
       "historyTitle": "Scan History",
+      "historyReplay": "Replay scan",
+      "historyReplayError": "Could not replay scan",
       "purchaseProTitle": "Zaparoo Pro",
       "purchaseProP1": "Turn your phone into a wireless Zaparoo reader with a one-time purchase of {{price}}. Your purchase also supports future Zaparoo development.",
       "purchaseProP2": "Pro unlocks Launch on scan and future App features that use your phone's hardware sensors as a reader. Pro is not a subscription and does not include Warp cloud features.",


### PR DESCRIPTION
## Summary
- add replay controls to scan history entries
- resend original scan payload while connected
- disable unavailable replays and report launch failures
- cover replay and disabled states with tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to replay scans directly from history entries.
  * Replay controls are disabled when disconnected or when scan data is unavailable.
  * Added notifications for replay failures and rate-limit errors.
  * Added English translations for the new replay actions and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->