### PR TITLE
Refine bottom tab reselection

### DIFF
--- a/src/__tests__/unit/components/BottomNav.test.tsx
+++ b/src/__tests__/unit/components/BottomNav.test.tsx
@@ -1,9 +1,5 @@
-import {
-  findA11yViolations,
-  render,
-  screen,
-  fireEvent,
-} from "../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import { findA11yViolations, render, screen } from "../../../test-utils";
 import { BottomNav } from "@/components/BottomNav";
 import { useStatusStore } from "@/lib/store";
 import { useTabSessionStore } from "@/lib/tabSessionStore";
@@ -157,7 +153,8 @@ describe("BottomNav", () => {
     );
   });
 
-  it("resets active Library navigation to its root", () => {
+  it("resets active Library navigation to its root", async () => {
+    const user = userEvent.setup();
     mockUseLocation.mockReturnValue({
       pathname: "/library/SNES",
       href: "/library/SNES",
@@ -174,7 +171,7 @@ describe("BottomNav", () => {
 
     const libraryLink = screen.getByTestId("link-/library");
     expect(libraryLink).toHaveAttribute("data-reset-scroll", "false");
-    fireEvent.click(libraryLink);
+    await user.click(libraryLink);
 
     expect(useTabSessionStore.getState().lastHref.library).toBe("/library");
     expect(useTabSessionStore.getState().scrollPositions).toHaveProperty(
@@ -188,7 +185,8 @@ describe("BottomNav", () => {
     expect(useLibrarySessionStore.getState().embeddedSearchOpen).toEqual({});
   });
 
-  it("scrolls an active tab root to the top without clearing its state", () => {
+  it("scrolls an active tab root to the top without clearing its state", async () => {
+    const user = userEvent.setup();
     mockUseLocation.mockReturnValue({
       pathname: "/library",
       href: "/library",
@@ -214,7 +212,7 @@ describe("BottomNav", () => {
       </>,
     );
 
-    fireEvent.click(screen.getByTestId("link-/library"));
+    await user.click(screen.getByTestId("link-/library"));
 
     expect(scrollTo).toHaveBeenCalledWith({
       left: 0,
@@ -229,7 +227,8 @@ describe("BottomNav", () => {
     expect(mockImpact).toHaveBeenCalledWith("light");
   });
 
-  it("does nothing when an active tab root is already at the top", () => {
+  it("does nothing when an active tab root is already at the top", async () => {
+    const user = userEvent.setup();
     mockUseLocation.mockReturnValue({
       pathname: "/library",
       href: "/library",
@@ -247,7 +246,7 @@ describe("BottomNav", () => {
       </>,
     );
 
-    fireEvent.click(screen.getByTestId("link-/library"));
+    await user.click(screen.getByTestId("link-/library"));
 
     expect(scrollTo).not.toHaveBeenCalled();
     expect(mockImpact).not.toHaveBeenCalled();
@@ -324,10 +323,11 @@ describe("BottomNav", () => {
     );
   });
 
-  it("triggers haptic feedback when nav button is clicked", () => {
+  it("triggers haptic feedback when nav button is clicked", async () => {
+    const user = userEvent.setup();
     render(<BottomNav />);
 
-    fireEvent.click(screen.getByTestId("link-/library"));
+    await user.click(screen.getByTestId("link-/library"));
 
     expect(mockImpact).toHaveBeenCalledWith("light");
   });

--- a/src/__tests__/unit/components/BottomNav.test.tsx
+++ b/src/__tests__/unit/components/BottomNav.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@tanstack/react-router", () => ({
     "aria-current": ariaCurrent,
     "aria-label": ariaLabel,
     className,
+    resetScroll,
   }: {
     children: React.ReactNode;
     to: string;
@@ -42,6 +43,7 @@ vi.mock("@tanstack/react-router", () => ({
     "aria-current"?: "page" | "step" | "location" | "date" | "time" | boolean;
     "aria-label"?: string;
     className?: string;
+    resetScroll?: boolean;
   }) => (
     <a
       href={to}
@@ -53,6 +55,7 @@ vi.mock("@tanstack/react-router", () => ({
       aria-current={ariaCurrent}
       aria-label={ariaLabel}
       className={className}
+      data-reset-scroll={String(resetScroll)}
     >
       {children}
     </a>
@@ -165,12 +168,19 @@ describe("BottomNav", () => {
       { name: "Games", path: "/roms/SNES" },
     ]);
     librarySession.setEmbeddedSearchOpen("SNES", true);
+    useTabSessionStore.getState().rememberScroll("/library", 0, 160);
     useTabSessionStore.getState().rememberScroll("library:SNES:browse", 0, 240);
     render(<BottomNav />);
 
-    fireEvent.click(screen.getByTestId("link-/library"));
+    const libraryLink = screen.getByTestId("link-/library");
+    expect(libraryLink).toHaveAttribute("data-reset-scroll", "false");
+    fireEvent.click(libraryLink);
 
     expect(useTabSessionStore.getState().lastHref.library).toBe("/library");
+    expect(useTabSessionStore.getState().scrollPositions).toHaveProperty(
+      "/library",
+      { scrollX: 0, scrollY: 160 },
+    );
     expect(useTabSessionStore.getState().scrollPositions).not.toHaveProperty(
       "library:SNES:browse",
     );
@@ -178,7 +188,7 @@ describe("BottomNav", () => {
     expect(useLibrarySessionStore.getState().embeddedSearchOpen).toEqual({});
   });
 
-  it("does nothing when active Library root is pressed", () => {
+  it("scrolls an active tab root to the top without clearing its state", () => {
     mockUseLocation.mockReturnValue({
       pathname: "/library",
       href: "/library",
@@ -189,15 +199,57 @@ describe("BottomNav", () => {
       system: "all",
       tags: [],
     });
-    render(<BottomNav />);
+    const scrollTo = vi.fn();
+    render(
+      <>
+        <div
+          ref={(element) => {
+            if (!element) return;
+            element.scrollTop = 240;
+            element.scrollTo = scrollTo;
+          }}
+          data-scroll-restoration-id="page-scroll"
+        />
+        <BottomNav />
+      </>,
+    );
 
     fireEvent.click(screen.getByTestId("link-/library"));
 
+    expect(scrollTo).toHaveBeenCalledWith({
+      left: 0,
+      top: 0,
+      behavior: "smooth",
+    });
     expect(useTabSessionStore.getState().scrollPositions).toHaveProperty(
       "/library",
-      { scrollX: 0, scrollY: 240 },
+      { scrollX: 0, scrollY: 0 },
     );
     expect(useLibrarySessionStore.getState().searches).toHaveProperty("all");
+    expect(mockImpact).toHaveBeenCalledWith("light");
+  });
+
+  it("does nothing when an active tab root is already at the top", () => {
+    mockUseLocation.mockReturnValue({
+      pathname: "/library",
+      href: "/library",
+    });
+    const scrollTo = vi.fn();
+    render(
+      <>
+        <div
+          ref={(element) => {
+            if (element) element.scrollTo = scrollTo;
+          }}
+          data-scroll-restoration-id="page-scroll"
+        />
+        <BottomNav />
+      </>,
+    );
+
+    fireEvent.click(screen.getByTestId("link-/library"));
+
+    expect(scrollTo).not.toHaveBeenCalled();
     expect(mockImpact).not.toHaveBeenCalled();
   });
 
@@ -275,8 +327,7 @@ describe("BottomNav", () => {
   it("triggers haptic feedback when nav button is clicked", () => {
     render(<BottomNav />);
 
-    const homeLink = screen.getByTestId("link-/");
-    fireEvent.click(homeLink);
+    fireEvent.click(screen.getByTestId("link-/library"));
 
     expect(mockImpact).toHaveBeenCalledWith("light");
   });

--- a/src/__tests__/unit/lib/tabSessionStore.test.ts
+++ b/src/__tests__/unit/lib/tabSessionStore.test.ts
@@ -85,19 +85,24 @@ describe("tabSessionStore", () => {
     });
   });
 
-  it("should reset only the active tab's navigation state", () => {
+  it("should pop only the active tab to its root", () => {
     const store = useTabSessionStore.getState();
     store.rememberLocation("/create/search", "/create/search");
     store.rememberLocation("/settings/media", "/settings/media");
+    store.rememberScroll("/create", 0, 120);
     store.rememberScroll("/create/search", 0, 200);
     store.rememberScroll("/settings/media", 0, 300);
     store.setCreateSearch({ query: "game", system: "all", tags: [] });
 
-    store.resetTab("create");
+    store.popTabToRoot("create");
 
     const state = useTabSessionStore.getState();
     expect(state.lastHref.create).toBe("/create");
     expect(state.lastHref.settings).toBe("/settings/media");
+    expect(state.scrollPositions["/create"]).toEqual({
+      scrollX: 0,
+      scrollY: 120,
+    });
     expect(state.scrollPositions["/create/search"]).toBeUndefined();
     expect(state.scrollPositions["/settings/media"]).toEqual({
       scrollX: 0,

--- a/src/__tests__/unit/lib/tabSessionStore.test.ts
+++ b/src/__tests__/unit/lib/tabSessionStore.test.ts
@@ -90,6 +90,7 @@ describe("tabSessionStore", () => {
     store.rememberLocation("/create/search", "/create/search");
     store.rememberLocation("/settings/media", "/settings/media");
     store.rememberScroll("/create", 0, 120);
+    store.rememberScroll("/create/", 0, 140);
     store.rememberScroll("/create/search", 0, 200);
     store.rememberScroll("/settings/media", 0, 300);
     store.setCreateSearch({ query: "game", system: "all", tags: [] });
@@ -102,6 +103,10 @@ describe("tabSessionStore", () => {
     expect(state.scrollPositions["/create"]).toEqual({
       scrollX: 0,
       scrollY: 120,
+    });
+    expect(state.scrollPositions["/create/"]).toEqual({
+      scrollX: 0,
+      scrollY: 140,
     });
     expect(state.scrollPositions["/create/search"]).toBeUndefined();
     expect(state.scrollPositions["/settings/media"]).toEqual({

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -14,6 +14,7 @@ import { useLibrarySessionStore } from "@/lib/librarySessionStore";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useCoreFeature } from "@/hooks/useCoreFeature";
 import { NotificationBadge } from "@/components/NotificationBadge";
+import { PAGE_SCROLL_RESTORATION_SELECTOR } from "@/components/PageFrame";
 import { ResponsiveContainer } from "./ResponsiveContainer";
 
 function NavButton(props: {
@@ -22,11 +23,12 @@ function NavButton(props: {
   path: string;
   rootPath: string;
   isActive: boolean;
-  onReset: () => void;
+  isAtRoot: boolean;
+  onPopToRoot: () => void;
+  onScrollToTop: () => boolean;
   className?: string;
   notificationCount?: number;
   ariaLabel?: string;
-  noOpWhenActive?: boolean;
   "data-tour"?: string;
 }) {
   const { impact } = useHaptics();
@@ -41,14 +43,16 @@ function NavButton(props: {
     >
       <Link
         to={props.isActive ? props.rootPath : props.path}
-        resetScroll={props.isActive}
+        resetScroll={false}
         onClick={(event) => {
-          if (props.isActive && props.noOpWhenActive) {
+          if (props.isActive && props.isAtRoot) {
             event.preventDefault();
+            if (props.onScrollToTop()) impact("light");
             return;
           }
+
           impact("light");
-          if (props.isActive) props.onReset();
+          if (props.isActive) props.onPopToRoot();
         }}
         aria-current={props.isActive ? "page" : undefined}
         aria-label={props.ariaLabel}
@@ -77,7 +81,7 @@ export function BottomNav() {
   const rememberLocation = useTabSessionStore(
     (state) => state.rememberLocation,
   );
-  const resetTab = useTabSessionStore((state) => state.resetTab);
+  const popTabToRoot = useTabSessionStore((state) => state.popTabToRoot);
   const resetLibraryNavigation = useLibrarySessionStore(
     (state) => state.resetNavigation,
   );
@@ -97,9 +101,28 @@ export function BottomNav() {
 
   const settingsNotificationCount =
     inboxFeature.available && !isSettings ? inboxCount : 0;
-  const resetNavigation = (tab: BottomTabId) => {
-    resetTab(tab);
+  const popNavigationToRoot = (tab: BottomTabId) => {
+    popTabToRoot(tab);
     if (tab === "library") resetLibraryNavigation();
+  };
+  const isAtRoot = (rootPath: string) =>
+    pathname === rootPath || (rootPath !== "/" && pathname === `${rootPath}/`);
+  const scrollActivePageToTop = () => {
+    const scrollContainer = document.querySelector(
+      PAGE_SCROLL_RESTORATION_SELECTOR,
+    );
+    if (
+      !(scrollContainer instanceof HTMLElement) ||
+      scrollContainer.scrollTop <= 0
+    ) {
+      return false;
+    }
+
+    useTabSessionStore
+      .getState()
+      .rememberScroll(location.href ?? pathname, 0, 0);
+    scrollContainer.scrollTo({ left: 0, top: 0, behavior: "smooth" });
+    return true;
   };
 
   const settingsLabel =
@@ -134,7 +157,9 @@ export function BottomNav() {
             path={lastHref.zap}
             rootPath="/"
             isActive={isHome}
-            onReset={() => resetNavigation("zap")}
+            isAtRoot={isAtRoot("/")}
+            onPopToRoot={() => popNavigationToRoot("zap")}
+            onScrollToTop={scrollActivePageToTop}
           />
           <NavButton
             text={t("nav.library")}
@@ -142,8 +167,9 @@ export function BottomNav() {
             path={lastHref.library}
             rootPath="/library"
             isActive={isLibrary}
-            onReset={() => resetNavigation("library")}
-            noOpWhenActive={pathname === "/library"}
+            isAtRoot={isAtRoot("/library")}
+            onPopToRoot={() => popNavigationToRoot("library")}
+            onScrollToTop={scrollActivePageToTop}
           />
           <NavButton
             text={t("nav.create")}
@@ -151,7 +177,9 @@ export function BottomNav() {
             path={lastHref.create}
             rootPath="/create"
             isActive={isCreate}
-            onReset={() => resetNavigation("create")}
+            isAtRoot={isAtRoot("/create")}
+            onPopToRoot={() => popNavigationToRoot("create")}
+            onScrollToTop={scrollActivePageToTop}
             data-tour="nav-create"
           />
           <NavButton
@@ -160,7 +188,9 @@ export function BottomNav() {
             path={lastHref.settings}
             rootPath="/settings"
             isActive={isSettings}
-            onReset={() => resetNavigation("settings")}
+            isAtRoot={isAtRoot("/settings")}
+            onPopToRoot={() => popNavigationToRoot("settings")}
+            onScrollToTop={scrollActivePageToTop}
             notificationCount={settingsNotificationCount}
             ariaLabel={settingsLabel}
             data-tour="nav-settings"

--- a/src/components/library/LibraryMediaDetailsModal.tsx
+++ b/src/components/library/LibraryMediaDetailsModal.tsx
@@ -319,7 +319,7 @@ export function LibraryMediaDetailsModal(props: {
       isOpen={props.isOpen}
       close={closeModal}
       title={title}
-      fixedHeight="90vh"
+      fixedHeight="85vh"
     >
       {entry && (
         <div className="flex flex-col gap-4 py-2">

--- a/src/lib/tabSessionStore.ts
+++ b/src/lib/tabSessionStore.ts
@@ -98,7 +98,11 @@ function scrollKeyBelongsToTab(key: string, tab: BottomTabId): boolean {
 
 function scrollKeyBelongsToTabRoot(key: string, tab: BottomTabId): boolean {
   const rootPath = defaultLastHref[tab];
-  return key === rootPath || key.startsWith(`${rootPath}?`);
+  return (
+    key === rootPath ||
+    (rootPath !== "/" && key === `${rootPath}/`) ||
+    key.startsWith(`${rootPath}?`)
+  );
 }
 
 function initialTabSessionState() {

--- a/src/lib/tabSessionStore.ts
+++ b/src/lib/tabSessionStore.ts
@@ -16,7 +16,7 @@ interface TabSessionState {
   rememberScroll: (key: string, scrollX: number, scrollY: number) => void;
   forgetScroll: (key: string) => void;
   setCreateSearch: (search: SessionSearchParams) => void;
-  resetTab: (tab: BottomTabId) => void;
+  popTabToRoot: (tab: BottomTabId) => void;
   reset: () => void;
 }
 
@@ -96,6 +96,11 @@ function scrollKeyBelongsToTab(key: string, tab: BottomTabId): boolean {
   }
 }
 
+function scrollKeyBelongsToTabRoot(key: string, tab: BottomTabId): boolean {
+  const rootPath = defaultLastHref[tab];
+  return key === rootPath || key.startsWith(`${rootPath}?`);
+}
+
 function initialTabSessionState() {
   return {
     lastHref: { ...defaultLastHref },
@@ -131,12 +136,14 @@ export const useTabSessionStore = create<TabSessionState>()((set) => ({
       return { scrollPositions };
     }),
   setCreateSearch: (createSearch) => set({ createSearch }),
-  resetTab: (tab) =>
+  popTabToRoot: (tab) =>
     set((state) => ({
       lastHref: { ...state.lastHref, [tab]: defaultLastHref[tab] },
       scrollPositions: Object.fromEntries(
         Object.entries(state.scrollPositions).filter(
-          ([key]) => !scrollKeyBelongsToTab(key, tab),
+          ([key]) =>
+            !scrollKeyBelongsToTab(key, tab) ||
+            scrollKeyBelongsToTabRoot(key, tab),
         ),
       ),
       createSearch: tab === "create" ? null : state.createSearch,


### PR DESCRIPTION
## Summary

- restore inactive tab context while popping active nested tabs to their root
- scroll active root tabs to the top on repeated taps without clearing root state
- shorten Library game details so launch toasts do not cover the dismiss handle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved bottom navigation behavior:
    * Active root tabs smoothly scroll to the top.
    * Active nested tabs return to the tab’s root page.
    * Scroll positions are preserved when navigating.
    * Navigation provides haptic feedback where supported.
  * Trailing-slash paths are handled consistently.

* **UI Improvements**
  * Reduced the height of the library media details modal for better screen visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->