### PR TITLE
Prepare 1.12.0 release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "dev.wizzo.tapto"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 27
-        versionName "1.11.2"
+        versionCode 28
+        versionName "1.12.0"
         resValue "string", "capawesome_live_update_default_channel", "production-" + defaultConfig.versionCode
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -104,7 +104,7 @@ Required for:
 7. Check About page credits in `src/routes/settings.about.tsx`:
    - translation credits
    - active Patreon CSV export names
-   - Patreon tier coloring (`#F1C40D` Supporter/Sponsor, `#E74C3C` Mega Supporter, `#E91E63` Ultra Supporter)
+   - Patreon tier coloring (`#F1C40D` Sponsor styling for active pledges of US$25/month or more; all lower pledges use the default white text)
 8. Run validation:
    - `npm run typecheck`
    - `npm run format:check`

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = App/Info.plist;
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.2;
+				MARKETING_VERSION = 1.12.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -415,7 +415,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = App/Info.plist;
@@ -426,7 +426,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.2;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zaparoo-app",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zaparoo-app",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zaparoo-app",
   "private": true,
   "license": "Apache-2.0",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "type": "module",
   "packageManager": "npm@12.0.1",
   "engines": {

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -73,10 +73,10 @@ describe("whatsNew", () => {
     expect(identity.liveBundleId).toBe("bundle-2026-06-04");
   });
 
-  it("should find the first 1.11.2 announcement", () => {
-    const announcement = getWhatsNewAnnouncement("native:1.11.2+27");
+  it("should find the first 1.12.0 announcement", () => {
+    const announcement = getWhatsNewAnnouncement("native:1.12.0+28");
 
-    expect(announcement?.id).toBe("release-1.11.2");
+    expect(announcement?.id).toBe("release-1.12.0");
     expect(announcement?.items).toHaveLength(5);
   });
 });

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -59,6 +59,28 @@ describe("whatsNew", () => {
     );
   });
 
+  it("should find the native announcement when a live bundle is active", async () => {
+    vi.mocked(App.getInfo).mockResolvedValue({
+      name: "Zaparoo",
+      id: "dev.wizzo.tapto",
+      version: "1.12.0",
+      build: "28",
+    });
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
+    vi.mocked(LiveUpdate.getCurrentBundle).mockResolvedValue({
+      bundleId: "bundle-2026-08-11",
+    });
+
+    const identity = await resolveRuntimeReleaseIdentity();
+    const announcement = getWhatsNewAnnouncement(identity.releaseKey);
+
+    expect(identity.releaseKey).toBe(
+      "native:1.12.0+28:bundle:bundle-2026-08-11",
+    );
+    expect(announcement?.id).toBe("release-1.12.0");
+  });
+
   it("should prefer the injected release key", async () => {
     vi.stubEnv("VITE_RELEASE_KEY", "live:1.2.3-ota.1");
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);

--- a/src/__tests__/unit/routes/settings.about.test.tsx
+++ b/src/__tests__/unit/routes/settings.about.test.tsx
@@ -165,6 +165,13 @@ describe("Settings About Route", () => {
 
       expect(screen.queryByText("Jose BG")).not.toBeInTheDocument();
       expect(screen.queryByText("Glenn")).not.toBeInTheDocument();
+
+      for (const sponsor of ["Biddle", "TheJesusFish", "Filip Kindt"]) {
+        expect(screen.getByText(sponsor)).toHaveStyle({ color: "#F1C40D" });
+      }
+      expect(screen.getByText("RetroRGB")).not.toHaveStyle({
+        color: "#F1C40D",
+      });
     });
 
     it("should render join patreon button", () => {

--- a/src/__tests__/unit/routes/settings.about.test.tsx
+++ b/src/__tests__/unit/routes/settings.about.test.tsx
@@ -127,13 +127,44 @@ describe("Settings About Route", () => {
       expect(screen.getByText("German/Deutsch")).toBeInTheDocument();
     });
 
-    it("should display patron credits section", () => {
+    it("should display current patron credits", () => {
       renderComponent();
       expect(screen.getByText("settings.about.wizzodev")).toBeInTheDocument();
-      expect(screen.getByText("RetroRGB")).toBeInTheDocument();
-      expect(screen.getByText("Jose BG")).toBeInTheDocument();
-      expect(screen.getByText("Biddle")).toBeInTheDocument();
-      expect(screen.getByText("Retrosoft Studios")).toBeInTheDocument();
+
+      for (const patron of [
+        "Jon",
+        "RetroRGB",
+        "theypsilon",
+        "Dan Doyle",
+        "Phil Felice",
+        "The8Flux",
+        "Alexander Facchini",
+        "Lu's Retro Source",
+        "Tony Shadwick",
+        "Clinton Cronin",
+        "Tuxosaurus",
+        "Retrosoft Studios",
+        "Casey McGinty",
+        "Biddle",
+        "Shijuro",
+        "TheJesusFish",
+        "disctoad",
+        "Mark Dodsworth",
+        "ayoub",
+        "Michael Quinn",
+        "Lina Blue",
+        "Filip Kindt",
+        "Not Work",
+        "angel rooney",
+        "Danny Garfield",
+        "pxa",
+        "Antony Boudreau",
+      ]) {
+        expect(screen.getByText(patron)).toBeInTheDocument();
+      }
+
+      expect(screen.queryByText("Jose BG")).not.toBeInTheDocument();
+      expect(screen.queryByText("Glenn")).not.toBeInTheDocument();
     });
 
     it("should render join patreon button", () => {

--- a/src/__tests__/validation/release-config.test.ts
+++ b/src/__tests__/validation/release-config.test.ts
@@ -54,7 +54,7 @@ describe("release configuration", () => {
       new Set([packageJson.version]),
     );
     expect(new Set(iosBuildNumbers)).toEqual(new Set([androidVersionCode]));
-    expect(androidVersionCode).toBeGreaterThan(27);
+    expect(androidVersionCode).toBe(28);
   });
 
   it("should use versioned Capawesome live update channels", () => {

--- a/src/__tests__/validation/release-config.test.ts
+++ b/src/__tests__/validation/release-config.test.ts
@@ -54,7 +54,7 @@ describe("release configuration", () => {
       new Set([packageJson.version]),
     );
     expect(new Set(iosBuildNumbers)).toEqual(new Set([androidVersionCode]));
-    expect(androidVersionCode).toBeGreaterThan(26);
+    expect(androidVersionCode).toBeGreaterThan(27);
   });
 
   it("should use versioned Capawesome live update channels", () => {

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -20,15 +20,15 @@ export type WhatsNewAnnouncement = {
 
 export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
   {
-    id: "release-1.11.2",
-    releaseKeys: ["native:1.11.2+27"],
-    title: "What's new in 1.11.2",
+    id: "release-1.12.0",
+    releaseKeys: ["native:1.12.0+28"],
+    title: "What's new in 1.12.0",
     items: [
-      "Use the new Controls modal for remote and keyboard input.",
-      "View and manage existing mappings from the Mappings page.",
-      "Monitor and start media scraper runs from Settings.",
-      "Use encrypted sessions with supported Core versions.",
-      "Reliability fixes for deep links, startup, media search, NFC, and purchases.",
+      "Browse, search, favorite, launch, and write media from the new Library tab.",
+      "Subscribe to and manage Zaparoo Warp directly in the app.",
+      "Log in to Zaparoo Online accounts protected by two-factor authentication.",
+      "Replay past scans and customize ZapScript tags from search results.",
+      "Enjoy improved NFC writing, encrypted connections, accessibility, notifications, and log sharing.",
     ],
   },
 ];

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -79,7 +79,13 @@ export async function resolveRuntimeReleaseIdentity(): Promise<RuntimeReleaseIde
 export function getWhatsNewAnnouncement(
   releaseKey: string,
 ): WhatsNewAnnouncement | undefined {
+  const bundleSuffixIndex = releaseKey.indexOf(":bundle:");
+  const announcementReleaseKey =
+    releaseKey.startsWith("native:") && bundleSuffixIndex !== -1
+      ? releaseKey.slice(0, bundleSuffixIndex)
+      : releaseKey;
+
   return WHATS_NEW_ANNOUNCEMENTS.find((announcement) =>
-    announcement.releaseKeys.includes(releaseKey),
+    announcement.releaseKeys.includes(announcementReleaseKey),
   );
 }

--- a/src/routes/settings.about.tsx
+++ b/src/routes/settings.about.tsx
@@ -104,25 +104,22 @@ export function About() {
           </h3>
 
           <div className="text-center">
-            Jon, <span style={{ color: "#F1C40D" }}>RetroRGB</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Jose BG</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Dan Doyle</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Phil Felice</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Glenn</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Alexander Facchini</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Lu&apos;s Retro Source</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Tony Shadwick</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Clinton Cronin</span>,{" "}
-            Tuxosaurus,{" "}
-            <span style={{ color: "#E74C3C" }}>Retrosoft Studios</span>, Casey
-            McGinty, <span style={{ color: "#F06292" }}>Biddle</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Shijuro</span>,{" "}
+            <span>Jon</span>, <span>RetroRGB</span>, <span>theypsilon</span>,{" "}
+            <span>Dan Doyle</span>, <span>Phil Felice</span>,{" "}
+            <span>The8Flux</span>, <span>Alexander Facchini</span>,{" "}
+            <span>Lu&apos;s Retro Source</span>, <span>Tony Shadwick</span>,{" "}
+            <span>Clinton Cronin</span>, <span>Tuxosaurus</span>,{" "}
+            <span>Retrosoft Studios</span>, <span>Casey McGinty</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>Biddle</span>,{" "}
+            <span>Shijuro</span>,{" "}
             <span style={{ color: "#F1C40D" }}>TheJesusFish</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>disctoad</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Mark Dodsworth</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>ayoub</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Michael Quinn</span>,{" "}
-            <span style={{ color: "#F1C40D" }}>Lina Blue</span>
+            <span>disctoad</span>, <span>Mark Dodsworth</span>,{" "}
+            <span>ayoub</span>, <span>Michael Quinn</span>,{" "}
+            <span>Lina Blue</span>,{" "}
+            <span style={{ color: "#F1C40D" }}>Filip Kindt</span>,{" "}
+            <span>Not Work</span>, <span>angel rooney</span>,{" "}
+            <span>Danny Garfield</span>, <span>pxa</span>,{" "}
+            <span>Antony Boudreau</span>
           </div>
 
           <Button


### PR DESCRIPTION
## Summary

- bump package, Android, and iOS versions to 1.12.0 build 28
- add in-app release notes and update release configuration coverage
- refresh active Patreon credits and apply Sponsor styling to US$25-plus pledges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released version 1.12.0 across Android, iOS, and package distributions.
  * Added updated What's New information for the 1.12.0 release, including improved handling for live bundles.
  * Refreshed contributor and patron credits in the About section, including updated sponsor highlights.
* **Documentation**
  * Updated sponsorship styling guidance to reflect current active-pledge eligibility and presentation.
* **Tests**
  * Updated release and credit checks to validate the 1.12.0 release details and current listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->