### PR TITLE
Preserve pairing after mDNS migration

### DIFF
--- a/src/__tests__/integration/network-scan-modal.test.tsx
+++ b/src/__tests__/integration/network-scan-modal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, act } from "../../test-utils";
 import userEvent from "@testing-library/user-event";
 import { NetworkScanModal } from "@/components/NetworkScanModal";
 import { Capacitor } from "@capacitor/core";
+import { credentialStore } from "@/lib/crypto/credentials";
 import {
   __simulateDeviceDiscovered,
   type ZeroConfService,
@@ -343,10 +344,11 @@ describe("NetworkScanModal", () => {
   });
 
   describe("device selection", () => {
-    it("should select normalized hostname when device clicked", async () => {
+    it("should select normalized hostname and register its IP credential fallback", async () => {
       // Arrange
       const user = userEvent.setup();
       const onSelectDevice = vi.fn();
+      const registerFallback = vi.spyOn(credentialStore, "registerFallback");
 
       render(
         <NetworkScanModal
@@ -383,6 +385,10 @@ describe("NetworkScanModal", () => {
       // Assert
       expect(onSelectDevice).toHaveBeenCalledWith(
         expect.objectContaining({ address: "mister.local", name: "MiSTer" }),
+      );
+      expect(registerFallback).toHaveBeenCalledWith(
+        "mister.local",
+        "192.168.1.100",
       );
     });
 

--- a/src/__tests__/integration/network-scan-modal.test.tsx
+++ b/src/__tests__/integration/network-scan-modal.test.tsx
@@ -348,7 +348,9 @@ describe("NetworkScanModal", () => {
       // Arrange
       const user = userEvent.setup();
       const onSelectDevice = vi.fn();
-      const registerFallback = vi.spyOn(credentialStore, "registerFallback");
+      const registerFallback = vi
+        .spyOn(credentialStore, "registerFallback")
+        .mockImplementation(() => undefined);
 
       render(
         <NetworkScanModal

--- a/src/__tests__/unit/lib/crypto/credentials.test.ts
+++ b/src/__tests__/unit/lib/crypto/credentials.test.ts
@@ -68,10 +68,13 @@ describe("SecureCredentialStore", () => {
     await store.set("192.168.1.50", creds);
     store.registerFallback("mister.local", "192.168.1.50");
 
-    expect(await store.get("mister.local")).toEqual(creds);
+    const migratedResult = await store.get("mister.local");
 
     const fresh = new SecureCredentialStore();
-    expect(await fresh.get("mister.local")).toEqual(creds);
+    const persistedResult = await fresh.get("mister.local");
+
+    expect(migratedResult).toEqual(creds);
+    expect(persistedResult).toEqual(creds);
   });
 
   it("should prefer credentials already stored under the stable key", async () => {

--- a/src/__tests__/unit/lib/crypto/credentials.test.ts
+++ b/src/__tests__/unit/lib/crypto/credentials.test.ts
@@ -64,6 +64,25 @@ describe("SecureCredentialStore", () => {
     expect(await store.get("unknown-device")).toBeNull();
   });
 
+  it("should migrate credentials from a registered fallback key", async () => {
+    await store.set("192.168.1.50", creds);
+    store.registerFallback("mister.local", "192.168.1.50");
+
+    expect(await store.get("mister.local")).toEqual(creds);
+
+    const fresh = new SecureCredentialStore();
+    expect(await fresh.get("mister.local")).toEqual(creds);
+  });
+
+  it("should prefer credentials already stored under the stable key", async () => {
+    const stableCreds = { ...creds, clientId: "stable-client" };
+    await store.set("192.168.1.50", creds);
+    await store.set("mister.local", stableCreds);
+    store.registerFallback("mister.local", "192.168.1.50");
+
+    expect(await store.get("mister.local")).toEqual(stableCreds);
+  });
+
   it("should remove key on delete", async () => {
     await store.set("192.168.1.50", creds);
     await store.delete("192.168.1.50");

--- a/src/components/NetworkScanModal.tsx
+++ b/src/components/NetworkScanModal.tsx
@@ -7,6 +7,7 @@ import {
   type DiscoveredDevice,
 } from "@/hooks/useNetworkScan";
 import { EmptyState } from "@/components/wui/EmptyState";
+import { credentialStore, normalizeDeviceKey } from "@/lib/crypto/credentials";
 import { SlideModal } from "./SlideModal";
 import { DeviceRow } from "./DeviceRow";
 
@@ -23,14 +24,15 @@ interface NetworkScanModalProps {
   onSelectDevice: (device: SelectedScanDevice) => void;
 }
 
+function formatConnectionString(host: string, port: number): string {
+  const formattedHost = host.includes(":") ? `[${host}]` : host;
+  return port === 7497 ? formattedHost : `${formattedHost}:${port}`;
+}
+
 function buildConnectionString(device: DiscoveredDevice): string {
   // Prefer the DNS-SD hostname so one saved pairing survives interface and
   // DHCP address changes. Services without a hostname still connect by IP.
-  const host = device.hostname || device.address;
-  const formattedHost = host.includes(":") ? `[${host}]` : host;
-  return device.port === 7497
-    ? formattedHost
-    : `${formattedHost}:${device.port}`;
+  return formatConnectionString(device.hostname || device.address, device.port);
 }
 
 export function NetworkScanModal({
@@ -52,8 +54,20 @@ export function NetworkScanModal({
 
   const handleSelectDevice = (device: DiscoveredDevice) => {
     stopScan();
+    const address = buildConnectionString(device);
+
+    if (device.hostname) {
+      // Before 1.12, scan selections were saved by IP. Register that key as a
+      // one-shot fallback so selecting the new stable hostname preserves the
+      // existing pairing and migrates it on the first credential lookup.
+      credentialStore.registerFallback(
+        normalizeDeviceKey(address),
+        normalizeDeviceKey(formatConnectionString(device.address, device.port)),
+      );
+    }
+
     onSelectDevice({
-      address: buildConnectionString(device),
+      address,
       name: device.name,
       platform: device.platform,
       version: device.version,

--- a/src/lib/crypto/credentials.ts
+++ b/src/lib/crypto/credentials.ts
@@ -17,6 +17,7 @@ export interface CredentialStore {
   set(deviceKey: string, creds: StoredCredentials): Promise<void>;
   delete(deviceKey: string): Promise<boolean>;
   list(): Promise<Array<{ deviceKey: string; creds: StoredCredentials }>>;
+  registerFallback(deviceKey: string, fallbackKey: string): void;
 }
 
 // Normalize an address to a stable device key for credential lookup.
@@ -41,6 +42,11 @@ export class SecureCredentialStore implements CredentialStore {
   // after a later set on the same key, even when callers fire them in parallel
   // (e.g., removeDeviceHistory + a re-pair flow on the same address).
   private readonly keyLocks = new Map<string, Promise<unknown>>();
+  // Network discovery now prefers stable mDNS hostnames, but older app builds
+  // stored credentials by IP address. A scan can register the discovered IP as
+  // a one-shot fallback before switching to the hostname; get() copies a match
+  // to the stable key so subsequent launches no longer need the fallback.
+  private readonly fallbackKeys = new Map<string, Set<string>>();
 
   constructor() {
     this.initPromise = SecureStorage.setKeyPrefix(KEY_PREFIX);
@@ -58,13 +64,53 @@ export class SecureCredentialStore implements CredentialStore {
     return next;
   }
 
+  registerFallback(deviceKey: string, fallbackKey: string): void {
+    if (deviceKey === fallbackKey) return;
+    const keys = this.fallbackKeys.get(deviceKey) ?? new Set<string>();
+    keys.add(fallbackKey);
+    this.fallbackKeys.set(deviceKey, keys);
+  }
+
   async get(deviceKey: string): Promise<StoredCredentials | null> {
     await this.initPromise;
     return this.enqueue(deviceKey, async () => {
+      const fallbackKeys = this.fallbackKeys.get(deviceKey) ?? [];
+      this.fallbackKeys.delete(deviceKey);
+
       try {
         const value = await SecureStorage.get(deviceKey, false);
-        if (value == null) return null;
-        return value as unknown as StoredCredentials;
+        if (value != null) {
+          return value as unknown as StoredCredentials;
+        }
+
+        for (const fallbackKey of fallbackKeys) {
+          const fallbackValue = await SecureStorage.get(fallbackKey, false);
+          if (fallbackValue == null) continue;
+
+          const credentials = fallbackValue as unknown as StoredCredentials;
+          try {
+            await SecureStorage.set(
+              deviceKey,
+              credentials as unknown as Record<string, unknown>,
+            );
+          } catch (err) {
+            // The recovered credentials still work for this connection even if
+            // persisting the stable hostname alias fails. Report the migration
+            // failure without forcing an unnecessary re-pair.
+            logger.error(
+              "Failed to migrate credentials to stable device key",
+              err,
+              {
+                category: "storage",
+                action: "migrateCredentials",
+                severity: "error",
+              },
+            );
+          }
+          return credentials;
+        }
+
+        return null;
       } catch (err) {
         logger.error("SecureStorage.get failed", err, {
           category: "storage",


### PR DESCRIPTION
## Summary
- reuse IP-keyed credentials when network scan now selects a stable mDNS hostname
- migrate recovered credentials to the hostname key for future connections
- preserve hostname-keyed credentials and cover fallback behavior with regression tests

Verified with focused credential, network scan, connection, and encrypted transport tests; typecheck, ESLint, and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device connection handling when switching between hostnames and IP addresses, preserving previously saved credentials.
  * Added automatic migration of legacy saved credentials for a smoother reconnection experience.
  * Improved connection-string formatting for IPv6 addresses and connections using the default port.
* **Tests**
  * Expanded coverage for credential fallback, migration, and device selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->