### PR TITLE
Suppress stale token errors after reconnect

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -2945,7 +2945,7 @@ describe("API error handling", () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
-  it("should suppress error toast when tokens fetch fails after RECONNECTING", async () => {
+  it("should suppress a stale tokens error after reconnect succeeds", async () => {
     let rejectTokens: (e: Error) => void = () => {};
     vi.mocked(CoreAPI.tokens).mockReturnValueOnce(
       new Promise<never>((_, rej) => {
@@ -2966,13 +2966,27 @@ describe("API error handling", () => {
     });
 
     await waitFor(() => {
-      expect(CoreAPI.tokens).toHaveBeenCalled();
+      expect(CoreAPI.tokens).toHaveBeenCalledTimes(1);
     });
 
-    useStatusStore.setState({
-      connectionState: ConnectionState.RECONNECTING,
-      connected: true,
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "reconnecting",
+      hasData: true,
+      hasConnectedBefore: true,
     });
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "connected",
+      hasData: true,
+      hasConnectedBefore: true,
+    });
+
+    await waitFor(() => {
+      expect(CoreAPI.tokens).toHaveBeenCalledTimes(2);
+    });
+    expect(useStatusStore.getState().connectionState).toBe(
+      ConnectionState.CONNECTED,
+    );
+
     rejectTokens(new Error("Request cancelled: connection reset"));
 
     await Promise.resolve();

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -1000,6 +1000,9 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     // Fetch tokens information
     CoreAPI.tokens()
       .then((v) => {
+        if (clientRequestToken !== currentClientRequestToken.current) {
+          return;
+        }
         // Skip processing if request was cancelled (stale, aborted, or connection reset)
         if (isCancelled(v)) {
           logger.log("Tokens request was cancelled, skipping");
@@ -1016,6 +1019,12 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         }
       })
       .catch((e) => {
+        // A request from the previous socket can reject after reconnection has
+        // already restored CONNECTED. Ignore that stale failure rather than
+        // showing an error for the healthy replacement connection.
+        if (clientRequestToken !== currentClientRequestToken.current) {
+          return;
+        }
         logger.error("Failed to get tokens information:", e);
         if (
           useStatusStore.getState().connectionState ===


### PR DESCRIPTION
## Summary
- ignore token hydration callbacks from an obsolete connection generation
- prevent stale token failures from showing after reconnect has already succeeded
- cover the connected-to-reconnecting-to-connected race with a regression test

Validated with the ConnectionProvider test suite, typecheck, ESLint, Prettier, and git diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when reconnecting.
  * Prevented outdated token requests from disrupting an active connection or displaying incorrect error messages.
  * Connections now remain stable after a successful reconnect, even if an earlier request later fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->