### PR TITLE
Fix Library artwork recovery after reconnects

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -90,6 +90,7 @@ vi.mock("../../../lib/coreApi", () => ({
   CoreAPI: {
     setWsInstance: vi.fn(),
     flushQueue: vi.fn(),
+    handleDisconnect: vi.fn(),
     reset: vi.fn(),
     processReceived: vi.fn().mockResolvedValue(null),
     media: vi.fn().mockResolvedValue({ database: {}, active: [] }),
@@ -2266,6 +2267,27 @@ describe("connection event handling", () => {
     },
   );
 
+  it("should cancel pending RPCs and image queries while reconnecting", () => {
+    const cancelSpy = vi.spyOn(QueryClient.prototype, "cancelQueries");
+
+    render(
+      <ConnectionProvider>
+        <ConnectionConsumer />
+      </ConnectionProvider>,
+    );
+    cancelSpy.mockClear();
+
+    capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
+      state: "reconnecting",
+      hasData: true,
+      hasConnectedBefore: true,
+    });
+
+    expect(CoreAPI.handleDisconnect).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["mediaImage"] });
+    cancelSpy.mockRestore();
+  });
+
   it("should clear stale client capabilities while reconnecting", () => {
     useStatusStore.setState({
       currentClient: {
@@ -2298,7 +2320,6 @@ describe("connection event handling", () => {
 
   it("should invalidate library queries after reconnecting", async () => {
     const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
-    const removeSpy = vi.spyOn(QueryClient.prototype, "removeQueries");
 
     render(
       <ConnectionProvider>
@@ -2306,7 +2327,6 @@ describe("connection event handling", () => {
       </ConnectionProvider>,
     );
     invalidateSpy.mockClear();
-    removeSpy.mockClear();
 
     capturedEventHandlers.onConnectionChange!("192.168.1.100:7497", {
       state: "connected",
@@ -2323,9 +2343,11 @@ describe("connection event handling", () => {
     });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["mediaBrowse"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["mediaMeta"] });
-    expect(removeSpy).toHaveBeenCalledWith({ queryKey: ["mediaImage"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["mediaImage"],
+      refetchType: "active",
+    });
     invalidateSpy.mockRestore();
-    removeSpy.mockRestore();
   });
 
   it("should fetch inbox messages when connected Core supports inbox", async () => {

--- a/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
@@ -67,9 +67,8 @@ describe("LibraryArtwork", () => {
       />,
     );
 
-    await waitFor(
-      () => expect(onAvailabilityChange).toHaveBeenCalledWith(true),
-      { timeout: 3000 },
+    await waitFor(() =>
+      expect(onAvailabilityChange).toHaveBeenCalledWith(true),
     );
     expect(requestLibraryImage).toHaveBeenCalledTimes(2);
   });

--- a/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
@@ -38,5 +38,39 @@ describe("LibraryArtwork", () => {
     await waitFor(() =>
       expect(onAvailabilityChange).toHaveBeenCalledWith(false),
     );
+    expect(requestLibraryImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry one transient connection failure", async () => {
+    vi.mocked(requestLibraryImage)
+      .mockRejectedValueOnce(new Error("Request timeout"))
+      .mockResolvedValueOnce({
+        url: "data:image/webp;base64,AAAA",
+        typeTag: "property:image-boxart",
+      });
+    const onAvailabilityChange = vi.fn();
+
+    render(
+      <LibraryArtwork
+        entry={{
+          mediaId: 42,
+          name: "Super Game",
+          path: "/roms/SNES/Super Game.sfc",
+          type: "media",
+          systemId: "SNES",
+        }}
+        systemId="SNES"
+        targetDeviceAddress="device-a"
+        maxSize={320}
+        priority="thumbnail"
+        onAvailabilityChange={onAvailabilityChange}
+      />,
+    );
+
+    await waitFor(
+      () => expect(onAvailabilityChange).toHaveBeenCalledWith(true),
+      { timeout: 3000 },
+    );
+    expect(requestLibraryImage).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/__tests__/unit/lib/coreApi.reset.test.ts
+++ b/src/__tests__/unit/lib/coreApi.reset.test.ts
@@ -35,16 +35,18 @@ describe("CoreAPI reset method", () => {
   });
 
   it("should reject sent requests on disconnect without clearing reconnect queue", async () => {
+    let isConnected = true;
     const mockWsManager = {
       send: vi.fn(),
-      isConnected: true,
-      destroy: vi.fn(),
-    };
+      get isConnected() {
+        return isConnected;
+      },
+    } satisfies Parameters<typeof CoreAPI.setWsInstance>[0];
 
-    CoreAPI.setWsInstance(mockWsManager as any);
+    CoreAPI.setWsInstance(mockWsManager);
     const sentPromise = CoreAPI.version();
 
-    mockWsManager.isConnected = false;
+    isConnected = false;
     CoreAPI.handleDisconnect();
     const queuedPromise = CoreAPI.media();
 
@@ -52,7 +54,7 @@ describe("CoreAPI reset method", () => {
       "Request cancelled: connection reset",
     );
 
-    mockWsManager.isConnected = true;
+    isConnected = true;
     CoreAPI.flushQueue();
 
     expect(mockWsManager.send).toHaveBeenCalledTimes(2);

--- a/src/__tests__/unit/lib/coreApi.reset.test.ts
+++ b/src/__tests__/unit/lib/coreApi.reset.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { CoreAPI } from "../../../lib/coreApi";
 
 describe("CoreAPI reset method", () => {
   beforeEach(() => {
     // Clear any existing state
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    CoreAPI.reset();
   });
 
   it("should clear response pool and cancel pending requests", async () => {

--- a/src/__tests__/unit/lib/coreApi.reset.test.ts
+++ b/src/__tests__/unit/lib/coreApi.reset.test.ts
@@ -30,6 +30,38 @@ describe("CoreAPI reset method", () => {
     );
   });
 
+  it("should reject sent requests on disconnect without clearing reconnect queue", async () => {
+    const mockWsManager = {
+      send: vi.fn(),
+      isConnected: true,
+      destroy: vi.fn(),
+    };
+
+    CoreAPI.setWsInstance(mockWsManager as any);
+    const sentPromise = CoreAPI.version();
+
+    mockWsManager.isConnected = false;
+    CoreAPI.handleDisconnect();
+    const queuedPromise = CoreAPI.media();
+
+    await expect(sentPromise).rejects.toThrow(
+      "Request cancelled: connection reset",
+    );
+
+    mockWsManager.isConnected = true;
+    CoreAPI.flushQueue();
+
+    expect(mockWsManager.send).toHaveBeenCalledTimes(2);
+    expect(mockWsManager.send).toHaveBeenLastCalledWith(
+      expect.stringContaining('"method":"media"'),
+    );
+
+    CoreAPI.reset();
+    await expect(queuedPromise).rejects.toThrow(
+      "Request cancelled: connection reset",
+    );
+  });
+
   it("should clear request queue", async () => {
     // Set up a mock WebSocket manager that's not connected
     const mockWsManager = {

--- a/src/__tests__/unit/lib/libraryImages.test.ts
+++ b/src/__tests__/unit/lib/libraryImages.test.ts
@@ -62,15 +62,15 @@ describe("Library image scheduler", () => {
 
     const first = requestLibraryImage(entry(1), "SNES", {
       maxSize: 128,
-      priority: "thumbnail",
+      priority: "detail",
     });
     const second = requestLibraryImage(entry(2), "SNES", {
       maxSize: 128,
-      priority: "thumbnail",
+      priority: "detail",
     });
     const third = requestLibraryImage(entry(3), "SNES", {
       maxSize: 128,
-      priority: "thumbnail",
+      priority: "detail",
     });
 
     await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(2));
@@ -80,6 +80,82 @@ describe("Library image scheduler", () => {
     resolvers[1]?.(IMAGE_RESPONSE);
     resolvers[2]?.(IMAGE_RESPONSE);
     await Promise.all([second, third]);
+  });
+
+  it("should space thumbnail starts by 800 milliseconds", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const imageSpy = vi
+      .spyOn(CoreAPI, "mediaImage")
+      .mockResolvedValue(IMAGE_RESPONSE);
+
+    try {
+      const first = requestLibraryImage(entry(1), "SNES", {
+        maxSize: 128,
+        priority: "thumbnail",
+      });
+      const second = requestLibraryImage(entry(2), "SNES", {
+        maxSize: 128,
+        priority: "thumbnail",
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(imageSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(799);
+      expect(imageSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(imageSpy).toHaveBeenCalledTimes(2);
+      await Promise.all([first, second]);
+    } finally {
+      clearQueuedLibraryImages();
+      vi.useRealTimers();
+    }
+  });
+
+  it("should let detail images bypass thumbnail pacing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const resolvers: Array<(value: MediaImageResponse) => void> = [];
+    const imageSpy = vi.spyOn(CoreAPI, "mediaImage").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    try {
+      const thumbnail = requestLibraryImage(entry(1), "SNES", {
+        maxSize: 128,
+        priority: "thumbnail",
+      });
+      const pacedThumbnail = requestLibraryImage(entry(2), "SNES", {
+        maxSize: 128,
+        priority: "thumbnail",
+      });
+      const detail = requestLibraryImage(entry(3), "SNES", {
+        maxSize: 512,
+        priority: "detail",
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(imageSpy).toHaveBeenCalledTimes(2);
+      expect(imageSpy.mock.calls[1]?.[0]).toEqual({
+        mediaId: 3,
+        imageTypes: undefined,
+        maxSize: 512,
+      });
+
+      resolvers[0]?.(IMAGE_RESPONSE);
+      resolvers[1]?.(IMAGE_RESPONSE);
+      await Promise.all([thumbnail, detail]);
+      await vi.advanceTimersByTimeAsync(800);
+      expect(imageSpy).toHaveBeenCalledTimes(3);
+      resolvers[2]?.(IMAGE_RESPONSE);
+      await pacedThumbnail;
+    } finally {
+      clearQueuedLibraryImages();
+      vi.useRealTimers();
+    }
   });
 
   it("should prioritize detail images over queued thumbnails", async () => {
@@ -109,18 +185,18 @@ describe("Library image scheduler", () => {
     });
 
     await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(2));
-    resolvers[0]?.(IMAGE_RESPONSE);
-    await activeOne;
-    await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(3));
-    expect(imageSpy.mock.calls[2]?.[0]).toEqual({
+    expect(imageSpy.mock.calls[1]?.[0]).toEqual({
       mediaId: 4,
       imageTypes: undefined,
       maxSize: 512,
     });
 
+    resolvers[0]?.(IMAGE_RESPONSE);
     resolvers[1]?.(IMAGE_RESPONSE);
+    await Promise.all([activeOne, queuedDetail]);
+    await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(3));
     resolvers[2]?.(IMAGE_RESPONSE);
-    await Promise.all([activeTwo, queuedDetail]);
+    await activeTwo;
     await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(4));
     resolvers[3]?.(IMAGE_RESPONSE);
     await queuedThumbnail;
@@ -136,7 +212,7 @@ describe("Library image scheduler", () => {
       requestLibraryImage(entry(42), "SNES", {
         imageTypes: ["boxart"],
         maxSize: 128,
-        priority: "thumbnail",
+        priority: "detail",
       }),
     ).resolves.toEqual({
       url: "data:image/webp;base64,AAAA",
@@ -160,6 +236,66 @@ describe("Library image scheduler", () => {
     );
   });
 
+  it("should not fall back to path after a transport failure", async () => {
+    const imageSpy = vi
+      .spyOn(CoreAPI, "mediaImage")
+      .mockRejectedValue(new Error("Request timeout"));
+
+    await expect(
+      requestLibraryImage(entry(42), "SNES", {
+        maxSize: 128,
+        priority: "detail",
+      }),
+    ).rejects.toThrow("Request timeout");
+
+    expect(imageSpy).toHaveBeenCalledTimes(1);
+    expect(imageSpy).toHaveBeenCalledWith(
+      { mediaId: 42, imageTypes: undefined, maxSize: 128 },
+      undefined,
+    );
+  });
+
+  it("should retain active slots until aborted Core requests settle", async () => {
+    const resolvers: Array<(value: MediaImageResponse) => void> = [];
+    const imageSpy = vi.spyOn(CoreAPI, "mediaImage").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const activeOne = requestLibraryImage(entry(1), "SNES", {
+      maxSize: 128,
+      priority: "thumbnail",
+      signal: firstController.signal,
+    });
+    const activeTwo = requestLibraryImage(entry(2), "SNES", {
+      maxSize: 128,
+      priority: "detail",
+      signal: secondController.signal,
+    });
+    const replacement = requestLibraryImage(entry(3), "SNES", {
+      maxSize: 128,
+      priority: "thumbnail",
+    });
+
+    await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(2));
+    firstController.abort();
+    secondController.abort();
+    await Promise.resolve();
+    expect(imageSpy).toHaveBeenCalledTimes(2);
+
+    resolvers[0]?.(IMAGE_RESPONSE);
+    await expect(activeOne).rejects.toThrow("cancelled");
+    await vi.waitFor(() => expect(imageSpy).toHaveBeenCalledTimes(3));
+
+    resolvers[1]?.(IMAGE_RESPONSE);
+    await expect(activeTwo).rejects.toThrow("cancelled");
+    resolvers[2]?.(IMAGE_RESPONSE);
+    await replacement;
+  });
+
   it("should cancel queued requests before they reach Core", async () => {
     const resolvers: Array<(value: MediaImageResponse) => void> = [];
     const imageSpy = vi.spyOn(CoreAPI, "mediaImage").mockImplementation(
@@ -170,11 +306,11 @@ describe("Library image scheduler", () => {
     );
     const activeOne = requestLibraryImage(entry(1), "SNES", {
       maxSize: 128,
-      priority: "thumbnail",
+      priority: "detail",
     });
     const activeTwo = requestLibraryImage(entry(2), "SNES", {
       maxSize: 128,
-      priority: "thumbnail",
+      priority: "detail",
     });
     const controller = new AbortController();
     const queued = requestLibraryImage(entry(3), "SNES", {

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.lifecycle.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.lifecycle.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WebSocketTransport } from "../../../../lib/transport/WebSocketTransport";
 import type { TransportState } from "../../../../lib/transport/types";
-import { logger } from "../../../../lib/logger";
+import { logger } from "@/lib/logger";
 
 /**
  * MockWebSocket that allows manual triggering of WebSocket events.
@@ -181,8 +181,10 @@ describe("WebSocketTransport lifecycle", () => {
         undefined,
         expect.objectContaining({
           action: "socket-close",
+          category: "websocket",
           code: 1006,
           reason: "network lost",
+          severity: "warning",
           wasClean: false,
         }),
       );

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.lifecycle.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.lifecycle.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { WebSocketTransport } from "../../../../lib/transport/WebSocketTransport";
 import type { TransportState } from "../../../../lib/transport/types";
+import { logger } from "../../../../lib/logger";
 
 /**
  * MockWebSocket that allows manual triggering of WebSocket events.
@@ -159,6 +160,32 @@ describe("WebSocketTransport lifecycle", () => {
 
       expect(transport.state).toBe("reconnecting");
       expect(stateChanges).toContain("reconnecting");
+
+      transport.destroy();
+    });
+
+    it("should log close metadata for unexpected disconnects", () => {
+      const transport = new WebSocketTransport({
+        deviceId: "test-device",
+        url: "ws://localhost:7497",
+      });
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      transport.connect();
+      const ws = MockWebSocket.getLatest()!;
+      ws.simulateOpen();
+      ws.simulateClose(1006, "network lost");
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[Transport:test-device] WebSocket closed",
+        undefined,
+        expect.objectContaining({
+          action: "socket-close",
+          code: 1006,
+          reason: "network lost",
+          wasClean: false,
+        }),
+      );
 
       transport.destroy();
     });

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/lib/models";
 import { isCoreFeatureAvailable } from "@/lib/featureGates";
 import { invalidateLibraryImageCache } from "@/lib/libraryImageCache";
+import { clearQueuedLibraryImages } from "@/lib/libraryImages";
 import { LIBRARY_QUERY_KEYS } from "@/lib/libraryMedia";
 import { satisfies as versionSatisfies } from "@/lib/coreVersion";
 import {
@@ -925,7 +926,10 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     queryClient.invalidateQueries({
       queryKey: [LIBRARY_QUERY_KEYS.meta],
     });
-    queryClient.removeQueries({ queryKey: [LIBRARY_QUERY_KEYS.image] });
+    void queryClient.invalidateQueries({
+      queryKey: [LIBRARY_QUERY_KEYS.image],
+      refetchType: "active",
+    });
 
     const fetchMediaState = (retryDelayMs: number) => {
       const scheduledFor = currentConnectionId.current;
@@ -1151,6 +1155,26 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
           if (connection.state !== "connected") {
             invalidateCurrentClientRequest();
             setCurrentClient(null);
+            CoreAPI.handleDisconnect();
+            void queryClient.cancelQueries({
+              queryKey: [LIBRARY_QUERY_KEYS.image],
+            });
+            const imageRequests = clearQueuedLibraryImages();
+            if (
+              imageRequests.activeRequests > 0 ||
+              imageRequests.queuedRequests > 0
+            ) {
+              logger.error(
+                "Library image requests cancelled after connection reset",
+                undefined,
+                {
+                  category: "queue",
+                  action: "library-images-disconnect",
+                  severity: "info",
+                  ...imageRequests,
+                },
+              );
+            }
           }
 
           // Each new connect attempt starts unverified — clear stale signals
@@ -1332,6 +1356,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setPairingRequired,
     setDeviceHistory,
     mapTransportState,
+    queryClient,
     // Note: handleConnectionOpen, processNotification, and t are accessed via refs
     // to prevent this effect from re-running when those callbacks change
   ]);

--- a/src/components/library/LibraryArtwork.tsx
+++ b/src/components/library/LibraryArtwork.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { FileIcon } from "lucide-react";
+import { isTransientApiConnectionError } from "@/lib/coreApi";
 import { requestLibraryImage } from "@/lib/libraryImages";
 import { LIBRARY_QUERY_KEYS, mediaRefKey } from "@/lib/libraryMedia";
 import type { MediaBrowseEntry } from "@/lib/models";
@@ -44,7 +45,8 @@ export function LibraryArtwork(props: {
     enabled,
     staleTime: Infinity,
     gcTime: 2 * 60 * 1000,
-    retry: false,
+    retry: (failureCount, error) =>
+      failureCount < 1 && isTransientApiConnectionError(error),
   });
 
   useEffect(() => {

--- a/src/lib/coreApi.ts
+++ b/src/lib/coreApi.ts
@@ -161,6 +161,29 @@ export function isMissingMediaImageError(error: unknown): boolean {
   );
 }
 
+export function isMediaIdLookupError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes("media id not found") ||
+    message.includes("media not found") ||
+    message.includes("no media found")
+  );
+}
+
+export function isTransientApiConnectionError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return [
+    "request timeout",
+    "request requires active connection",
+    "connection reset",
+    "connection closed",
+    "transport send error",
+    "websocket",
+    "socket is not open",
+    "readystate",
+  ].some((token) => message.includes(token));
+}
+
 export function isMissingMediaDatabaseSetupError(error: unknown): boolean {
   const message = getErrorMessage(error).toLowerCase();
   return (
@@ -436,15 +459,15 @@ class CoreApi {
     }
   }
 
-  // Method to reset all internal state - useful when reconnecting to a different device
-  reset() {
-    logger.log("Resetting CoreAPI state");
-
+  /**
+   * Reject requests sent through a socket that is no longer usable. Requests
+   * created after this point remain in requestQueue for the next connection.
+   */
+  handleDisconnect() {
     const cancelError = new RequestCancelledError(
       "Request cancelled: connection reset",
     );
 
-    // Clear all pending response promises with rejection
     Object.keys(this.responsePool).forEach((id) => {
       const responsePromise = this.responsePool[id];
       if (!responsePromise) return;
@@ -452,12 +475,19 @@ class CoreApi {
         clearTimeout(responsePromise.timeoutId);
       }
       responsePromise.reject(cancelError);
-    });
-
-    // Clear response pool contents
-    Object.keys(this.responsePool).forEach((id) => {
       delete this.responsePool[id];
     });
+    this.pendingWriteId = null;
+  }
+
+  // Method to reset all internal state - useful when reconnecting to a different device
+  reset() {
+    logger.log("Resetting CoreAPI state");
+    this.handleDisconnect();
+
+    const cancelError = new RequestCancelledError(
+      "Request cancelled: connection reset",
+    );
 
     // Clear request queue
     this.requestQueue.forEach((queued) => {

--- a/src/lib/libraryImages.ts
+++ b/src/lib/libraryImages.ts
@@ -1,5 +1,6 @@
 import {
   CoreAPI,
+  isMediaIdLookupError,
   isMissingMediaImageError,
   isRequestCancelledError,
 } from "@/lib/coreApi";
@@ -30,21 +31,45 @@ interface QueuedImageRequest {
 export type LibraryImageResult = CachedLibraryImage;
 
 const MAX_CONCURRENT_IMAGE_REQUESTS = 2;
+const THUMBNAIL_START_INTERVAL_MS = 800;
 let activeRequests = 0;
 let thumbnailsPaused = false;
+let lastThumbnailStartedAt: number | null = null;
+let thumbnailStartTimer: ReturnType<typeof setTimeout> | undefined;
 const queue: QueuedImageRequest[] = [];
+
+function scheduleThumbnailDrain(delay: number): void {
+  if (thumbnailStartTimer) return;
+  thumbnailStartTimer = setTimeout(() => {
+    thumbnailStartTimer = undefined;
+    drainQueue();
+  }, delay);
+}
 
 function drainQueue(): void {
   while (activeRequests < MAX_CONCURRENT_IMAGE_REQUESTS && queue.length > 0) {
-    const request = queue.shift();
+    const request = queue[0];
     if (!request) return;
     if (request.signal?.aborted) {
+      queue.shift();
       request.removeAbortListener();
       request.reject(
         new RequestCancelledError("Media image request cancelled"),
       );
       continue;
     }
+    if (request.priority === "thumbnail") {
+      const elapsed = Date.now() - (lastThumbnailStartedAt ?? 0);
+      if (
+        lastThumbnailStartedAt !== null &&
+        elapsed < THUMBNAIL_START_INTERVAL_MS
+      ) {
+        scheduleThumbnailDrain(THUMBNAIL_START_INTERVAL_MS - elapsed);
+        return;
+      }
+      lastThumbnailStartedAt = Date.now();
+    }
+    queue.shift();
 
     activeRequests++;
     void request
@@ -123,6 +148,12 @@ function requestParams(
   return { ...shared, system, path: entry.path };
 }
 
+function throwIfImageRequestCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new RequestCancelledError("Media image request cancelled");
+  }
+}
+
 async function fetchImage(
   entry: MediaBrowseEntry,
   fallbackSystemId: string,
@@ -141,11 +172,17 @@ async function fetchImage(
 
   let response: MediaImageResponse;
   try {
-    response = await CoreAPI.mediaImage(primary, signal);
+    // Once sent, keep this scheduler slot occupied until Core settles the RPC.
+    // Aborting only the local promise would let rapid scrolling exceed the
+    // physical concurrency limit while Core continues processing old requests.
+    response = await CoreAPI.mediaImage(primary, undefined);
+    throwIfImageRequestCancelled(signal);
   } catch (error) {
+    throwIfImageRequestCancelled(signal);
     if (isRequestCancelledError(error)) throw error;
     if (isMissingMediaImageError(error)) return null;
-    if (entry.mediaId === undefined) throw error;
+    if (entry.mediaId === undefined || !isMediaIdLookupError(error))
+      throw error;
     const fallback = requestParams(
       entry,
       fallbackSystemId,
@@ -155,8 +192,10 @@ async function fetchImage(
     );
     if (!fallback) throw error;
     try {
-      response = await CoreAPI.mediaImage(fallback, signal);
+      response = await CoreAPI.mediaImage(fallback, undefined);
+      throwIfImageRequestCancelled(signal);
     } catch (fallbackError) {
+      throwIfImageRequestCancelled(signal);
       if (isMissingMediaImageError(fallbackError)) return null;
       throw fallbackError;
     }
@@ -185,7 +224,7 @@ function persistentCacheKey(
   )}\u0000size:${maxSize}`;
 }
 
-export function requestLibraryImage(
+export async function requestLibraryImage(
   entry: MediaBrowseEntry,
   fallbackSystemId: string,
   options: {
@@ -196,25 +235,23 @@ export function requestLibraryImage(
     signal?: AbortSignal;
   },
 ): Promise<LibraryImageResult | null> {
+  const cacheKey = persistentCacheKey(
+    entry,
+    fallbackSystemId,
+    options.imageTypes,
+    options.maxSize,
+  );
+  if (cacheKey) {
+    const cached = await readLibraryImageCache(
+      options.targetDeviceAddress,
+      cacheKey,
+    );
+    throwIfImageRequestCancelled(options.signal);
+    if (cached.hit) return cached.value;
+  }
+
   return scheduleImageRequest(
     async () => {
-      const cacheKey = persistentCacheKey(
-        entry,
-        fallbackSystemId,
-        options.imageTypes,
-        options.maxSize,
-      );
-      if (cacheKey) {
-        const cached = await readLibraryImageCache(
-          options.targetDeviceAddress,
-          cacheKey,
-        );
-        if (options.signal?.aborted) {
-          throw new RequestCancelledError("Media image request cancelled");
-        }
-        if (cached.hit) return cached.value;
-      }
-
       const result = await fetchImage(
         entry,
         fallbackSystemId,
@@ -248,11 +285,24 @@ export function resumeLibraryThumbnails(): void {
   drainQueue();
 }
 
-export function clearQueuedLibraryImages(): void {
+export function clearQueuedLibraryImages(): {
+  activeRequests: number;
+  queuedRequests: number;
+} {
+  if (thumbnailStartTimer) {
+    clearTimeout(thumbnailStartTimer);
+    thumbnailStartTimer = undefined;
+  }
+  lastThumbnailStartedAt = null;
+  const requestCounts = {
+    activeRequests,
+    queuedRequests: queue.length,
+  };
   while (queue.length > 0) {
     const request = queue.shift();
     if (!request) continue;
     request.removeAbortListener();
     request.reject(new RequestCancelledError("Media image queue cleared"));
   }
+  return requestCounts;
 }

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -354,8 +354,15 @@ export class WebSocketTransport implements Transport {
       void this.initEncryption();
     };
 
-    this.ws.onclose = () => {
-      logger.debug(`[Transport:${this.deviceId}] WebSocket closed`);
+    this.ws.onclose = (event) => {
+      logger.error(`[Transport:${this.deviceId}] WebSocket closed`, undefined, {
+        category: "websocket",
+        action: "socket-close",
+        severity: "warning",
+        code: event.code,
+        reason: event.reason || "none",
+        wasClean: event.wasClean,
+      });
       this.clearConnectionTimeout();
       this.heartReset();
       // Silent close while attempting encrypted handshake — server likely
@@ -870,8 +877,14 @@ export class WebSocketTransport implements Transport {
 
           // Start pong timeout - if no response, force disconnect
           this.pongTimeoutId = setTimeout(() => {
-            logger.warn(
+            logger.error(
               `[Transport:${this.deviceId}] Pong timeout - forcing disconnect`,
+              undefined,
+              {
+                category: "websocket",
+                action: "heartbeat-timeout",
+                severity: "warning",
+              },
             );
             // Close and null handlers before triggering disconnect to prevent
             // onclose from firing a duplicate handleDisconnection()
@@ -907,7 +920,15 @@ export class WebSocketTransport implements Transport {
   private startConnectionTimeout(): void {
     this.clearConnectionTimeout();
     this.connectionTimer = setTimeout(() => {
-      logger.warn(`[Transport:${this.deviceId}] Connection timeout`);
+      logger.error(
+        `[Transport:${this.deviceId}] Connection timeout`,
+        undefined,
+        {
+          category: "websocket",
+          action: "connection-timeout",
+          severity: "warning",
+        },
+      );
       if (this.ws && this.ws.readyState === WebSocket.CONNECTING) {
         this.ws.close();
       }

--- a/src/test-utils/index.tsx
+++ b/src/test-utils/index.tsx
@@ -16,6 +16,7 @@ export const createTestQueryClient = () =>
     defaultOptions: {
       queries: {
         retry: false,
+        retryDelay: 0,
         staleTime: Infinity,
       },
       mutations: {


### PR DESCRIPTION
## Summary

- cancel stale RPC and artwork state immediately when WebSocket disconnects, then refetch visible artwork after reconnect
- preserve two actual in-flight image requests during rapid scrolling and pace thumbnail starts below Core generic WebSocket quota
- retry only transient artwork transport failures and avoid path fallback for unrelated errors
- report actionable WebSocket close and image queue diagnostics
- add reconnect, cancellation, pacing, retry, and close-metadata regression coverage

Validated with full 3,307-test suite, TypeScript, ESLint, and Prettier.

Ref ZaparooProject/zaparoo-core#1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery by safely cancelling in-flight requests and refreshing library images after reconnecting.
  * Added one retry for artwork images after temporary connection failures.
  * Improved library image scheduling, cancellation, caching, and thumbnail request pacing.
  * Enhanced WebSocket diagnostics with structured details for unexpected closures and timeouts.

* **Tests**
  * Expanded coverage for reconnect behavior, request cancellation, image retries, scheduling, and WebSocket lifecycle logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->