### PR TITLE
Harden device lifecycle recovery

### DIFF
--- a/src/__tests__/unit/components/ConnectionProvider.test.tsx
+++ b/src/__tests__/unit/components/ConnectionProvider.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
+import { SecureStorage } from "@aparajita/capacitor-secure-storage";
 import type { ConnectionStatus } from "@capacitor/network";
 import {
   __simulateDeviceDiscovered,
@@ -17,7 +18,10 @@ import {
 import { QueryClient } from "@tanstack/react-query";
 import { act, render, screen, waitFor } from "../../../test-utils";
 import { ConnectionProvider } from "../../../components/ConnectionProvider";
-import { useConnection } from "../../../hooks/useConnection";
+import {
+  useConnection,
+  useDeviceConnectionActions,
+} from "../../../hooks/useConnection";
 import { connectionManager } from "../../../lib/transport";
 import { CoreAPI } from "@/lib/coreApi";
 import {
@@ -250,10 +254,14 @@ vi.mock("../../../components/A11yAnnouncer", () => ({
 
 // test-utils already provides QueryClientProvider, so we use render directly
 
+let forgetDeviceFromContext: ((recordId: string) => Promise<void>) | null =
+  null;
+
 // Test component that uses the connection context
 function ConnectionConsumer() {
   const { isConnected, hasData, showConnecting, showReconnecting } =
     useConnection();
+  forgetDeviceFromContext = useDeviceConnectionActions().forgetDevice;
   return (
     <div>
       <span data-testid="isConnected">{String(isConnected)}</span>
@@ -284,6 +292,7 @@ async function resetStore() {
 describe("ConnectionProvider", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    forgetDeviceFromContext = null;
     await resetStore();
 
     const bridge = await import("@/lib/capacitorBridge");
@@ -355,6 +364,159 @@ describe("ConnectionProvider", () => {
       expect(Preferences.get).not.toHaveBeenCalled();
       expect(App.addListener).not.toHaveBeenCalled();
       expect(Network.addListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("forgetting the active device", () => {
+    it("should recreate the owned transport when credential deletion fails", async () => {
+      vi.mocked(SecureStorage.remove).mockRejectedValueOnce(
+        new Error("secure storage deletion failed"),
+      );
+      render(
+        <ConnectionProvider>
+          <ConnectionConsumer />
+        </ConnectionProvider>,
+      );
+
+      await waitFor(() => {
+        expect(connectionManager.addDevice).toHaveBeenCalledTimes(1);
+      });
+
+      let caught: unknown;
+      await act(async () => {
+        try {
+          await forgetDeviceFromContext!(RECORD_ID);
+        } catch (error) {
+          caught = error;
+        }
+      });
+
+      expect(caught).toEqual(new Error("secure storage deletion failed"));
+      expect(connectionManager.removeDevice).toHaveBeenCalledWith(RECORD_ID);
+      expect(deviceRegistry.getSnapshot().records[RECORD_ID]).toBeDefined();
+      await waitFor(() => {
+        expect(connectionManager.addDevice).toHaveBeenCalledTimes(2);
+        expect(CoreAPI.setWsInstance).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("should not connect a device activated while it is being forgotten", async () => {
+      const inactiveRecordId = "inactive-record";
+      await seedDeviceRegistry(
+        [
+          mockDeviceRecord({ recordId: RECORD_ID, address: DEVICE_ADDRESS }),
+          mockDeviceRecord({
+            recordId: inactiveRecordId,
+            address: "192.168.1.101:7497",
+          }),
+        ],
+        RECORD_ID,
+      );
+
+      let releaseCanonicalDelete!: () => void;
+      vi.mocked(SecureStorage.remove).mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            releaseCanonicalDelete = () => resolve(false);
+          }),
+      );
+      render(
+        <ConnectionProvider>
+          <ConnectionConsumer />
+        </ConnectionProvider>,
+      );
+
+      let forgetting!: Promise<void>;
+      await act(async () => {
+        forgetting = forgetDeviceFromContext!(inactiveRecordId);
+        await Promise.resolve();
+      });
+      await vi.waitFor(() => {
+        expect(SecureStorage.remove).toHaveBeenCalledWith(
+          credentialKeyForRecord(inactiveRecordId),
+        );
+      });
+
+      await act(async () => {
+        await deviceRegistry.setActiveRecord(inactiveRecordId);
+      });
+      expect(connectionManager.addDevice).not.toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: inactiveRecordId }),
+      );
+
+      releaseCanonicalDelete();
+      await act(async () => {
+        await forgetting;
+      });
+
+      expect(
+        deviceRegistry.getSnapshot().records[inactiveRecordId],
+      ).toBeUndefined();
+      expect(connectionManager.addDevice).not.toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: inactiveRecordId }),
+      );
+    });
+
+    it("should await started credential work before deleting the record", async () => {
+      await seedDeviceRegistry(
+        [
+          mockDeviceRecord({
+            recordId: RECORD_ID,
+            address: DEVICE_ADDRESS,
+            legacyCredentialKey: "192.168.1.100",
+          }),
+        ],
+        RECORD_ID,
+      );
+      await credentialStore.set("192.168.1.100", {
+        authToken: "token-abc",
+        pairingKey: "a".repeat(64),
+        clientId: "client-uuid-1234",
+        pairedAt: 1700000000000,
+      });
+
+      let finishPromotion!: (settled: boolean) => void;
+      vi.spyOn(
+        credentialStore,
+        "promoteRecordCredentials",
+      ).mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishPromotion = resolve;
+          }),
+      );
+      const removeRecord = vi.spyOn(deviceRegistry, "removeRecord");
+
+      render(
+        <ConnectionProvider>
+          <ConnectionConsumer />
+        </ConnectionProvider>,
+      );
+      const [config] = vi
+        .mocked(connectionManager.addDevice)
+        .mock.calls.at(-1)!;
+      await config.encryption!.getCredentials();
+      capturedEventHandlers.onEncryptedHandshakeOk!();
+
+      let forgetting!: Promise<void>;
+      await act(async () => {
+        forgetting = forgetDeviceFromContext!(RECORD_ID);
+        await Promise.resolve();
+      });
+
+      expect(connectionManager.removeDevice).toHaveBeenCalledWith(RECORD_ID);
+      expect(removeRecord).not.toHaveBeenCalled();
+
+      finishPromotion(true);
+      await act(async () => {
+        await forgetting;
+      });
+
+      expect(removeRecord).toHaveBeenCalledWith(RECORD_ID);
+      expect(deviceRegistry.getSnapshot().records[RECORD_ID]).toBeUndefined();
+      await expect(
+        credentialStore.get(credentialKeyForRecord(RECORD_ID)),
+      ).resolves.toBeNull();
     });
   });
 

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: vi.fn().mockReturnValue("ios"),
     isNativePlatform: vi.fn().mockReturnValue(true),
+    isPluginAvailable: vi.fn().mockReturnValue(true),
   },
 }));
 

--- a/src/__tests__/unit/lib/devices/deviceRegistry.test.ts
+++ b/src/__tests__/unit/lib/devices/deviceRegistry.test.ts
@@ -9,6 +9,7 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
+import { SecureStorage } from "@aparajita/capacitor-secure-storage";
 import {
   __resetDeviceRegistryForTests,
   activeAddressOf,
@@ -482,6 +483,71 @@ describe("forgetting a device", () => {
     // `typed` is still paired under that key and was not the record forgotten.
     expect(deviceRegistry.getSnapshot().records[typed!.recordId]).toBeDefined();
     await expect(credentialStore.get("10.0.0.206")).resolves.toEqual(creds);
+  });
+
+  it("should preserve a legacy pairing claimed during canonical deletion", async () => {
+    const target = await deviceRegistry.selectAddress("10.0.0.206");
+    await credentialStore.set("10.0.0.206", creds);
+
+    let releaseCanonicalDelete!: () => void;
+    vi.mocked(SecureStorage.remove).mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          releaseCanonicalDelete = () => resolve(false);
+        }),
+    );
+
+    const removal = deviceRegistry.removeRecord(target!.recordId);
+    await vi.waitFor(() => {
+      expect(SecureStorage.remove).toHaveBeenCalledWith(
+        credentialKeyForRecord(target!.recordId),
+      );
+    });
+
+    const discovered = await deviceRegistry.selectDiscovered({
+      discoveryId: "device-a",
+      hostname: "steamdeck.local",
+      addresses: ["10.0.0.206"],
+      port: 7497,
+    });
+    expect(discovered?.legacyCredentialKey).toBe("10.0.0.206");
+
+    releaseCanonicalDelete();
+    await removal;
+
+    expect(
+      deviceRegistry.getSnapshot().records[discovered!.recordId],
+    ).toBeDefined();
+    await expect(credentialStore.get("10.0.0.206")).resolves.toEqual(creds);
+  });
+
+  it("should not resurrect a removed record from a queued update", async () => {
+    const target = await deviceRegistry.selectAddress("10.0.0.207");
+    await credentialStore.set("10.0.0.207", creds);
+
+    let releaseLegacyDelete!: () => void;
+    vi.mocked(SecureStorage.remove)
+      .mockResolvedValueOnce(false)
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            releaseLegacyDelete = () => resolve(true);
+          }),
+      );
+
+    const removal = deviceRegistry.removeRecord(target!.recordId);
+    await vi.waitFor(() => {
+      expect(SecureStorage.remove).toHaveBeenCalledWith("10.0.0.207");
+    });
+    const rename = deviceRegistry.setCustomName(target!.recordId, "Too late");
+
+    releaseLegacyDelete();
+    await removal;
+    await rename;
+
+    expect(
+      deviceRegistry.getSnapshot().records[target!.recordId],
+    ).toBeUndefined();
   });
 
   it("should ignore removal of an unknown record", async () => {

--- a/src/__tests__/unit/lib/nfc.test.ts
+++ b/src/__tests__/unit/lib/nfc.test.ts
@@ -348,6 +348,95 @@ describe("nfc", () => {
       }
     });
 
+    it.each(["success", "cancellation"] as const)(
+      "should release the session when listener removal rejects after %s",
+      async (outcome) => {
+        const firstRead = readTag();
+
+        await vi.waitFor(() => {
+          expect(mockState.listenerHandles.length).toBe(3);
+        });
+        mockState.listenerHandles[0]!.remove.mockRejectedValueOnce(
+          new Error("native listener removal failed"),
+        );
+
+        if (outcome === "success") {
+          mockState.nfcTagScannedCallback?.({
+            nfcTag: { id: [1, 2, 3, 4] },
+          } as NfcTagScannedEvent);
+        } else {
+          mockState.scanSessionCanceledCallback?.();
+        }
+
+        await expect(firstRead).resolves.toMatchObject({
+          status: outcome === "success" ? Status.Success : Status.Cancelled,
+        });
+        expect(sessionManager.isScanning).toBe(false);
+        expect(logger.error).toHaveBeenCalledWith(
+          "Failed to remove NFC session listener",
+          expect.any(Error),
+          expect.objectContaining({ action: "removeSessionListener" }),
+        );
+
+        const secondRead = readTag();
+        await vi.waitFor(() => {
+          expect(mockState.listenerHandles.length).toBe(6);
+        });
+        mockState.nfcTagScannedCallback?.({
+          nfcTag: { id: [5, 6, 7, 8] },
+        } as NfcTagScannedEvent);
+
+        await expect(secondRead).resolves.toMatchObject({
+          status: Status.Success,
+        });
+      },
+    );
+
+    it("should ignore stale callbacks when listener removal fails", async () => {
+      const firstWrite = writeTag("old operation");
+
+      await vi.waitFor(() => {
+        expect(mockState.listenerHandles.length).toBe(3);
+      });
+      const staleTagCallback = mockState.nfcTagScannedCallback!;
+      const staleCancelCallback = mockState.scanSessionCanceledCallback!;
+      const staleErrorCallback = mockState.scanSessionErrorCallback!;
+      for (const handle of mockState.listenerHandles) {
+        handle.remove.mockRejectedValueOnce(
+          new Error("native listener removal failed"),
+        );
+      }
+
+      await cancelSession();
+      await expect(firstWrite).resolves.toMatchObject({
+        status: Status.Cancelled,
+      });
+
+      const stopCallsAfterCancellation = mockStopScanSession.mock.calls.length;
+      const secondRead = readTag();
+      await vi.waitFor(() => {
+        expect(mockState.listenerHandles.length).toBe(6);
+      });
+
+      await staleTagCallback({
+        nfcTag: { id: [1, 2, 3, 4] },
+      } as NfcTagScannedEvent);
+      await staleCancelCallback();
+      await staleErrorCallback(new Error("stale native error"));
+
+      expect(mockWrite).not.toHaveBeenCalled();
+      expect(mockStopScanSession).toHaveBeenCalledTimes(
+        stopCallsAfterCancellation,
+      );
+
+      mockState.nfcTagScannedCallback?.({
+        nfcTag: { id: [5, 6, 7, 8] },
+      } as NfcTagScannedEvent);
+      await expect(secondRead).resolves.toMatchObject({
+        status: Status.Success,
+      });
+    });
+
     it("should return Cancelled status when scan is cancelled", async () => {
       const readPromise = readTag();
 

--- a/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
+++ b/src/__tests__/unit/lib/transport/WebSocketTransport.encryption.test.ts
@@ -192,6 +192,56 @@ describe("WebSocketTransport encryption", () => {
       transport.destroy();
     });
 
+    it("should discard encryption that finishes after the socket is replaced", async () => {
+      let resolveStaleEncryption!: (frame: string) => void;
+      const staleSession = {
+        ...makeMockSession(),
+        encryptAndFrame: vi.fn(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveStaleEncryption = resolve;
+            }),
+        ),
+      };
+      const replacementSession = makeMockSession();
+      vi.mocked(EncryptedSession.create)
+        .mockResolvedValueOnce(staleSession as unknown as EncryptedSession)
+        .mockResolvedValueOnce(
+          replacementSession as unknown as EncryptedSession,
+        );
+
+      const transport = makeTransport();
+      transport.connect();
+
+      const staleSocket = MockWebSocket.getLatest()!;
+      staleSocket.simulateOpen();
+      await flushPromises();
+      transport.send("stale-request");
+      await flushPromises();
+      expect(staleSession.encryptAndFrame).toHaveBeenCalledWith(
+        "stale-request",
+      );
+
+      transport.disconnect();
+      transport.connect();
+      const replacementSocket = MockWebSocket.getLatest()!;
+      replacementSocket.simulateOpen();
+      await flushPromises();
+
+      transport.send("replacement-request");
+      await flushPromises();
+      expect(replacementSocket.sentMessages).toHaveLength(1);
+
+      resolveStaleEncryption("stale-frame");
+      await flushPromises();
+
+      expect(staleSocket.sentMessages).toHaveLength(0);
+      expect(replacementSocket.sentMessages).toHaveLength(1);
+      expect(replacementSocket.sentMessages[0]).not.toBe("stale-frame");
+
+      transport.destroy();
+    });
+
     it("should decrypt incoming frames and fire onMessage + onEncryptedHandshakeOk", async () => {
       const onMessage = vi.fn();
       const onEncryptedHandshakeOk = vi.fn();

--- a/src/__tests__/unit/routes/settings.devices-detail.test.tsx
+++ b/src/__tests__/unit/routes/settings.devices-detail.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { CoreAPI } from "@/lib/coreApi";
+import { Preferences } from "@capacitor/preferences";
+import { SecureStorage } from "@aparajita/capacitor-secure-storage";
+import toast from "react-hot-toast";
 import {
   credentialKeyForRecord,
   credentialStore,
@@ -12,17 +14,19 @@ import {
   deviceRegistry,
   type DeviceRecord,
 } from "@/lib/devices/deviceRegistry";
-import { ConnectionState, useStatusStore } from "@/lib/store";
 import {
   mockDeviceRecord,
   seedDeviceRegistry,
 } from "@/test-utils/deviceRegistry";
 
-const { componentRef, mockNavigate, mockParams } = vi.hoisted(() => ({
-  componentRef: { current: null as any },
-  mockNavigate: vi.fn(),
-  mockParams: { current: { recordId: "" } },
-}));
+const { componentRef, mockForgetDevice, mockNavigate, mockParams } = vi.hoisted(
+  () => ({
+    componentRef: { current: null as any },
+    mockForgetDevice: vi.fn(),
+    mockNavigate: vi.fn(),
+    mockParams: { current: { recordId: "" } },
+  }),
+);
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual = (await importOriginal()) as any;
@@ -47,9 +51,16 @@ vi.mock("@/hooks/usePageHeadingFocus", () => ({
   usePageHeadingFocus: vi.fn(),
 }));
 
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
 const mockIsConnected = vi.fn(() => true);
 vi.mock("@/hooks/useConnection", () => ({
   useConnection: () => ({ isConnected: mockIsConnected() }),
+  useDeviceConnectionActions: () => ({ forgetDevice: mockForgetDevice }),
 }));
 
 import "@/routes/settings.devices_.$recordId";
@@ -94,6 +105,9 @@ describe("Settings Device Detail Route", () => {
       },
     });
     mockIsConnected.mockReturnValue(true);
+    mockForgetDevice.mockImplementation((recordId: string) =>
+      deviceRegistry.removeRecord(recordId),
+    );
     await seedRecord();
   });
 
@@ -257,18 +271,13 @@ describe("Settings Device Detail Route", () => {
     });
   });
 
-  it("should tear the connection down when forgetting the active device", async () => {
-    await seedRecord(true);
+  it("should keep the device available without orphaning credentials when registry persistence fails", async () => {
     const user = userEvent.setup();
-    useStatusStore.setState({
-      connectionState: ConnectionState.CONNECTED,
-      connected: true,
-      connectionError: "stale error",
-    });
-    CoreAPI.setWsInstance({
-      isConnected: true,
-      send: () => {},
-    } as unknown as Parameters<typeof CoreAPI.setWsInstance>[0]);
+    const credentialKey = credentialKeyForRecord(record.recordId);
+    await credentialStore.set(credentialKey, credentials);
+    vi.mocked(Preferences.set).mockRejectedValueOnce(
+      new Error("preferences write failed"),
+    );
     renderRoute();
 
     await user.click(
@@ -281,12 +290,80 @@ describe("Settings Device Detail Route", () => {
     );
 
     await waitFor(() => {
-      expect(useStatusStore.getState().connectionState).toBe(
-        ConnectionState.IDLE,
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings.deviceDetail.forgetFailed",
       );
     });
-    expect(useStatusStore.getState().connectionError).toBe("");
-    expect(CoreAPI.isConnected()).toBe(false);
+    expect(deviceRegistry.getSnapshot().records[record.recordId]).toBeDefined();
+    await expect(credentialStore.get(credentialKey)).resolves.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "settings.deviceDetail.forgetConfirm",
+      }),
+    ).toBeEnabled();
+    expect(mockNavigate).not.toHaveBeenCalledWith({
+      to: "/settings/devices",
+      replace: true,
+    });
+  });
+
+  it("should keep the device without writing the registry when credential deletion fails", async () => {
+    const user = userEvent.setup();
+    const credentialKey = credentialKeyForRecord(record.recordId);
+    await credentialStore.set(credentialKey, credentials);
+    vi.mocked(SecureStorage.remove).mockRejectedValueOnce(
+      new Error("secure storage deletion failed"),
+    );
+    vi.mocked(Preferences.set).mockClear();
+    renderRoute();
+
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceDetail.forget" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings.deviceDetail.forgetConfirm",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "settings.deviceDetail.forgetFailed",
+      );
+    });
+    expect(deviceRegistry.getSnapshot().records[record.recordId]).toBeDefined();
+    await expect(credentialStore.get(credentialKey)).resolves.toEqual(
+      credentials,
+    );
+    expect(Preferences.set).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: "settings.deviceDetail.forgetConfirm",
+      }),
+    ).toBeEnabled();
+    expect(mockNavigate).not.toHaveBeenCalledWith({
+      to: "/settings/devices",
+      replace: true,
+    });
+  });
+
+  it("should delegate active-device teardown to the connection owner", async () => {
+    await seedRecord(true);
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceDetail.forget" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings.deviceDetail.forgetConfirm",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockForgetDevice).toHaveBeenCalledWith(record.recordId);
+    });
     expect(deviceRegistry.getSnapshot().activeRecordId).toBeNull();
   });
 

--- a/src/components/ConnectionProvider.tsx
+++ b/src/components/ConnectionProvider.tsx
@@ -85,7 +85,9 @@ import { parseDeviceEndpoint } from "@/lib/devices/endpoint";
 import { formatDurationDisplay, formatDurationAccessible } from "@/lib/utils";
 import {
   ConnectionContext,
+  DeviceConnectionActionsContext,
   type ConnectionContextValue,
+  type DeviceConnectionActionsContextValue,
 } from "@/hooks/useConnection";
 import { useNetworkScan } from "@/hooks/useNetworkScan";
 import { useAnnouncer } from "./A11yAnnouncer";
@@ -226,6 +228,10 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   const isInitialized = useRef(false);
   // Track current connection to prevent stale events from old connections
   const currentConnectionId = useRef<string | null>(null);
+  const credentialWorkRef = useRef(
+    new Map<symbol, { recordId: string; promise: Promise<void> }>(),
+  );
+  const forgettingRecordIdsRef = useRef(new Set<string>());
   const mdnsRetryPendingForRecord = useRef<string | null>(null);
   // Monotonically identifies the latest current-client capability request.
   // Connection transitions invalidate older callbacks before they can write.
@@ -279,6 +285,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setCurrentClient,
     setEncryptionState,
     setPairingRequired,
+    resetConnectionState,
     addInboxMessage,
     setInboxMessages,
     setInboxModalOpen,
@@ -302,6 +309,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       setCurrentClient: state.setCurrentClient,
       setEncryptionState: state.setEncryptionState,
       setPairingRequired: state.setPairingRequired,
+      resetConnectionState: state.resetConnectionState,
       addInboxMessage: state.addInboxMessage,
       setInboxMessages: state.setInboxMessages,
       setInboxModalOpen: state.setInboxModalOpen,
@@ -329,6 +337,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
   // These are updated via onConnectionChange callback
   const [localConnection, setLocalConnection] =
     useState<DeviceConnection | null>(null);
+  const [connectionRevision, setConnectionRevision] = useState(0);
 
   // Derive display states from local connection state
   const isConnected = localConnection?.state === "connected";
@@ -1252,7 +1261,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setPairingRequired(false);
     setPairingOpen(false);
 
-    if (connectionWsUrl === "" || activeRecordId === null) {
+    if (
+      connectionWsUrl === "" ||
+      activeRecordId === null ||
+      forgettingRecordIdsRef.current.has(activeRecordId)
+    ) {
       setConnectionState(ConnectionState.DISCONNECTED);
       return;
     }
@@ -1274,8 +1287,11 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     const connectionId =
       typeof crypto.randomUUID === "function"
         ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        : `${Date.now()}-${connectionRevision}-${Math.random().toString(36).slice(2)}`;
     currentConnectionId.current = connectionId;
+    const isCurrentConnection = () =>
+      currentConnectionId.current === connectionId &&
+      !forgettingRecordIdsRef.current.has(recordId);
 
     // Reset CoreAPI to clear any zombie requests from previous connections
     CoreAPI.reset();
@@ -1380,6 +1396,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         }
       },
       onEncryptedHandshakeOk: () => {
+        if (!isCurrentConnection()) return;
         setEncryptionState("encrypted");
         setPairingRequired(false);
         // The peer authenticated with whatever key answered getCredentials, so
@@ -1388,19 +1405,25 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         // to the canonical key now, and only drop the pointer to the old key
         // once that has actually landed.
         const provenKey = legacyKeyUsed;
-        void (
+        const workToken = Symbol("credentialWork");
+        const work = (
           provenKey === null
             ? Promise.resolve(true)
             : credentialStore.promoteRecordCredentials(recordId, provenKey)
         )
-          .then((migrationSettled) =>
-            deviceRegistry.markConnected(recordId, {
+          .then(async (migrationSettled) => {
+            if (!isCurrentConnection()) return;
+            await deviceRegistry.markConnected(recordId, {
               ...(provenKey === null ? {} : { provenLegacyKey: provenKey }),
               migrationSettled,
-            }),
-          )
-          .then(async () => {
-            if (!credentialsUsed || aliasReconciliationInFlight) return;
+            });
+            if (
+              !isCurrentConnection() ||
+              !credentialsUsed ||
+              aliasReconciliationInFlight
+            ) {
+              return;
+            }
             aliasReconciliationInFlight = true;
             try {
               const mergedRecordIds = await reconcileCredentialProvenAliases(
@@ -1417,9 +1440,15 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
               aliasReconciliationInFlight = false;
             }
           })
-          .catch(ignoreReportedRegistryFailure);
+          .catch(ignoreReportedRegistryFailure)
+          .finally(() => {
+            credentialWorkRef.current.delete(workToken);
+          });
+        credentialWorkRef.current.set(workToken, { recordId, promise: work });
+        void work;
       },
       onPlaintextMode: () => {
+        if (!isCurrentConnection()) return;
         setEncryptionState("plaintext");
         setPairingRequired(false);
         // Nothing was proven, so the legacy key pointer stays put.
@@ -1445,6 +1474,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
         );
       },
       onCredentialsRevoked: () => {
+        if (!isCurrentConnection()) return;
         // Server rejected our stored credentials — clear them and prompt
         // the user to pair again.
         // Delete exactly the key the server rejected — which may still be the
@@ -1531,6 +1561,7 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     };
   }, [
     activeRecordId,
+    connectionRevision,
     connectionWsUrl,
     connectionWsUrls,
     invalidateCurrentClientRequest,
@@ -1662,6 +1693,44 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
     setPairingOpen(true);
   }, []);
 
+  const forgetDevice = useCallback(
+    async (recordId: string): Promise<void> => {
+      forgettingRecordIdsRef.current.add(recordId);
+      const isActive = deviceRegistry.getSnapshot().activeRecordId === recordId;
+
+      if (isActive) {
+        // ConnectionProvider owns transport lifetime. Invalidate callbacks before
+        // destroying the transport, then wait for credential work that already
+        // started so the final delete cannot be followed by a stale promotion.
+        currentConnectionId.current = null;
+        setPairingOpen(false);
+        setLocalConnection(null);
+        resetConnectionState();
+        CoreAPI.reset();
+        connectionManager.removeDevice(recordId);
+      }
+
+      const credentialWork = [...credentialWorkRef.current.values()]
+        .filter((work) => work.recordId === recordId)
+        .map((work) => work.promise);
+      await Promise.all(credentialWork);
+
+      try {
+        await deviceRegistry.removeRecord(recordId);
+      } catch (error) {
+        // Secure-storage failure leaves the record unchanged. If it became or
+        // remained active while fenced, recreate and rebind its transport.
+        if (deviceRegistry.getSnapshot().activeRecordId === recordId) {
+          setConnectionRevision((revision) => revision + 1);
+        }
+        throw error;
+      } finally {
+        forgettingRecordIdsRef.current.delete(recordId);
+      }
+    },
+    [resetConnectionState],
+  );
+
   // Memoize context value to prevent unnecessary re-renders of consumers
   const contextValue = useMemo<ConnectionContextValue>(
     () => ({
@@ -1681,20 +1750,26 @@ export function ConnectionProvider({ children }: ConnectionProviderProps) {
       openPairingModal,
     ],
   );
+  const connectionActions = useMemo<DeviceConnectionActionsContextValue>(
+    () => ({ forgetDevice }),
+    [forgetDevice],
+  );
 
   const pairingAddress =
     connectionManager.getActiveConnection()?.address ?? connectionAddress;
 
   return (
     <ConnectionContext.Provider value={contextValue}>
-      {children}
-      <PairingModal
-        isOpen={pairingOpen}
-        close={() => setPairingOpen(false)}
-        address={pairingAddress}
-        recordId={activeRecordId ?? ""}
-        onSuccess={() => connectionManager.restartActiveConnection()}
-      />
+      <DeviceConnectionActionsContext.Provider value={connectionActions}>
+        {children}
+        <PairingModal
+          isOpen={pairingOpen}
+          close={() => setPairingOpen(false)}
+          address={pairingAddress}
+          recordId={activeRecordId ?? ""}
+          onSuccess={() => connectionManager.restartActiveConnection()}
+        />
+      </DeviceConnectionActionsContext.Provider>
     </ConnectionContext.Provider>
   );
 }

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -26,6 +26,11 @@ export interface ConnectionContextValue {
   openPairingModal: () => void;
 }
 
+export interface DeviceConnectionActionsContextValue {
+  /** Forget a device after its owned transport and credential work are quiet. */
+  forgetDevice: (recordId: string) => Promise<void>;
+}
+
 export const ConnectionContext = createContext<ConnectionContextValue>({
   activeConnection: null,
   isConnected: false,
@@ -35,9 +40,18 @@ export const ConnectionContext = createContext<ConnectionContextValue>({
   openPairingModal: () => {},
 });
 
+export const DeviceConnectionActionsContext =
+  createContext<DeviceConnectionActionsContextValue>({
+    forgetDevice: () => Promise.resolve(),
+  });
+
 /**
  * Hook to access connection state from ConnectionProvider.
  */
 export function useConnection() {
   return useContext(ConnectionContext);
+}
+
+export function useDeviceConnectionActions() {
+  return useContext(DeviceConnectionActionsContext);
 }

--- a/src/lib/devices/deviceRegistry.ts
+++ b/src/lib/devices/deviceRegistry.ts
@@ -566,8 +566,8 @@ class DeviceRegistryRepository {
     }
   }
 
-  private commit(
-    update: (registry: DeviceRegistryV2) => DeviceRegistryV2,
+  private applyCommit(
+    update: (registry: DeviceRegistryV2) => DeviceRegistryV2 | null,
   ): Promise<void> {
     const execute = async () => {
       if (!this.snapshot.hydrated) {
@@ -588,6 +588,7 @@ class DeviceRegistryRepository {
         activeRecordId: previous.activeRecordId,
         records: previous.records,
       });
+      if (next === null) return;
       const published: DeviceRegistrySnapshot = {
         ...next,
         hydrated: true,
@@ -602,15 +603,19 @@ class DeviceRegistryRepository {
       }
     };
 
-    // Publish the first optimistic update synchronously, but do not let a newer
-    // update publish until its predecessor either persists or rolls back. This
-    // prevents failed state from being captured by a queued durable write.
+    return execute();
+  }
+
+  private enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
+    // Start the first mutation synchronously, but do not let a newer mutation
+    // observe or publish state until its predecessor settles. Credential
+    // ownership decisions use the same queue as durable registry writes.
     const startsImmediately = this.pendingCommits === 0;
     this.pendingCommits++;
-    const operation = startsImmediately
-      ? execute()
-      : this.commitChain.then(execute, execute);
-    this.commitChain = operation.then(
+    const result = startsImmediately
+      ? operation()
+      : this.commitChain.then(operation, operation);
+    this.commitChain = result.then(
       () => {
         this.pendingCommits--;
       },
@@ -618,7 +623,13 @@ class DeviceRegistryRepository {
         this.pendingCommits--;
       },
     );
-    return operation;
+    return result;
+  }
+
+  private commit(
+    update: (registry: DeviceRegistryV2) => DeviceRegistryV2 | null,
+  ): Promise<void> {
+    return this.enqueueMutation(() => this.applyCommit(update));
   }
 
   hydrate(): Promise<void> {
@@ -724,30 +735,35 @@ class DeviceRegistryRepository {
     const parsed = parseDeviceEndpoint(address);
     if (!parsed.ok) return null;
 
-    const existing = Object.values(this.snapshot.records).find((record) =>
-      record.endpoints.some(
-        (endpoint) => endpoint.endpointId === parsed.endpoint.endpointId,
-      ),
-    );
-    const record =
-      existing ??
-      createRecord(
-        parsed.endpoint,
-        "manual",
-        {},
-        // Keyed off the address the user actually typed, not the canonical
-        // form, so a pairing stored by an older build is still found.
-        normalizeDeviceKey(address),
+    let selected: DeviceRecord | null = null;
+    await this.commit((registry) => {
+      const existing = Object.values(registry.records).find((record) =>
+        record.endpoints.some(
+          (endpoint) => endpoint.endpointId === parsed.endpoint.endpointId,
+        ),
       );
+      const record =
+        existing ??
+        createRecord(
+          parsed.endpoint,
+          "manual",
+          {},
+          // Keyed off the address the user actually typed, not the canonical
+          // form, so a pairing stored by an older build is still found.
+          normalizeDeviceKey(address),
+        );
+      selected = record;
 
-    await this.commit((registry) => ({
-      ...registry,
-      activeRecordId: record.recordId,
-      records: existing
-        ? registry.records
-        : { ...registry.records, [record.recordId]: record },
-    }));
-    return record;
+      if (existing && registry.activeRecordId === record.recordId) return null;
+      return {
+        ...registry,
+        activeRecordId: record.recordId,
+        records: existing
+          ? registry.records
+          : { ...registry.records, [record.recordId]: record },
+      };
+    });
+    return selected;
   }
 
   /** Make the record for an mDNS announcement active, creating it if it is new. */
@@ -763,98 +779,97 @@ class DeviceRegistryRepository {
     );
     if (!parsed.ok) return null;
 
-    // A stable service id wins. Without one, only the exact advertised
-    // hostname can reuse a record; an IP is never identity because DHCP can
-    // hand it to another device. Explicitly selecting a scan result may upgrade
-    // an unidentified manual hostname record to mDNS instead of creating the
-    // same endpoint twice.
     const discoveryId = normalizeDiscoveryId(device.discoveryId);
-    const records = Object.values(this.snapshot.records);
-    const byDiscoveryId = discoveryId
-      ? records.find((record) => record.discoveryId === discoveryId)
-      : undefined;
-    const byExactHostname = hostname
-      ? records.find(
-          (record) =>
-            (!discoveryId ||
-              !record.discoveryId ||
-              normalizeDiscoveryId(record.discoveryId) === discoveryId) &&
-            record.endpoints.some(
-              (endpoint) => endpoint.endpointId === parsed.endpoint.endpointId,
-            ),
-        )
-      : undefined;
-    const existing = byDiscoveryId ?? byExactHostname;
-    const effectiveDiscoveryId = discoveryId ?? existing?.discoveryId;
-
     const resolvedAddresses = unique(device.addresses);
-    const existingEndpoint = existing?.endpoints.find(
-      (endpoint) => endpoint.endpointId === parsed.endpoint.endpointId,
-    );
+    let selected: DeviceRecord | null = null;
 
-    // Compare against what the commit below would actually write: a custom name
-    // is never overwritten and empty metadata is never applied, so testing
-    // fields the commit refuses to change would make this permanently false and
-    // rewrite the record on every mDNS announcement.
-    const unchanged =
-      existing !== undefined &&
-      existing.discoveryId === effectiveDiscoveryId &&
-      existing.preferredEndpointId === parsed.endpoint.endpointId &&
-      existingEndpoint?.source === "mdns" &&
-      sameAddressSet(
-        existingEndpoint.resolvedAddresses ?? [],
-        resolvedAddresses,
-      ) &&
-      (!device.name ||
-        existing.nameIsCustom === true ||
-        existing.name === device.name) &&
-      (!device.platform || existing.platform === device.platform) &&
-      (!device.version || existing.version === device.version);
-    if (unchanged) {
-      if (this.snapshot.activeRecordId !== existing.recordId) {
-        await this.setActiveRecord(existing.recordId);
-      }
-      return existing;
-    }
-
-    const discoveredEndpoint = endpointFromParsed(parsed.endpoint, "mdns", {
-      lastSeenAt: Date.now(),
-      resolvedAddresses,
-    });
-    const base =
-      existing ??
-      // Before the registry, picking a device from a scan saved it by IP even
-      // when it advertised a hostname. A new record connects by hostname, so
-      // the advertised address is where any existing pairing still lives.
-      createRecord(
-        parsed.endpoint,
-        "mdns",
-        {},
-        device.addresses[0]
-          ? normalizeDeviceKey(`${device.addresses[0]}:${device.port}`)
-          : normalizeDeviceKey(parsed.endpoint.address),
+    await this.commit((registry) => {
+      // A stable service id wins. Without one, only the exact advertised
+      // hostname can reuse a record; an IP is never identity because DHCP can
+      // hand it to another device.
+      const records = Object.values(registry.records);
+      const byDiscoveryId = discoveryId
+        ? records.find((record) => record.discoveryId === discoveryId)
+        : undefined;
+      const byExactHostname = hostname
+        ? records.find(
+            (record) =>
+              (!discoveryId ||
+                !record.discoveryId ||
+                normalizeDiscoveryId(record.discoveryId) === discoveryId) &&
+              record.endpoints.some(
+                (endpoint) =>
+                  endpoint.endpointId === parsed.endpoint.endpointId,
+              ),
+          )
+        : undefined;
+      const existing = byDiscoveryId ?? byExactHostname;
+      const effectiveDiscoveryId = discoveryId ?? existing?.discoveryId;
+      const existingEndpoint = existing?.endpoints.find(
+        (endpoint) => endpoint.endpointId === parsed.endpoint.endpointId,
       );
-    const record: DeviceRecord = {
-      ...base,
-      ...(discoveryId ? { discoveryId } : {}),
-      endpoints: [
-        ...base.endpoints.filter(
-          (endpoint) => endpoint.endpointId !== discoveredEndpoint.endpointId,
-        ),
-        discoveredEndpoint,
-      ],
-      preferredEndpointId: discoveredEndpoint.endpointId,
-      ...(device.name && !base.nameIsCustom ? { name: device.name } : {}),
-      ...(device.platform ? { platform: device.platform } : {}),
-      ...(device.version ? { version: device.version } : {}),
-    };
 
-    await this.commit((registry) => ({
-      ...registry,
-      activeRecordId: record.recordId,
-      records: { ...registry.records, [record.recordId]: record },
-    }));
-    return record;
+      const unchanged =
+        existing !== undefined &&
+        existing.discoveryId === effectiveDiscoveryId &&
+        existing.preferredEndpointId === parsed.endpoint.endpointId &&
+        existingEndpoint?.source === "mdns" &&
+        sameAddressSet(
+          existingEndpoint.resolvedAddresses ?? [],
+          resolvedAddresses,
+        ) &&
+        (!device.name ||
+          existing.nameIsCustom === true ||
+          existing.name === device.name) &&
+        (!device.platform || existing.platform === device.platform) &&
+        (!device.version || existing.version === device.version);
+      if (unchanged) {
+        selected = existing;
+        return registry.activeRecordId === existing.recordId
+          ? null
+          : { ...registry, activeRecordId: existing.recordId };
+      }
+
+      const discoveredEndpoint = endpointFromParsed(parsed.endpoint, "mdns", {
+        lastSeenAt: Date.now(),
+        resolvedAddresses,
+      });
+      const base =
+        existing ??
+        // Before the registry, picking a device from a scan saved it by IP even
+        // when it advertised a hostname. A new record connects by hostname, so
+        // the advertised address is where any existing pairing still lives.
+        createRecord(
+          parsed.endpoint,
+          "mdns",
+          {},
+          device.addresses[0]
+            ? normalizeDeviceKey(`${device.addresses[0]}:${device.port}`)
+            : normalizeDeviceKey(parsed.endpoint.address),
+        );
+      const record: DeviceRecord = {
+        ...base,
+        ...(discoveryId ? { discoveryId } : {}),
+        endpoints: [
+          ...base.endpoints.filter(
+            (endpoint) => endpoint.endpointId !== discoveredEndpoint.endpointId,
+          ),
+          discoveredEndpoint,
+        ],
+        preferredEndpointId: discoveredEndpoint.endpointId,
+        ...(device.name && !base.nameIsCustom ? { name: device.name } : {}),
+        ...(device.platform ? { platform: device.platform } : {}),
+        ...(device.version ? { version: device.version } : {}),
+      };
+      selected = record;
+      return {
+        ...registry,
+        activeRecordId: record.recordId,
+        records: { ...registry.records, [record.recordId]: record },
+      };
+    });
+
+    return selected;
   }
 
   /**
@@ -876,44 +891,43 @@ class DeviceRegistryRepository {
     options: { provenLegacyKey?: string; migrationSettled?: boolean } = {},
   ): Promise<void> {
     await this.hydrate();
-    const target = this.snapshot.records[recordId];
-    if (!target) return;
+    await this.commit((registry) => {
+      const target = registry.records[recordId];
+      if (!target) return null;
 
-    const provenKey = options.provenLegacyKey;
-    const absorbed = provenKey
-      ? Object.values(this.snapshot.records).filter(
-          (record) =>
-            record.recordId !== recordId &&
-            record.legacyCredentialKey === provenKey,
-        )
-      : [];
-
-    const endpoints = new Map(
-      target.endpoints.map((endpoint) => [endpoint.endpointId, endpoint]),
-    );
-    for (const source of absorbed) {
-      for (const endpoint of source.endpoints) {
-        if (!endpoints.has(endpoint.endpointId)) {
-          endpoints.set(endpoint.endpointId, endpoint);
+      const provenKey = options.provenLegacyKey;
+      const absorbed = provenKey
+        ? Object.values(registry.records).filter(
+            (record) =>
+              record.recordId !== recordId &&
+              record.legacyCredentialKey === provenKey,
+          )
+        : [];
+      const endpoints = new Map(
+        target.endpoints.map((endpoint) => [endpoint.endpointId, endpoint]),
+      );
+      for (const source of absorbed) {
+        for (const endpoint of source.endpoints) {
+          if (!endpoints.has(endpoint.endpointId)) {
+            endpoints.set(endpoint.endpointId, endpoint);
+          }
         }
       }
-    }
 
-    const donor = absorbed[0];
-    const merged: DeviceRecord = {
-      ...target,
-      endpoints: [...endpoints.values()],
-      lastConnectedAt: Date.now(),
-      name: target.name ?? donor?.name,
-      nameIsCustom: target.nameIsCustom ?? donor?.nameIsCustom,
-      platform: target.platform ?? donor?.platform,
-      version: target.version ?? donor?.version,
-    };
-    if (options.migrationSettled) {
-      delete merged.legacyCredentialKey;
-    }
+      const donor = absorbed[0];
+      const merged: DeviceRecord = {
+        ...target,
+        endpoints: [...endpoints.values()],
+        lastConnectedAt: Date.now(),
+        name: target.name ?? donor?.name,
+        nameIsCustom: target.nameIsCustom ?? donor?.nameIsCustom,
+        platform: target.platform ?? donor?.platform,
+        version: target.version ?? donor?.version,
+      };
+      if (options.migrationSettled) {
+        delete merged.legacyCredentialKey;
+      }
 
-    await this.commit((registry) => {
       const records = { ...registry.records, [recordId]: merged };
       for (const source of absorbed) delete records[source.recordId];
       return { ...registry, activeRecordId: recordId, records };
@@ -930,27 +944,30 @@ class DeviceRegistryRepository {
     metadata: DiscoveredDeviceMetadata,
   ): Promise<void> {
     await this.hydrate();
-    const record = this.snapshot.records[recordId];
-    if (!record) return;
+    await this.commit((registry) => {
+      const record = registry.records[recordId];
+      if (!record) return null;
 
-    const next: DeviceRecord = {
-      ...record,
-      ...(metadata.name && !record.nameIsCustom ? { name: metadata.name } : {}),
-      ...(metadata.platform ? { platform: metadata.platform } : {}),
-      ...(metadata.version ? { version: metadata.version } : {}),
-    };
-    if (
-      next.name === record.name &&
-      next.platform === record.platform &&
-      next.version === record.version
-    ) {
-      return;
-    }
-
-    await this.commit((registry) => ({
-      ...registry,
-      records: { ...registry.records, [recordId]: next },
-    }));
+      const next: DeviceRecord = {
+        ...record,
+        ...(metadata.name && !record.nameIsCustom
+          ? { name: metadata.name }
+          : {}),
+        ...(metadata.platform ? { platform: metadata.platform } : {}),
+        ...(metadata.version ? { version: metadata.version } : {}),
+      };
+      if (
+        next.name === record.name &&
+        next.platform === record.platform &&
+        next.version === record.version
+      ) {
+        return null;
+      }
+      return {
+        ...registry,
+        records: { ...registry.records, [recordId]: next },
+      };
+    });
   }
 
   /**
@@ -968,32 +985,34 @@ class DeviceRegistryRepository {
     addresses: readonly string[],
   ): Promise<void> {
     await this.hydrate();
-    const record = this.snapshot.records[recordId];
-    const preferred = preferredEndpointFor(record);
-    if (!record || !preferred) return;
-
     const resolved = unique(addresses.filter((address) => address.length > 0));
-    if (
-      resolved.length === 0 ||
-      sameAddressSet(preferred.resolvedAddresses ?? [], resolved)
-    ) {
-      // mDNS re-announces constantly; only a genuine change is worth a write.
-      return;
-    }
+    if (resolved.length === 0) return;
 
-    const next: DeviceRecord = {
-      ...record,
-      endpoints: record.endpoints.map((endpoint) =>
-        endpoint.endpointId === preferred.endpointId
-          ? { ...endpoint, resolvedAddresses: resolved }
-          : endpoint,
-      ),
-    };
+    await this.commit((registry) => {
+      const record = registry.records[recordId];
+      const preferred = preferredEndpointFor(record);
+      if (
+        !record ||
+        !preferred ||
+        sameAddressSet(preferred.resolvedAddresses ?? [], resolved)
+      ) {
+        // mDNS re-announces constantly; only a genuine change is worth a write.
+        return null;
+      }
 
-    await this.commit((registry) => ({
-      ...registry,
-      records: { ...registry.records, [recordId]: next },
-    }));
+      const next: DeviceRecord = {
+        ...record,
+        endpoints: record.endpoints.map((endpoint) =>
+          endpoint.endpointId === preferred.endpointId
+            ? { ...endpoint, resolvedAddresses: resolved }
+            : endpoint,
+        ),
+      };
+      return {
+        ...registry,
+        records: { ...registry.records, [recordId]: next },
+      };
+    });
   }
 
   /**
@@ -1050,7 +1069,8 @@ class DeviceRegistryRepository {
       );
     }
 
-    const sourceWasActive = this.snapshot.activeRecordId === sourceRecordId;
+    const activeRecordIdAtMerge = this.snapshot.activeRecordId;
+    const sourceWasActive = activeRecordIdAtMerge === sourceRecordId;
     const sourceIsNewer =
       (source.lastConnectedAt ?? 0) > (target.lastConnectedAt ?? 0);
     const newest = sourceIsNewer ? source : target;
@@ -1092,6 +1112,13 @@ class DeviceRegistryRepository {
     // is published, so a preparation error never disconnects an intact record.
     options.beforeCommit?.();
     await this.commit((registry) => {
+      if (
+        registry.records[targetRecordId] !== target ||
+        registry.records[sourceRecordId] !== source ||
+        registry.activeRecordId !== activeRecordIdAtMerge
+      ) {
+        throw new Error("Device records changed while preparing the merge");
+      }
       const records = { ...registry.records, [targetRecordId]: merged };
       delete records[sourceRecordId];
       return {
@@ -1133,23 +1160,24 @@ class DeviceRegistryRepository {
   /** Set or clear the user's own name for a record. Blank clears it. */
   async setCustomName(recordId: string, name: string): Promise<void> {
     await this.hydrate();
-    const record = this.snapshot.records[recordId];
-    if (!record) return;
-
     const trimmed = name.trim();
-    const next: DeviceRecord = { ...record };
-    if (trimmed) {
-      next.name = trimmed;
-      next.nameIsCustom = true;
-    } else {
-      delete next.name;
-      next.nameIsCustom = false;
-    }
+    await this.commit((registry) => {
+      const record = registry.records[recordId];
+      if (!record) return null;
 
-    await this.commit((registry) => ({
-      ...registry,
-      records: { ...registry.records, [recordId]: next },
-    }));
+      const next: DeviceRecord = { ...record };
+      if (trimmed) {
+        next.name = trimmed;
+        next.nameIsCustom = true;
+      } else {
+        delete next.name;
+        next.nameIsCustom = false;
+      }
+      return {
+        ...registry,
+        records: { ...registry.records, [recordId]: next },
+      };
+    });
   }
 
   /**
@@ -1162,43 +1190,79 @@ class DeviceRegistryRepository {
    */
   async removeRecord(recordId: string): Promise<DeviceRecord | null> {
     await this.hydrate();
-    const removed = this.snapshot.records[recordId] ?? null;
-    if (!removed) return null;
+    if (!this.snapshot.records[recordId]) return null;
 
-    await this.commit((registry) => {
-      const records = { ...registry.records };
-      delete records[recordId];
-      return {
-        ...registry,
-        activeRecordId:
-          registry.activeRecordId === recordId ? null : registry.activeRecordId,
-        records,
-      };
-    });
-
-    const keys = [credentialKeyForRecord(recordId)];
-    const legacyKey = removed.legacyCredentialKey;
-    if (
-      legacyKey &&
-      !Object.values(this.snapshot.records).some(
-        (record) => record.legacyCredentialKey === legacyKey,
-      )
-    ) {
-      keys.push(legacyKey);
+    // Delete the record-specific key first. Other registry mutations may land
+    // during this native-storage await, so shared legacy ownership is checked
+    // again only after entering the registry mutation queue below.
+    try {
+      await credentialStore.delete(credentialKeyForRecord(recordId));
+    } catch (error) {
+      logger.error("Failed to delete forgotten device credentials", error, {
+        category: "storage",
+        action: "deleteDeviceCredentials",
+        severity: "error",
+        recordId,
+      });
+      throw error;
     }
-    await Promise.all(keys.map((key) => credentialStore.delete(key)));
 
-    return removed;
+    return this.enqueueMutation(async () => {
+      const removed = this.snapshot.records[recordId] ?? null;
+      if (!removed) return null;
+
+      const legacyKey = removed.legacyCredentialKey;
+      const legacyKeyHasAnotherOwner =
+        legacyKey !== undefined &&
+        Object.values(this.snapshot.records).some(
+          (record) =>
+            record.recordId !== recordId &&
+            record.legacyCredentialKey === legacyKey,
+        );
+
+      // Hold the registry mutation queue across the shared-key decision and
+      // deletion so no new claimant can appear between them.
+      if (legacyKey && !legacyKeyHasAnotherOwner) {
+        try {
+          await credentialStore.delete(legacyKey);
+        } catch (error) {
+          logger.error("Failed to delete forgotten device credentials", error, {
+            category: "storage",
+            action: "deleteDeviceCredentials",
+            severity: "error",
+            recordId,
+          });
+          throw error;
+        }
+      }
+
+      // Secrets are gone before the durable registry record. Secure-storage
+      // failure leaves the record as a retry path; registry failure leaves a
+      // visible record that can be paired again rather than an orphan secret.
+      await this.applyCommit((registry) => {
+        const records = { ...registry.records };
+        delete records[recordId];
+        return {
+          ...registry,
+          activeRecordId:
+            registry.activeRecordId === recordId
+              ? null
+              : registry.activeRecordId,
+          records,
+        };
+      });
+
+      return removed;
+    });
   }
 
   async setActiveRecord(recordId: string | null): Promise<void> {
     await this.hydrate();
-    if (recordId !== null && !this.snapshot.records[recordId]) return;
-    if (this.snapshot.activeRecordId === recordId) return;
-    await this.commit((registry) => ({
-      ...registry,
-      activeRecordId: recordId,
-    }));
+    await this.commit((registry) => {
+      if (recordId !== null && !registry.records[recordId]) return null;
+      if (registry.activeRecordId === recordId) return null;
+      return { ...registry, activeRecordId: recordId };
+    });
   }
 
   resetForTests(): void {

--- a/src/lib/nfc.ts
+++ b/src/lib/nfc.ts
@@ -176,6 +176,9 @@ async function withNfcSession<T>(
       waiter.resolve(event);
     };
 
+    const ownsActiveSession = () =>
+      !settled && activeSessionToken === sessionToken;
+
     const cleanup = async () => {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
@@ -186,13 +189,34 @@ async function withNfcSession<T>(
       resolvePendingWaiter(null);
       // Remove listeners BEFORE releasing the session lock - a successor
       // session may start the moment the lock frees, and this session's
-      // listeners must not still be attached when it does.
-      await Promise.all(listeners.map((listener) => listener.remove()));
+      // listeners must not still be attached when it does. Native listener
+      // removal is best-effort: one rejected handle must not strand the lock or
+      // leave the operation promise unsettled.
+      const sessionListeners = listeners;
       listeners = [];
-      if (activeSessionToken === sessionToken) {
-        activeSessionToken = null;
-        activeSessionCancel = null;
-        sessionManager.setIsScanning(false);
+      try {
+        const removalResults = await Promise.allSettled(
+          sessionListeners.map(async (listener) => listener.remove()),
+        );
+        for (const result of removalResults) {
+          if (result.status === "rejected") {
+            logger.error(
+              "Failed to remove NFC session listener",
+              result.reason,
+              {
+                category: "nfc",
+                action: "removeSessionListener",
+                severity: "warning",
+              },
+            );
+          }
+        }
+      } finally {
+        if (activeSessionToken === sessionToken) {
+          activeSessionToken = null;
+          activeSessionCancel = null;
+          sessionManager.setIsScanning(false);
+        }
       }
     };
 
@@ -246,6 +270,8 @@ async function withNfcSession<T>(
         const nfcTagScannedHandle = await Nfc.addListener(
           "nfcTagScanned",
           async (event) => {
+            if (!ownsActiveSession()) return;
+
             // iOS restartPolling re-fires scans while the tag stays in the
             // field; re-running the handler would repeat its side effects
             // (e.g. double-write), so later events only feed waiters.
@@ -298,6 +324,7 @@ async function withNfcSession<T>(
         const scanCanceledHandle = await Nfc.addListener(
           "scanSessionCanceled",
           async () => {
+            if (!ownsActiveSession()) return;
             await stopScanSessionSafely();
             await handleError(new NfcCancelledError());
           },
@@ -306,6 +333,7 @@ async function withNfcSession<T>(
         const scanErrorHandle = await Nfc.addListener(
           "scanSessionError",
           async (err) => {
+            if (!ownsActiveSession()) return;
             const wrappedError = wrapNfcError(err);
             if (isExpectedNfcError(wrappedError)) {
               logger.debug("Expected NFC scan session failure:", wrappedError);
@@ -338,6 +366,7 @@ async function withNfcSession<T>(
 
         if (Capacitor.getPlatform() === "android") {
           timeoutId = setTimeout(() => {
+            if (!ownsActiveSession()) return;
             void stopScanSessionSafely();
             void handleError(
               new NfcCancelledError("NFC scan session timed out"),

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -84,6 +84,7 @@ export class WebSocketTransport implements Transport {
   private session: EncryptedSession | null = null;
   private outboundQueue: string[] = [];
   private drainInFlight = false;
+  private outboundGeneration = 0;
   private inboundMessageChain: Promise<void> = Promise.resolve();
   private inboundGeneration = 0;
   // True once the server has answered a plaintext request without a -32002/-32001
@@ -322,6 +323,7 @@ export class WebSocketTransport implements Transport {
   private createWebSocket(): void {
     // Invalidate queued work from the previous socket before creating another.
     this.resetEncryptedInbound();
+    this.resetEncryptedOutbound();
     // Close any existing WebSocket to prevent stale handlers from corrupting state
     this.closeWebSocket();
 
@@ -784,28 +786,53 @@ export class WebSocketTransport implements Transport {
     void this.drain();
   }
 
+  private resetEncryptedOutbound(): void {
+    this.outboundGeneration++;
+    this.outboundQueue = [];
+    this.drainInFlight = false;
+  }
+
   private async drain(): Promise<void> {
-    while (this.outboundQueue.length > 0) {
-      if (this.ws?.readyState !== WebSocket.OPEN) {
+    const generation = this.outboundGeneration;
+    const session = this.session;
+    const ws = this.ws;
+
+    if (!session || !ws) {
+      if (generation === this.outboundGeneration) {
         this.drainInFlight = false;
-        return;
       }
-      const item = this.outboundQueue.shift()!;
-      try {
-        const frame = await this.session!.encryptAndFrame(item);
-        if (this.ws?.readyState === WebSocket.OPEN) {
-          this.ws.send(frame);
+      return;
+    }
+
+    try {
+      while (this.outboundQueue.length > 0) {
+        if (ws.readyState !== WebSocket.OPEN) return;
+
+        const item = this.outboundQueue.shift()!;
+        const frame = await session.encryptAndFrame(item);
+        if (
+          generation !== this.outboundGeneration ||
+          session !== this.session ||
+          ws !== this.ws
+        ) {
+          return;
         }
-      } catch (err) {
-        logger.error(`[Transport:${this.deviceId}] Encrypt failed:`, err, {
-          category: "crypto",
-          action: "encrypt-failed",
-        });
-        this.handleConnectionError();
-        break;
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(frame);
+        }
+      }
+    } catch (err) {
+      if (generation !== this.outboundGeneration) return;
+      logger.error(`[Transport:${this.deviceId}] Encrypt failed:`, err, {
+        category: "crypto",
+        action: "encrypt-failed",
+      });
+      this.handleConnectionError();
+    } finally {
+      if (generation === this.outboundGeneration) {
+        this.drainInFlight = false;
       }
     }
-    this.drainInFlight = false;
   }
 
   // ── End encryption helpers ───────────────────────────────────────────────
@@ -1018,11 +1045,10 @@ export class WebSocketTransport implements Transport {
 
     this.closeWebSocket();
     this.resetEncryptedInbound();
+    this.resetEncryptedOutbound();
 
     // Reset encryption state for next connect cycle.
     this.session = null;
-    this.outboundQueue = [];
-    this.drainInFlight = false;
     this.encMode = "idle";
     this.plaintextVerified = false;
   }

--- a/src/routes/-pages/DeviceDetail.tsx
+++ b/src/routes/-pages/DeviceDetail.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { useStatusStore } from "@/lib/store";
-import { useConnection } from "@/hooks/useConnection";
+import toast from "react-hot-toast";
+import {
+  useConnection,
+  useDeviceConnectionActions,
+} from "@/hooks/useConnection";
 import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useSelectDevice } from "@/hooks/useSelectDevice";
-import { CoreAPI } from "@/lib/coreApi";
 import {
   deviceRegistry,
   parsedEndpointForRecord,
@@ -54,11 +56,10 @@ export function DeviceDetail() {
     preventScrollOnSwipe: false,
   });
 
-  const resetConnectionState = useStatusStore((s) => s.resetConnectionState);
-
   const record = records[params.recordId];
   const endpoint = parsedEndpointForRecord(record);
   const { isConnected } = useConnection();
+  const { forgetDevice } = useDeviceConnectionActions();
   const { selectRecord } = useSelectDevice();
 
   const headingTitle = record?.name ?? endpoint?.address ?? "";
@@ -68,6 +69,7 @@ export function DeviceDetail() {
   const [draftName, setDraftName] = useState(initialName);
   const [trackedRecordId, setTrackedRecordId] = useState(record?.recordId);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [forgetting, setForgetting] = useState(false);
 
   // Reset the draft when navigating between different device records.
   if (record?.recordId !== trackedRecordId) {
@@ -80,10 +82,10 @@ export function DeviceDetail() {
   // id in the URL. Redirecting before the read has settled would bounce the
   // user off a device that was about to appear.
   useEffect(() => {
-    if (registrySettled && (!record || !endpoint)) {
+    if (!forgetting && registrySettled && (!record || !endpoint)) {
       router.navigate({ to: "/settings/devices", replace: true });
     }
-  }, [endpoint, record, registrySettled, router]);
+  }, [endpoint, forgetting, record, registrySettled, router]);
 
   if (!record || !endpoint) return null;
 
@@ -100,29 +102,24 @@ export function DeviceDetail() {
   };
 
   const handleConfirmForget = async () => {
-    // Tear the connection down before dropping the record. A still-live
-    // transport can finish its handshake at any point and write the pairing it
-    // just proved straight back into storage after removeRecord deleted it.
-    if (isCurrentDevice) {
-      resetConnectionState();
-      CoreAPI.reset();
-    }
-    try {
-      await deviceRegistry.removeRecord(record.recordId);
-    } catch {
-      // The record has already left the snapshot — the registry publishes
-      // before it persists — so the list will not show it again either way.
-      // Finish the teardown rather than stranding the user in a modal for a
-      // device that is visibly gone; the registry has already reported the
-      // write failure itself.
-    }
+    if (forgetting) return;
+    setForgetting(true);
 
-    invalidateLibraryImageCache(record.recordId);
-    queryClient.removeQueries({
-      predicate: (query) => query.queryKey.includes(record.recordId),
-    });
-    setConfirmOpen(false);
-    router.navigate({ to: "/settings/devices", replace: true });
+    try {
+      await forgetDevice(record.recordId);
+      invalidateLibraryImageCache(record.recordId);
+      queryClient.removeQueries({
+        predicate: (query) => query.queryKey.includes(record.recordId),
+      });
+      setConfirmOpen(false);
+      router.navigate({ to: "/settings/devices", replace: true });
+    } catch {
+      // Registry writes roll back automatically. Credential cleanup failures
+      // leave the record unchanged, so the user can retry from the same
+      // confirmation instead of receiving a false success.
+      setForgetting(false);
+      toast.error(t("settings.deviceDetail.forgetFailed"));
+    }
   };
 
   const lastConnectedLine =
@@ -212,7 +209,9 @@ export function DeviceDetail() {
 
       <SlideModal
         isOpen={confirmOpen}
-        close={() => setConfirmOpen(false)}
+        close={() => {
+          if (!forgetting) setConfirmOpen(false);
+        }}
         title={t("settings.deviceDetail.forgetTitle")}
       >
         <div className="flex flex-col gap-4 py-4">
@@ -222,6 +221,7 @@ export function DeviceDetail() {
               variant="outline"
               label={t("settings.deviceDetail.forgetCancel")}
               onClick={() => setConfirmOpen(false)}
+              disabled={forgetting}
               className="flex-1"
             />
             <Button
@@ -229,7 +229,10 @@ export function DeviceDetail() {
               intent="destructive"
               label={t("settings.deviceDetail.forgetConfirm")}
               onClick={() => void handleConfirmForget()}
-              className="border-error text-error flex-1"
+              disabled={forgetting}
+              className={
+                forgetting ? "flex-1" : "border-error text-error flex-1"
+              }
             />
           </div>
         </div>

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -817,7 +817,8 @@
         "forgetTitle": "Forget this device?",
         "forgetBody": "This will remove it from your saved devices and erase the pairing credentials.",
         "forgetCancel": "Cancel",
-        "forgetConfirm": "Forget device"
+        "forgetConfirm": "Forget device",
+        "forgetFailed": "Device could not be forgotten. Try again."
       },
       "deviceCombine": {
         "edit": "Combine devices",


### PR DESCRIPTION
## Summary

- serialize device registry mutations and coordinate credential cleanup with provider-owned transport teardown
- prevent stale encrypted WebSocket and NFC session work from affecting replacement sessions
- keep failed device forgets recoverable with truthful UI feedback and regression coverage

Validated with typecheck, lint, formatting, full tests, preflight review, and deep-risk review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device removal reliability and error handling when cleanup fails.
  * Prevented stale connection activity from affecting forgotten or reconnected devices.
  * Prevented encrypted messages from being sent through outdated connections.
  * Improved NFC session cleanup and handling of cancelled or superseded scans.
  * Prevented device registry updates from overwriting or restoring newer changes.

* **User Experience**
  * Device removal now shows progress, prevents duplicate actions, and redirects only after successful completion.
  * Added an error message when a device cannot be forgotten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->