### PR TITLE
Add interactive swipe-back feedback

### DIFF
--- a/src/__tests__/unit/components/PageFrame.test.tsx
+++ b/src/__tests__/unit/components/PageFrame.test.tsx
@@ -139,6 +139,71 @@ describe("PageFrame", () => {
     expect(pageFrame).toHaveAttribute("role", "main");
   });
 
+  it("should render the swipe-back indicator only on back-navigable pages", () => {
+    const { container, rerender } = render(
+      <PageFrame>
+        <div>Root page</div>
+      </PageFrame>,
+    );
+
+    expect(
+      container.querySelector("[data-swipe-back-indicator]"),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <PageFrame onSwipeBack={vi.fn()}>
+        <div>Child page</div>
+      </PageFrame>,
+    );
+
+    expect(
+      container.querySelector("[data-swipe-back-indicator]"),
+    ).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should keep a gradually reversed swipe canceled until the next gesture", () => {
+    const onSwipeBack = vi.fn();
+    const { container } = render(
+      <PageFrame onSwipeBack={onSwipeBack}>
+        <div>Child page</div>
+      </PageFrame>,
+    );
+    const pageFrame = container.firstElementChild;
+    const indicator = container.querySelector("[data-swipe-back-indicator]");
+    expect(pageFrame).toBeInstanceOf(HTMLElement);
+    if (!(pageFrame instanceof HTMLElement)) return;
+
+    fireEvent.touchStart(pageFrame, {
+      touches: [{ clientX: 0, clientY: 100 }],
+    });
+    fireEvent.touchMove(pageFrame, {
+      touches: [{ clientX: 120, clientY: 100 }],
+    });
+    fireEvent.touchMove(pageFrame, {
+      touches: [{ clientX: 114, clientY: 100 }],
+    });
+    fireEvent.touchMove(pageFrame, {
+      touches: [{ clientX: 108, clientY: 100 }],
+    });
+    fireEvent.touchMove(pageFrame, {
+      touches: [{ clientX: 102, clientY: 100 }],
+    });
+    expect(indicator).toHaveStyle({ opacity: "0" });
+    fireEvent.touchEnd(pageFrame, { touches: [] });
+
+    expect(onSwipeBack).not.toHaveBeenCalled();
+
+    fireEvent.touchStart(pageFrame, {
+      touches: [{ clientX: 0, clientY: 100 }],
+    });
+    fireEvent.touchMove(pageFrame, {
+      touches: [{ clientX: 100, clientY: 100 }],
+    });
+    fireEvent.touchEnd(pageFrame, { touches: [] });
+
+    expect(onSwipeBack).toHaveBeenCalledOnce();
+  });
+
   it("should identify its scroll container for router restoration", () => {
     const { container } = render(
       <PageFrame>

--- a/src/__tests__/unit/components/SwipeBackIndicator.test.tsx
+++ b/src/__tests__/unit/components/SwipeBackIndicator.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { SwipeBackIndicator } from "@/components/SwipeBackIndicator";
+
+vi.mock("@/lib/store", () => ({
+  useStatusStore: vi.fn((selector) =>
+    selector({
+      safeInsets: {
+        top: "0px",
+        right: "0px",
+        bottom: "0px",
+        left: "12px",
+      },
+    }),
+  ),
+}));
+
+describe("SwipeBackIndicator", () => {
+  it("fades and moves the arrow with gesture progress", () => {
+    const { container, rerender } = render(<SwipeBackIndicator progress={0} />);
+    const indicator = container.querySelector("[data-swipe-back-indicator]");
+
+    expect(indicator).toHaveAttribute("aria-hidden", "true");
+    expect(indicator).toHaveAttribute("data-ready", "false");
+    expect(indicator).toHaveStyle({
+      left: "calc(12px + 4px)",
+      opacity: "0",
+    });
+
+    rerender(<SwipeBackIndicator progress={0.5} />);
+    expect(indicator).toHaveStyle({ opacity: "0.8", transition: "none" });
+    expect(indicator).toHaveAttribute("data-ready", "false");
+
+    rerender(<SwipeBackIndicator progress={1} />);
+    expect(indicator).toHaveStyle({ opacity: "1" });
+    expect(indicator).toHaveAttribute("data-ready", "true");
+  });
+
+  it("clamps progress outside the supported range", () => {
+    const { container, rerender } = render(
+      <SwipeBackIndicator progress={-1} />,
+    );
+    const indicator = container.querySelector("[data-swipe-back-indicator]");
+
+    expect(indicator).toHaveStyle({ opacity: "0" });
+    expect(indicator).toHaveAttribute("data-ready", "false");
+
+    rerender(<SwipeBackIndicator progress={2} />);
+    expect(indicator).toHaveStyle({ opacity: "1" });
+    expect(indicator).toHaveAttribute("data-ready", "true");
+  });
+});

--- a/src/__tests__/unit/components/SwipeBackIndicator.test.tsx
+++ b/src/__tests__/unit/components/SwipeBackIndicator.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/lib/store", () => ({
 }));
 
 describe("SwipeBackIndicator", () => {
-  it("fades and moves the arrow with gesture progress", () => {
+  it("should fade and move the arrow with gesture progress", () => {
     const { container, rerender } = render(<SwipeBackIndicator progress={0} />);
     const indicator = container.querySelector("[data-swipe-back-indicator]");
 
@@ -36,7 +36,7 @@ describe("SwipeBackIndicator", () => {
     expect(indicator).toHaveAttribute("data-ready", "true");
   });
 
-  it("clamps progress outside the supported range", () => {
+  it("should clamp progress outside the supported range", () => {
     const { container, rerender } = render(
       <SwipeBackIndicator progress={-1} />,
     );

--- a/src/__tests__/unit/hooks/useSmartSwipe.test.tsx
+++ b/src/__tests__/unit/hooks/useSmartSwipe.test.tsx
@@ -224,6 +224,92 @@ describe("useSmartSwipe", () => {
       // Assert
       expect(onSwipeLeft).toHaveBeenCalled();
     });
+
+    it("should trigger at the exact distance without a velocity requirement", () => {
+      const onSwipeRight = vi.fn();
+      renderHook(() =>
+        useSmartSwipe({
+          onSwipeRight,
+          swipeThreshold: 96,
+          velocityThreshold: 0,
+        }),
+      );
+
+      const swipeData = {
+        deltaX: 96,
+        deltaY: 0,
+        velocity: 0,
+        dir: "Right" as const,
+        event: {} as TouchEvent,
+        initial: [0, 0] as [number, number],
+        absX: 96,
+        absY: 0,
+        first: false,
+        vxvy: [0, 0] as [number, number],
+      };
+
+      lastSwipeableConfig?.onSwipedRight?.(swipeData);
+
+      expect(onSwipeRight).toHaveBeenCalledOnce();
+    });
+
+    it("should suppress callbacks and haptics when the swipe guard rejects", () => {
+      const onSwipeRight = vi.fn();
+      renderHook(() =>
+        useSmartSwipe({
+          onSwipeRight,
+          shouldHandleSwipe: () => false,
+        }),
+      );
+
+      const swipeData = {
+        deltaX: 100,
+        deltaY: 0,
+        velocity: 0.5,
+        dir: "Right" as const,
+        event: {} as TouchEvent,
+        initial: [0, 0] as [number, number],
+        absX: 100,
+        absY: 0,
+        first: false,
+        vxvy: [0.5, 0] as [number, number],
+      };
+
+      lastSwipeableConfig?.onSwipedRight?.(swipeData);
+
+      expect(onSwipeRight).not.toHaveBeenCalled();
+      expect(mockImpact).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("swipe lifecycle", () => {
+    it("should forward start, progress, and completion callbacks", () => {
+      const onSwipeStart = vi.fn();
+      const onSwiping = vi.fn();
+      const onSwiped = vi.fn();
+      renderHook(() => useSmartSwipe({ onSwipeStart, onSwiping, onSwiped }));
+
+      const swipeData = {
+        deltaX: 30,
+        deltaY: 0,
+        velocity: 0.5,
+        dir: "Right" as const,
+        event: {} as TouchEvent,
+        initial: [0, 0] as [number, number],
+        absX: 30,
+        absY: 0,
+        first: false,
+        vxvy: [0.5, 0] as [number, number],
+      };
+
+      lastSwipeableConfig?.onSwipeStart?.(swipeData);
+      lastSwipeableConfig?.onSwiping?.(swipeData);
+      lastSwipeableConfig?.onSwiped?.(swipeData);
+
+      expect(onSwipeStart).toHaveBeenCalledWith(swipeData);
+      expect(onSwiping).toHaveBeenCalledWith(swipeData);
+      expect(onSwiped).toHaveBeenCalledWith(swipeData);
+    });
   });
 
   describe("haptic feedback", () => {

--- a/src/__tests__/unit/hooks/useSwipeBack.test.tsx
+++ b/src/__tests__/unit/hooks/useSwipeBack.test.tsx
@@ -38,7 +38,7 @@ describe("useSwipeBack", () => {
     swipeOptions = undefined;
   });
 
-  it("tracks rightward progress up to the trigger distance", () => {
+  it("should track rightward progress up to the trigger distance", () => {
     const { result } = renderHook(() => useSwipeBack(vi.fn()));
 
     act(() => {
@@ -62,7 +62,7 @@ describe("useSwipeBack", () => {
     expect(result.current.progress).toBe(1);
   });
 
-  it("latches cancellation after a meaningful reversal", () => {
+  it("should latch cancellation after a meaningful reversal", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -83,7 +83,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).not.toHaveBeenCalled();
   });
 
-  it("latches cancellation after cumulative gradual reversal", () => {
+  it("should latch cancellation after cumulative gradual reversal", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -103,7 +103,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).not.toHaveBeenCalled();
   });
 
-  it("latches cancellation after vertical movement", () => {
+  it("should latch cancellation after vertical movement", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -144,7 +144,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).not.toHaveBeenCalled();
   });
 
-  it("resets cancellation when the next gesture starts", () => {
+  it("should reset cancellation when the next gesture starts", () => {
     const onSwipeBack = vi.fn();
     renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -166,7 +166,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).toHaveBeenCalledOnce();
   });
 
-  it("cancels visual progress when an incomplete swipe ends", () => {
+  it("should cancel visual progress when an incomplete swipe ends", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -195,7 +195,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).not.toHaveBeenCalled();
   });
 
-  it("blocks completion after touch cancellation", () => {
+  it("should block completion after touch cancellation", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -212,7 +212,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).not.toHaveBeenCalled();
   });
 
-  it("configures distance-based back navigation", () => {
+  it("should configure distance-based back navigation", () => {
     const onSwipeBack = vi.fn();
     renderHook(() => useSwipeBack(onSwipeBack));
 
@@ -231,7 +231,7 @@ describe("useSwipeBack", () => {
     expect(onSwipeBack).toHaveBeenCalledOnce();
   });
 
-  it("does not track progress when back navigation is unavailable", () => {
+  it("should not track progress when back navigation is unavailable", () => {
     const { result } = renderHook(() => useSwipeBack());
 
     expect(swipeOptions?.onSwipeRight).toBeUndefined();

--- a/src/__tests__/unit/hooks/useSwipeBack.test.tsx
+++ b/src/__tests__/unit/hooks/useSwipeBack.test.tsx
@@ -170,14 +170,24 @@ describe("useSwipeBack", () => {
     const onSwipeBack = vi.fn();
     const { result } = renderHook(() => useSwipeBack(onSwipeBack));
 
+    const incompleteDistance = SWIPE_BACK_TRIGGER_DISTANCE - 1;
+
     act(() => {
       swipeOptions?.onSwiping?.(
-        swipeData({ absX: 48, deltaX: 48, velocity: 0.5 }),
+        swipeData({
+          absX: incompleteDistance,
+          deltaX: incompleteDistance,
+          velocity: 0.5,
+        }),
       );
     });
     act(() => {
       swipeOptions?.onSwiped?.(
-        swipeData({ absX: 48, deltaX: 48, velocity: 0.5 }),
+        swipeData({
+          absX: incompleteDistance,
+          deltaX: incompleteDistance,
+          velocity: 0.5,
+        }),
       );
     });
 

--- a/src/__tests__/unit/hooks/useSwipeBack.test.tsx
+++ b/src/__tests__/unit/hooks/useSwipeBack.test.tsx
@@ -1,0 +1,234 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SwipeEventData } from "react-swipeable";
+import {
+  SWIPE_BACK_TRIGGER_DISTANCE,
+  useSwipeBack,
+} from "@/hooks/useSwipeBack";
+import { useSmartSwipe } from "@/hooks/useSmartSwipe";
+
+let swipeOptions: Parameters<typeof useSmartSwipe>[0] | undefined;
+
+vi.mock("@/hooks/useSmartSwipe", () => ({
+  useSmartSwipe: vi.fn((options) => {
+    swipeOptions = options;
+    return { ref: vi.fn() };
+  }),
+}));
+
+function swipeData(overrides: Partial<SwipeEventData> = {}): SwipeEventData {
+  return {
+    absX: 0,
+    absY: 0,
+    deltaX: 0,
+    deltaY: 0,
+    dir: "Right",
+    event: {} as TouchEvent,
+    first: false,
+    initial: [0, 0],
+    velocity: 0,
+    vxvy: [0, 0],
+    ...overrides,
+  };
+}
+
+describe("useSwipeBack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    swipeOptions = undefined;
+  });
+
+  it("tracks rightward progress up to the trigger distance", () => {
+    const { result } = renderHook(() => useSwipeBack(vi.fn()));
+
+    act(() => {
+      swipeOptions?.onSwiping?.(
+        swipeData({
+          absX: SWIPE_BACK_TRIGGER_DISTANCE / 2,
+          deltaX: SWIPE_BACK_TRIGGER_DISTANCE / 2,
+        }),
+      );
+    });
+    expect(result.current.progress).toBe(0.5);
+
+    act(() => {
+      swipeOptions?.onSwiping?.(
+        swipeData({
+          absX: SWIPE_BACK_TRIGGER_DISTANCE * 2,
+          deltaX: SWIPE_BACK_TRIGGER_DISTANCE * 2,
+        }),
+      );
+    });
+    expect(result.current.progress).toBe(1);
+  });
+
+  it("latches cancellation after a meaningful reversal", () => {
+    const onSwipeBack = vi.fn();
+    const { result } = renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 120, absX: 120 }));
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 100, absX: 100 }));
+      swipeOptions?.onSwiped?.(swipeData({ deltaX: 100, absX: 100 }));
+      swipeOptions?.onSwipeRight?.();
+    });
+
+    expect(result.current.progress).toBe(0);
+    expect(
+      swipeOptions?.shouldHandleSwipe?.(swipeData({ deltaX: 100, absX: 100 })),
+    ).toBe(false);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("latches cancellation after cumulative gradual reversal", () => {
+    const onSwipeBack = vi.fn();
+    const { result } = renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 120, absX: 120 }));
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 114, absX: 114 }));
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 108, absX: 108 }));
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 102, absX: 102 }));
+      swipeOptions?.onSwiped?.(swipeData({ deltaX: 102, absX: 102 }));
+      swipeOptions?.onSwipeRight?.();
+    });
+
+    expect(result.current.progress).toBe(0);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("latches cancellation after vertical movement", () => {
+    const onSwipeBack = vi.fn();
+    const { result } = renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 60, absX: 60 }));
+      swipeOptions?.onSwiping?.(
+        swipeData({
+          deltaX: 60,
+          deltaY: 80,
+          absX: 60,
+          absY: 80,
+          dir: "Down",
+        }),
+      );
+      swipeOptions?.onSwiping?.(
+        swipeData({
+          deltaX: 100,
+          deltaY: 80,
+          absX: 100,
+          absY: 80,
+        }),
+      );
+      swipeOptions?.onSwiped?.(
+        swipeData({
+          deltaX: 100,
+          deltaY: 80,
+          absX: 100,
+          absY: 80,
+        }),
+      );
+      swipeOptions?.onSwipeRight?.();
+    });
+
+    expect(result.current.progress).toBe(0);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("resets cancellation when the next gesture starts", () => {
+    const onSwipeBack = vi.fn();
+    renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(
+        swipeData({ deltaY: 40, absY: 40, dir: "Down" }),
+      );
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 100, absX: 100 }));
+      swipeOptions?.onSwiped?.(swipeData({ deltaX: 100, absX: 100 }));
+      swipeOptions?.onSwipeRight?.();
+    });
+
+    expect(onSwipeBack).toHaveBeenCalledOnce();
+  });
+
+  it("cancels visual progress when an incomplete swipe ends", () => {
+    const onSwipeBack = vi.fn();
+    const { result } = renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwiping?.(
+        swipeData({ absX: 48, deltaX: 48, velocity: 0.5 }),
+      );
+    });
+    act(() => {
+      swipeOptions?.onSwiped?.(
+        swipeData({ absX: 48, deltaX: 48, velocity: 0.5 }),
+      );
+    });
+
+    expect(result.current.progress).toBe(0);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("blocks completion after touch cancellation", () => {
+    const onSwipeBack = vi.fn();
+    const { result } = renderHook(() => useSwipeBack(onSwipeBack));
+
+    act(() => {
+      swipeOptions?.onSwipeStart?.(
+        swipeData({ deltaX: 10, absX: 10, first: true }),
+      );
+      swipeOptions?.onSwiping?.(swipeData({ deltaX: 100, absX: 100 }));
+      result.current.cancelSwipeBack();
+      swipeOptions?.onSwipeRight?.();
+    });
+
+    expect(result.current.progress).toBe(0);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("configures distance-based back navigation", () => {
+    const onSwipeBack = vi.fn();
+    renderHook(() => useSwipeBack(onSwipeBack));
+
+    expect(swipeOptions).toMatchObject({
+      preventScrollOnSwipe: false,
+      swipeThreshold: SWIPE_BACK_TRIGGER_DISTANCE,
+      velocityThreshold: 0,
+    });
+    expect(swipeOptions?.onSwipeStart).toBeTypeOf("function");
+    expect(swipeOptions?.onSwipeRight).toBeTypeOf("function");
+    expect(swipeOptions?.shouldHandleSwipe).toBeTypeOf("function");
+
+    act(() => {
+      swipeOptions?.onSwipeRight?.();
+    });
+    expect(onSwipeBack).toHaveBeenCalledOnce();
+  });
+
+  it("does not track progress when back navigation is unavailable", () => {
+    const { result } = renderHook(() => useSwipeBack());
+
+    expect(swipeOptions?.onSwipeRight).toBeUndefined();
+    expect(swipeOptions?.onSwipeStart).toBeUndefined();
+    expect(swipeOptions?.onSwiping).toBeUndefined();
+    expect(swipeOptions?.onSwiped).toBeUndefined();
+    expect(swipeOptions?.shouldHandleSwipe).toBeUndefined();
+    expect(result.current.progress).toBe(0);
+  });
+});

--- a/src/components/PageFrame.tsx
+++ b/src/components/PageFrame.tsx
@@ -12,9 +12,11 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { ResponsiveContainer } from "@/components/ResponsiveContainer";
+import { SwipeBackIndicator } from "@/components/SwipeBackIndicator";
 import { useStatusStore } from "@/lib/store";
 import { useTabSessionStore } from "@/lib/tabSessionStore";
 import { InitialPageScrollOffsetContext } from "@/lib/pageScrollContext";
+import { useSwipeBack } from "@/hooks/useSwipeBack";
 
 export const PAGE_SCROLL_RESTORATION_ID = "page-scroll";
 export const PAGE_SCROLL_RESTORATION_SELECTOR = `[data-scroll-restoration-id="${PAGE_SCROLL_RESTORATION_ID}"]`;
@@ -32,6 +34,8 @@ interface PageFrameProps extends React.HTMLAttributes<HTMLDivElement> {
   scrollRef?: RefObject<HTMLDivElement | null>;
   /** In-memory scroll slot used when revisiting a bottom-tab screen. */
   sessionScrollKey?: string;
+  /** Navigate to this page's parent after a completed rightward swipe. */
+  onSwipeBack?: () => void;
 }
 
 interface PageHeaderProps {
@@ -124,10 +128,26 @@ function PageFrameLayout(props: PageFrameLayoutProps) {
     sessionScrollKey,
     restorationEntry,
     restorationKey,
+    onSwipeBack,
+    onMouseDown,
+    onTouchCancel,
     className,
     ...restProps
   } = props;
 
+  const { cancelSwipeBack, progress, swipeHandlers } =
+    useSwipeBack(onSwipeBack);
+  const { ref: swipeRef, onMouseDown: onSwipeMouseDown } = swipeHandlers;
+  const rootSwipeHandlers = {
+    ref: onSwipeBack ? swipeRef : undefined,
+    onMouseDown:
+      onSwipeBack || onMouseDown
+        ? (event: React.MouseEvent<HTMLDivElement>) => {
+            if (onSwipeBack) onSwipeMouseDown?.(event);
+            onMouseDown?.(event);
+          }
+        : undefined,
+  };
   const activeScrollRef = scrollRef ?? internalScrollRef;
   const hasHeaderContent = header || headerLeft || headerCenter || headerRight;
   const initialScrollOffset = sessionScrollKey
@@ -182,6 +202,15 @@ function PageFrameLayout(props: PageFrameLayoutProps) {
     <div
       className={`flex h-full w-full flex-col ${className || ""}`}
       {...restProps}
+      {...rootSwipeHandlers}
+      onTouchCancel={
+        onSwipeBack || onTouchCancel
+          ? (event) => {
+              cancelSwipeBack();
+              onTouchCancel?.(event);
+            }
+          : undefined
+      }
     >
       <div
         className={classNames(
@@ -241,6 +270,7 @@ function PageFrameLayout(props: PageFrameLayoutProps) {
           </InitialPageScrollOffsetContext.Provider>
         </ResponsiveContainer>
       </div>
+      {onSwipeBack && <SwipeBackIndicator progress={progress} />}
     </div>
   );
 }

--- a/src/components/SwipeBackIndicator.tsx
+++ b/src/components/SwipeBackIndicator.tsx
@@ -1,0 +1,35 @@
+import { ArrowLeft } from "lucide-react";
+import { useStatusStore } from "@/lib/store";
+
+interface SwipeBackIndicatorProps {
+  progress: number;
+}
+
+export function SwipeBackIndicator({ progress }: SwipeBackIndicatorProps) {
+  const safeLeft = useStatusStore((state) => state.safeInsets.left);
+  const clampedProgress = Math.min(Math.max(progress, 0), 1);
+  const active = clampedProgress > 0;
+  const opacity = Math.min(clampedProgress * 1.6, 1);
+  const translateX = -20 + clampedProgress * 32;
+  const scale = 0.85 + clampedProgress * 0.15;
+
+  return (
+    <div
+      data-swipe-back-indicator=""
+      data-ready={clampedProgress === 1 ? "true" : "false"}
+      aria-hidden="true"
+      className="bg-foreground text-primary-foreground pointer-events-none fixed top-1/2 z-20 flex h-14 w-14 items-center justify-center rounded-full border border-black/10 shadow-lg"
+      style={{
+        left: `calc(${safeLeft} + 0.25rem)`,
+        opacity,
+        transform: `translate3d(${translateX}px, -50%, 0) scale(${scale})`,
+        transition: active
+          ? "none"
+          : "opacity 140ms ease-out, transform 140ms ease-out",
+        willChange: "opacity, transform",
+      }}
+    >
+      <ArrowLeft size={32} strokeWidth={2.5} />
+    </div>
+  );
+}

--- a/src/components/library/LibraryGameSearch.tsx
+++ b/src/components/library/LibraryGameSearch.tsx
@@ -11,7 +11,6 @@ import { useLibrarySessionStore } from "@/lib/librarySessionStore";
 import { BackIcon, SearchIcon } from "@/lib/images";
 import { useCoreFeature } from "@/hooks/useCoreFeature";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { PageFrame } from "@/components/PageFrame";
 import { VirtualSearchResults } from "@/components/VirtualSearchResults";
 import { BackToTop } from "@/components/BackToTop";
@@ -111,10 +110,6 @@ export function LibraryGameSearch({
     canUseSearch && (browseAllSearchFeature.available || hasSearchConstraint);
   const goBack =
     onBack ?? (() => navigate({ to: "/library", resetScroll: false }));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const search = () => {
     if (!canSubmitSearch) return;
@@ -276,7 +271,7 @@ export function LibraryGameSearch({
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         scrollRef={scrollRef}
         headerLeft={
           <HeaderButton

--- a/src/hooks/useSmartSwipe.ts
+++ b/src/hooks/useSmartSwipe.ts
@@ -1,4 +1,9 @@
-import { useSwipeable, SwipeableHandlers } from "react-swipeable";
+import {
+  useSwipeable,
+  SwipeableHandlers,
+  type SwipeCallback,
+  type SwipeEventData,
+} from "react-swipeable";
 import { useMediaQuery } from "@uidotdev/usehooks";
 import { useHaptics } from "./useHaptics";
 
@@ -7,6 +12,10 @@ interface SmartSwipeOptions {
   onSwipeRight?: () => void;
   onSwipeUp?: () => void;
   onSwipeDown?: () => void;
+  onSwipeStart?: SwipeCallback;
+  onSwiping?: SwipeCallback;
+  onSwiped?: SwipeCallback;
+  shouldHandleSwipe?: (eventData: SwipeEventData) => boolean;
   preventScrollOnSwipe?: boolean;
   swipeThreshold?: number;
   velocityThreshold?: number;
@@ -29,6 +38,10 @@ export function useSmartSwipe(
     onSwipeRight,
     onSwipeUp,
     onSwipeDown,
+    onSwipeStart,
+    onSwiping,
+    onSwiped,
+    shouldHandleSwipe,
     preventScrollOnSwipe = false,
     swipeThreshold = 50,
     velocityThreshold = 0.3,
@@ -37,14 +50,15 @@ export function useSmartSwipe(
 
   // Enable mouse tracking only on mobile-sized screens, unless forced
   const enableMouseTracking = forceEnable || isMobile;
+  const meetsThreshold = (distance: number, eventData: SwipeEventData) =>
+    Math.abs(distance) >= swipeThreshold &&
+    eventData.velocity >= velocityThreshold &&
+    (shouldHandleSwipe?.(eventData) ?? true);
 
   return useSwipeable({
     onSwipedLeft: onSwipeLeft
       ? (eventData) => {
-          if (
-            Math.abs(eventData.deltaX) > swipeThreshold &&
-            eventData.velocity > velocityThreshold
-          ) {
+          if (meetsThreshold(eventData.deltaX, eventData)) {
             impact("light");
             onSwipeLeft();
           }
@@ -53,10 +67,7 @@ export function useSmartSwipe(
 
     onSwipedRight: onSwipeRight
       ? (eventData) => {
-          if (
-            Math.abs(eventData.deltaX) > swipeThreshold &&
-            eventData.velocity > velocityThreshold
-          ) {
+          if (meetsThreshold(eventData.deltaX, eventData)) {
             impact("light");
             onSwipeRight();
           }
@@ -65,10 +76,7 @@ export function useSmartSwipe(
 
     onSwipedUp: onSwipeUp
       ? (eventData) => {
-          if (
-            Math.abs(eventData.deltaY) > swipeThreshold &&
-            eventData.velocity > velocityThreshold
-          ) {
+          if (meetsThreshold(eventData.deltaY, eventData)) {
             impact("light");
             onSwipeUp();
           }
@@ -77,16 +85,16 @@ export function useSmartSwipe(
 
     onSwipedDown: onSwipeDown
       ? (eventData) => {
-          if (
-            Math.abs(eventData.deltaY) > swipeThreshold &&
-            eventData.velocity > velocityThreshold
-          ) {
+          if (meetsThreshold(eventData.deltaY, eventData)) {
             impact("light");
             onSwipeDown();
           }
         }
       : undefined,
 
+    onSwipeStart,
+    onSwiping,
+    onSwiped,
     preventScrollOnSwipe,
     delta: 10,
     trackMouse: enableMouseTracking,

--- a/src/hooks/useSwipeBack.ts
+++ b/src/hooks/useSwipeBack.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import type { SwipeEventData, SwipeableHandlers } from "react-swipeable";
 import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 
-export const SWIPE_BACK_TRIGGER_DISTANCE = 96;
+export const SWIPE_BACK_TRIGGER_DISTANCE = 72;
 const SWIPE_BACK_REVERSAL_TOLERANCE = 8;
 
 interface SwipeBackGesture {

--- a/src/hooks/useSwipeBack.ts
+++ b/src/hooks/useSwipeBack.ts
@@ -1,0 +1,88 @@
+import { useCallback, useRef, useState } from "react";
+import type { SwipeEventData, SwipeableHandlers } from "react-swipeable";
+import { useSmartSwipe } from "@/hooks/useSmartSwipe";
+
+export const SWIPE_BACK_TRIGGER_DISTANCE = 96;
+const SWIPE_BACK_REVERSAL_TOLERANCE = 8;
+
+interface SwipeBackGesture {
+  cancelSwipeBack: () => void;
+  progress: number;
+  swipeHandlers: SwipeableHandlers;
+}
+
+export function useSwipeBack(onSwipeBack?: () => void): SwipeBackGesture {
+  const [progress, setProgress] = useState(0);
+  const invalidatedRef = useRef(false);
+  const maximumDeltaXRef = useRef(0);
+  const enabled = Boolean(onSwipeBack);
+
+  const clearSwipeBackProgress = useCallback(() => {
+    setProgress(0);
+  }, []);
+
+  const cancelSwipeBack = useCallback(() => {
+    invalidatedRef.current = true;
+    clearSwipeBackProgress();
+  }, [clearSwipeBackProgress]);
+
+  const startSwipeBack = useCallback(() => {
+    invalidatedRef.current = false;
+    maximumDeltaXRef.current = 0;
+    clearSwipeBackProgress();
+  }, [clearSwipeBackProgress]);
+
+  const handleSwiping = useCallback((eventData: SwipeEventData) => {
+    maximumDeltaXRef.current = Math.max(
+      maximumDeltaXRef.current,
+      eventData.deltaX,
+    );
+    const reversed =
+      eventData.deltaX <
+      maximumDeltaXRef.current - SWIPE_BACK_REVERSAL_TOLERANCE;
+
+    if (
+      invalidatedRef.current ||
+      reversed ||
+      eventData.dir !== "Right" ||
+      eventData.deltaX <= 0
+    ) {
+      invalidatedRef.current = true;
+      setProgress(0);
+      return;
+    }
+
+    const nextProgress = Math.min(
+      eventData.deltaX / SWIPE_BACK_TRIGGER_DISTANCE,
+      1,
+    );
+    setProgress((currentProgress) =>
+      currentProgress === nextProgress ? currentProgress : nextProgress,
+    );
+  }, []);
+
+  const shouldCompleteSwipeBack = useCallback(
+    () => !invalidatedRef.current,
+    [],
+  );
+  const completeSwipeBack = useCallback(() => {
+    if (shouldCompleteSwipeBack()) onSwipeBack?.();
+  }, [onSwipeBack, shouldCompleteSwipeBack]);
+
+  const swipeHandlers = useSmartSwipe({
+    onSwipeRight: enabled ? completeSwipeBack : undefined,
+    onSwipeStart: enabled ? startSwipeBack : undefined,
+    onSwiping: enabled ? handleSwiping : undefined,
+    onSwiped: enabled ? clearSwipeBackProgress : undefined,
+    shouldHandleSwipe: enabled ? shouldCompleteSwipeBack : undefined,
+    preventScrollOnSwipe: false,
+    swipeThreshold: SWIPE_BACK_TRIGGER_DISTANCE,
+    velocityThreshold: 0,
+  });
+
+  return {
+    cancelSwipeBack,
+    progress: enabled ? progress : 0,
+    swipeHandlers,
+  };
+}

--- a/src/routes/-pages/DeviceDetail.tsx
+++ b/src/routes/-pages/DeviceDetail.tsx
@@ -7,7 +7,6 @@ import {
   useConnection,
   useDeviceConnectionActions,
 } from "@/hooks/useConnection";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useSelectDevice } from "@/hooks/useSelectDevice";
 import {
@@ -51,10 +50,6 @@ export function DeviceDetail() {
 
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings/devices"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const record = records[params.recordId];
   const endpoint = parsedEndpointForRecord(record);
@@ -131,7 +126,7 @@ export function DeviceDetail() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/-pages/Devices.tsx
+++ b/src/routes/-pages/Devices.tsx
@@ -4,7 +4,6 @@ import { Link, useRouter } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ListChecks, Pencil, X } from "lucide-react";
 import { useConnection } from "@/hooks/useConnection";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useSelectDevice } from "@/hooks/useSelectDevice";
 import {
@@ -62,10 +61,6 @@ export function Devices() {
   const queryClient = useQueryClient();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const records = useDeviceRegistry(selectRecords);
   const activeRecordId = useDeviceRegistry(selectActiveRecordId);
@@ -234,7 +229,7 @@ export function Devices() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/-pages/Logs.tsx
+++ b/src/routes/-pages/Logs.tsx
@@ -8,7 +8,6 @@ import { Clipboard } from "@capacitor/clipboard";
 import toast from "react-hot-toast";
 import { BackToTop } from "@/components/BackToTop";
 import { CoreAPI } from "@/lib/coreApi";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useStatusStore } from "@/lib/store";
 import { usePreferencesStore } from "@/lib/preferencesStore";
@@ -52,11 +51,6 @@ export function Logs() {
     new Set(),
   );
   const [expandedFields, setExpandedFields] = useState<Set<string>>(new Set());
-
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const logsQuery = useQuery({
     queryKey: ["logs"],
@@ -251,7 +245,7 @@ export function Logs() {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         headerLeft={
           <HeaderButton
             onClick={goBack}

--- a/src/routes/-pages/MappingEditor.tsx
+++ b/src/routes/-pages/MappingEditor.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/lib/writeNfcHook";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { WriteModal } from "@/components/WriteModal";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
 
@@ -106,11 +105,6 @@ export function MappingEditor({ id }: MappingEditorProps) {
 
   const goBack = () =>
     void navigate(appBackNavigationOptions("/create/mappings"));
-
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const headingKey = isEditing
     ? "create.mappings.editor.titleEdit"
@@ -296,7 +290,7 @@ export function MappingEditor({ id }: MappingEditorProps) {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         headerLeft={
           <HeaderButton
             onClick={goBack}

--- a/src/routes/-pages/Search.tsx
+++ b/src/routes/-pages/Search.tsx
@@ -15,7 +15,6 @@ import { SearchResultGame, SystemsResponse } from "@/lib/models";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { Button } from "@/components/wui/Button";
 import { HeaderButton } from "@/components/wui/HeaderButton";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { DEFAULT_GAMES_INDEX, useStatusStore } from "@/lib/store";
 import {
   appBackNavigationOptions,
@@ -220,10 +219,6 @@ export function Search() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/create"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   // Handle system selection from selector
   const handleSystemSelect = async (systems: string[]) => {
@@ -327,7 +322,7 @@ export function Search() {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         headerLeft={
           <HeaderButton
             onClick={goBack}

--- a/src/routes/create.custom.tsx
+++ b/src/routes/create.custom.tsx
@@ -6,7 +6,6 @@ import { ZapScriptInput } from "@/components/ZapScriptInput.tsx";
 import { BackIcon, CreateIcon } from "@/lib/images";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { Button } from "@/components/wui/Button";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { WriteModal } from "@/components/WriteModal";
 import {
   isWriteModalOpen,
@@ -47,15 +46,11 @@ export function CustomText() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/create"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         headerLeft={
           <HeaderButton
             onClick={goBack}

--- a/src/routes/create.mappings.tsx
+++ b/src/routes/create.mappings.tsx
@@ -18,7 +18,6 @@ import { Button } from "@/components/wui/Button";
 import { EmptyState } from "@/components/wui/EmptyState";
 import { PageFrame } from "@/components/PageFrame";
 import { MappingRow } from "@/components/MappingRow";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useCoreFeature } from "@/hooks/useCoreFeature";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
@@ -43,11 +42,6 @@ export function Mappings() {
     "readOnlyMappings",
     { requireKnownSupport: true },
   );
-
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const mappings = useQuery({
     queryKey: ["mappings", { includeReadOnly: readOnlyMappingsAvailable }],
@@ -112,7 +106,7 @@ export function Mappings() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/create.nfc.tsx
+++ b/src/routes/create.nfc.tsx
@@ -8,7 +8,6 @@ import { logger } from "@/lib/logger";
 //   WrenchIcon,
 //   ClockIcon
 // } from "lucide-react";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { useHaptics } from "@/hooks/useHaptics";
 import { WriteModal } from "@/components/WriteModal";
 import {
@@ -82,10 +81,6 @@ export function NfcUtils() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/create"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const handleScan = () => {
     nfcWriter.write(WriteAction.Read).catch((e) => {
@@ -114,8 +109,9 @@ export function NfcUtils() {
 
   return (
     <>
-      <div {...swipeHandlers} className="flex h-full w-full flex-col">
+      <div className="flex h-full w-full flex-col">
         <PageFrame
+          onSwipeBack={goBack}
           headerLeft={
             <HeaderButton
               onClick={goBack}

--- a/src/routes/library.$system.tsx
+++ b/src/routes/library.$system.tsx
@@ -46,7 +46,6 @@ import { useLibraryBrowse } from "@/hooks/useLibraryBrowse";
 import { useSystemName } from "@/hooks/useSystemName";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useBackButtonHandler } from "@/hooks/useBackButtonHandler";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { PageFrame } from "@/components/PageFrame";
 import { BackToTop } from "@/components/BackToTop";
 import { EmptyState } from "@/components/wui/EmptyState";
@@ -276,10 +275,6 @@ export function LibrarySystem() {
     goBack();
     return true;
   });
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const changeMediaSort = (nextSort: MediaBrowseSort) => {
     forgetScroll(libraryBrowseScrollKey(systemId, nextSort, currentPath));
@@ -397,7 +392,7 @@ export function LibrarySystem() {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         scrollRef={scrollRef}
         sessionScrollKey={sessionScrollKey}
         headerLeft={

--- a/src/routes/library.favorites.tsx
+++ b/src/routes/library.favorites.tsx
@@ -28,7 +28,6 @@ import { BackIcon, SearchIcon } from "@/lib/images";
 import { useBackButtonHandler } from "@/hooks/useBackButtonHandler";
 import { useCoreFeature } from "@/hooks/useCoreFeature";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { PageFrame } from "@/components/PageFrame";
 import { BackToTop } from "@/components/BackToTop";
 import { DelayedLoading } from "@/components/DelayedLoading";
@@ -128,10 +127,6 @@ export function LibraryFavorites() {
     return true;
   }, [goBack]);
   useBackButtonHandler("library-favorites", handleBackButton);
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   let content: ReactNode;
   if (!connected) {
@@ -198,7 +193,7 @@ export function LibraryFavorites() {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         scrollRef={scrollRef}
         sessionScrollKey={`library:favorites:${searchOpen ? "search" : "list"}`}
         headerLeft={

--- a/src/routes/settings.about.tsx
+++ b/src/routes/settings.about.tsx
@@ -5,7 +5,6 @@ import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { Button } from "@/components/wui/Button.tsx";
 import { BackIcon, NextIcon } from "@/lib/images";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
 
@@ -22,14 +21,9 @@ export function About() {
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
 
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
-
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.accessibility.tsx
+++ b/src/routes/settings.accessibility.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { Capacitor } from "@capacitor/core";
 import classNames from "classnames";
 import { ToggleSwitch } from "@/components/wui/ToggleSwitch";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { PageFrame } from "@/components/PageFrame";
 import { BackIcon, CheckIcon } from "@/lib/images";
@@ -57,14 +56,10 @@ export function AccessibilitySettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.advanced.tsx
+++ b/src/routes/settings.advanced.tsx
@@ -7,7 +7,6 @@ import { Capacitor } from "@capacitor/core";
 import { CoreAPI } from "@/lib/coreApi";
 import { ToggleSwitch } from "@/components/wui/ToggleSwitch";
 import { SettingHelp } from "@/components/wui/SettingHelp";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { useStatusStore, ConnectionState } from "@/lib/store";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { PageFrame } from "@/components/PageFrame";
@@ -86,17 +85,13 @@ export function AdvancedSettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   // Show loading skeletons when connecting or when connected but data is loading
   const isLoading = isConnecting || (connected && isPending);
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.help.tsx
+++ b/src/routes/settings.help.tsx
@@ -3,7 +3,6 @@ import { Browser } from "@capacitor/browser";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/wui/Button";
 import { HeaderButton } from "@/components/wui/HeaderButton";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { PageFrame } from "@/components/PageFrame";
 import { BackIcon } from "@/lib/images";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
@@ -21,14 +20,10 @@ export function Help() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.language-region.tsx
+++ b/src/routes/settings.language-region.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { PageFrame } from "@/components/PageFrame";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import i18n from "@/i18n";
 import { BackIcon } from "@/lib/images";
 import { usePreferencesStore } from "@/lib/preferencesStore";
@@ -66,14 +65,10 @@ export function LanguageRegionSettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.licenses.tsx
+++ b/src/routes/settings.licenses.tsx
@@ -16,7 +16,6 @@ import { HeaderButton } from "@/components/wui/HeaderButton";
 import { Button } from "@/components/wui/Button";
 import { TextInput } from "@/components/wui/TextInput";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import licenseDataJson from "@/generated/thirdPartyLicenses.json";
 import { BackIcon, ExternalIcon } from "@/lib/images";
 import { logger } from "@/lib/logger";
@@ -80,10 +79,6 @@ export function ThirdPartyLicenses() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const filteredPackages = useMemo(() => {
     const normalizedQuery = query.trim().toLocaleLowerCase();
@@ -144,7 +139,7 @@ export function ThirdPartyLicenses() {
   return (
     <>
       <PageFrame
-        {...swipeHandlers}
+        onSwipeBack={goBack}
         scrollRef={scrollContainerRef}
         headerLeft={
           <HeaderButton

--- a/src/routes/settings.media.tsx
+++ b/src/routes/settings.media.tsx
@@ -6,7 +6,6 @@ import { CoreOutdatedNotice } from "@/components/CoreOutdatedNotice";
 import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
 import { BackIcon } from "@/lib/images";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
 
@@ -22,14 +21,10 @@ export function MediaSettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -22,7 +22,6 @@ import { Label } from "@/components/ui/label";
 import { useStatusStore } from "@/lib/store.ts";
 import { PageFrame } from "@/components/PageFrame.tsx";
 import { HeaderButton } from "@/components/wui/HeaderButton";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { BackIcon, GoogleIcon, AppleIcon } from "@/lib/images";
 import { logger } from "@/lib/logger";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
@@ -136,10 +135,6 @@ export function OnlinePage() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const loggedInUser = useStatusStore((state) => state.loggedInUser);
   const connected = useStatusStore((state) => state.connected);
@@ -587,7 +582,7 @@ export function OnlinePage() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.play-controls.tsx
+++ b/src/routes/settings.play-controls.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect, useRef } from "react";
 import { CoreAPI } from "@/lib/coreApi";
 import { ToggleSwitch } from "@/components/wui/ToggleSwitch";
 import { SettingHelp } from "@/components/wui/SettingHelp";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { useStatusStore, ConnectionState } from "@/lib/store";
 import { PageFrame } from "@/components/PageFrame";
 import { BackIcon } from "@/lib/images";
@@ -54,10 +53,6 @@ export function PlayControlsSettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   const [dailyHours, setDailyHours] = useState("0");
   const [dailyMinutes, setDailyMinutes] = useState("0");
@@ -312,7 +307,7 @@ export function PlayControlsSettings() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}

--- a/src/routes/settings.readers.tsx
+++ b/src/routes/settings.readers.tsx
@@ -7,7 +7,6 @@ import { useShallow } from "zustand/react/shallow";
 import classNames from "classnames";
 import { ToggleSwitch } from "@/components/wui/ToggleSwitch";
 import { SettingHelp } from "@/components/wui/SettingHelp";
-import { useSmartSwipe } from "@/hooks/useSmartSwipe";
 import { useStatusStore, ConnectionState } from "@/lib/store";
 import { PageFrame } from "@/components/PageFrame";
 import {
@@ -119,10 +118,6 @@ export function ReadersSettings() {
   const router = useRouter();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
-  const swipeHandlers = useSmartSwipe({
-    onSwipeRight: goBack,
-    preventScrollOnSwipe: false,
-  });
 
   // Show loading skeletons when connecting or when connected but data is loading
   const isLoading = isConnecting || (connected && isPending);
@@ -130,7 +125,7 @@ export function ReadersSettings() {
 
   return (
     <PageFrame
-      {...swipeHandlers}
+      onSwipeBack={goBack}
       headerLeft={
         <HeaderButton
           onClick={goBack}


### PR DESCRIPTION
## Summary
- centralize swipe-back handling in `PageFrame` across navigable pages
- add progress-driven, high-contrast gesture feedback with deliberate completion and cancellation behavior
- harden swipe lifecycle handling for reversal, vertical movement, and canceled touches
- add regression coverage for gesture behavior and page integration

Validated with typecheck, lint, formatting, and 3,609 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added swipe-back navigation across supported pages.
  * Added a visual back-arrow indicator that responds to swipe progress and respects screen safe areas.
  * Swipes can be cancelled when reversed, moved vertically, or otherwise incomplete.
  * Back navigation now activates after reaching the swipe threshold.

* **Tests**
  * Added comprehensive coverage for gesture thresholds, cancellation, callbacks, accessibility, and indicator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->