### PR TITLE
Standardize modal behavior

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -446,7 +446,7 @@ Persistent footer behavior:
 - current reference implementations are `MediaDetailsModal` and `LibraryMediaDetailsModal`
 - use `footerSkipLabel` when long content needs direct keyboard/screen-reader navigation to actions
 
-Use `dismissible={false}` only for mandatory blocking flows. This removes overlay, drag, Escape, Android-back, and close-button dismissal while preserving explicit completion/logout actions.
+Use `dismissible={false}` only for mandatory blocking flows. This keeps the visible overlay but disables overlay-click, drag, Escape, Android-back, and close-button dismissal while preserving explicit completion/logout actions.
 
 Do not implement one-off bottom-sheet shells.
 

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -13,7 +13,7 @@ Do not add decorative icons, new card styles, helper text, descriptions, badges,
 Use these before creating or changing UI:
 
 - App shell: `src/components/PageFrame.tsx`, `src/components/ResponsiveContainer.tsx`, `src/components/BottomNav.tsx`, `BackToTop.tsx`, `ReconnectingIndicator.tsx`
-- WUI primitives: `src/components/wui/Button.tsx`, `HeaderButton.tsx`, `Card.tsx`, `ToggleSwitch.tsx`, `TextInput.tsx`, `Badge.tsx`, `EmptyState.tsx`, `Segmented.tsx`, `ToggleChip.tsx`, `SettingHelp.tsx`
+- WUI primitives: `src/components/wui/Button.tsx`, `ModalActionBar.tsx`, `ModalActionRail.tsx`, `HeaderButton.tsx`, `Card.tsx`, `ToggleSwitch.tsx`, `TextInput.tsx`, `Badge.tsx`, `EmptyState.tsx`, `Segmented.tsx`, `ToggleChip.tsx`, `SettingHelp.tsx`
 - Modals: `src/components/SlideModal.tsx`, `ConfirmClearModal.tsx`, `PairingModal.tsx`, `WriteModal.tsx`, `RequirementsModal.tsx`, `ProPurchase.tsx`, `home/StopConfirmModal.tsx`, `home/StagedTokenModal.tsx`
 - Settings screens: `src/routes/settings.index.tsx`, `settings.readers.tsx`, `settings.advanced.tsx`, `settings.accessibility.tsx`, `settings.media.tsx`, `settings.play-controls.tsx`, `settings.about.tsx`, `settings.help.tsx`, `settings.online.tsx`, `src/routes/-pages/Devices.tsx`, `DeviceDetail.tsx`, `Logs.tsx`
 - Create/search flows: `src/routes/create.index.tsx`, `create.custom.tsx`, `create.nfc.tsx`, `create.mappings.tsx`, `src/routes/-pages/Search.tsx`, `MappingEditor.tsx`, `ZapScriptInput.tsx`
@@ -156,7 +156,9 @@ Shape is owned by Button:
 - labeled buttons use rounded pill-like corners
 - haptics derive from `intent`: default light, primary medium, destructive heavy
 
-Use `className="w-full"` for full-width primary page actions. Use `className="flex-1"` for equal-width modal footer buttons.
+Use `className="w-full"` for full-width primary page actions and complex-modal primary actions. Use `className="flex-1"` only for equal-width confirmation actions sharing one footer row.
+
+Button layout is inline by default. `layout="responsive"` is reserved for compact action-rail items: icon above caption on narrow screens, then icon beside caption from the `sm` breakpoint. Keep rail captions on one line.
 
 Do not build custom buttons with raw `<button>` unless implementing a specialized primitive already present in the codebase, such as selector rows or segmented radio buttons.
 
@@ -292,7 +294,7 @@ Real behavior:
 
 - inline circular help button with `HelpCircleIcon size={18}`
 - hint color `text-foreground-hint`, hover/focus muted
-- opens a shadcn `Dialog`, not `SlideModal`
+- opens a content-sized `SlideModal`
 - supports `**bold**` and paragraph breaks in description text
 
 Do not replace an existing help-icon pattern with visible helper paragraphs.
@@ -397,7 +399,7 @@ Use `SystemSelector`, `TagSelector`, and their trigger components for choosing s
 
 Selector modal pattern:
 
-- `SlideModal fixedHeight="90vh"`
+- `SlideModal fixedHeight="90vh"`; shared modal maximum clamps rendered height to 80% of viewport
 - search bar at top with icon inside input
 - category tabs/accordion where relevant
 - virtualized list rows
@@ -416,6 +418,8 @@ Visual behavior:
 
 - black overlay `bg-black/50`
 - bottom sheet on mobile, centered max width on desktop
+- content-sized by default and capped at 80% of viewport height
+- fixed-height selector/search requests are still capped at 80%
 - `bg-[rgba(17,25,40,0.7)]`
 - border `rgba(255,255,255,0.13)`
 - backdrop blur
@@ -424,16 +428,35 @@ Visual behavior:
 - safe-area bottom padding
 - focus trap and Android back handling
 
+Persistent footer behavior:
+
+- footer stays in normal flex flow below scrollable body; never float actions over content
+- body shrinks and scrolls before footer; footer gets its own constrained overflow only as short-viewport/text-zoom fallback
+- simple confirmations keep two labelled, equal-width actions on one row
+- form and selector footers with one secondary action plus one primary action use `ModalActionBar`, preserving the same labelled, equal-width pair; examples include Reset/Apply, Clear/Apply, Delete/Save, and Logout/Save
+- media/detail modals with several independent contextual actions use `ModalActionRail`; do not treat those actions as confirmation buttons
+- on narrow screens, the rail spans the footer above a full-width primary action; rail items use an icon above a short caption
+- from the `sm` breakpoint, the rail sits left of the primary action and its items switch to inline icon-and-caption layout
+- rail items share available width while they fit, never wrap onto another row, and scroll horizontally once their minimum widths exceed the available space; adding actions must not shrink the primary action or grow the footer vertically
+- use short, stable visual captions such as `Favorite`, `Write`, `Copy`, and `Preview`; communicate toggle or loading state through icon treatment, `aria-pressed`, disabled state, and a state-specific accessible name rather than changing caption width
+- rail icons never shrink, captions remain on one line, action order stays stable, every item remains directly reachable, and secondary actions precede the primary action in DOM and focus order
+- reserve icon-only buttons for established constrained controls and always provide an accessible `aria-label`
+- modal action targets stay at least 48px high; keep actions mounted and disable them during temporary unavailable, empty, disconnected, or loading states so the rail does not reflow
+- do not use action rails for confirmations, form submission pairs, single terminal actions, navigation, or unbounded destination data such as individual collections
+- current reference implementations are `MediaDetailsModal` and `LibraryMediaDetailsModal`
+- use `footerSkipLabel` when long content needs direct keyboard/screen-reader navigation to actions
+
+Use `dismissible={false}` only for mandatory blocking flows. This removes overlay, drag, Escape, Android-back, and close-button dismissal while preserving explicit completion/logout actions.
+
 Do not implement one-off bottom-sheet shells.
 
-### Dialog modals and full-screen write state
+### Full-screen write state
 
-`Dialog` is not the default for new app actions. Reserve shadcn `Dialog` for existing small/help/system-specific flows:
+Shadcn `Dialog` is no longer used for app modal flows; keep its primitive only while shared compatibility/tests require it.
 
-- `SettingHelp`, `ProPurchase`, `RequirementsModal`, and `NFCModal` use shadcn `Dialog`.
-- `WriteModal` is a special full-screen fixed overlay with scan spinner and cancel button, not a bottom sheet.
+`WriteModal` is a special full-screen fixed overlay with scan spinner and cancel button, not a bottom sheet.
 
-Copy the existing modal type for the same job. For new action confirmations, use `SlideModal` unless matching a strong existing Dialog precedent. Do not move help/purchase/write flows into `SlideModal` unless redesigning those flows deliberately.
+Copy existing `SlideModal` patterns for the same job. Help and purchase flows use `SlideModal`; `WriteModal` remains the deliberate full-screen exception.
 
 ### Confirm modals
 
@@ -451,7 +474,7 @@ Match the existing confirmation type closest to the action. Destructive actions 
 Launch Guard staged token modal pattern:
 
 - `SlideModal fixedHeight="auto"`
-- footer with two equal buttons in `flex gap-3 pt-4`
+- footer with two equal buttons in `flex gap-3`; shared footer owns separator and top padding
 - content `flex flex-col gap-4 py-4`
 - muted small description
 - token value `text-foreground text-sm font-medium break-all`

--- a/src/__tests__/integration/index-route.test.tsx
+++ b/src/__tests__/integration/index-route.test.tsx
@@ -137,7 +137,7 @@ const { mockSetProPurchaseModalOpen, mockProPurchaseState } = vi.hoisted(
 vi.mock("@/components/ProPurchase", () => ({
   useProPurchase: vi.fn(() => ({
     proAccess: mockProPurchaseState.proAccess,
-    PurchaseModal: () => null,
+    purchaseModal: null,
     proPurchaseModalOpen: mockProPurchaseState.proPurchaseModalOpen,
     setProPurchaseModalOpen: mockSetProPurchaseModalOpen,
   })),

--- a/src/__tests__/integration/settings-readers.test.tsx
+++ b/src/__tests__/integration/settings-readers.test.tsx
@@ -113,7 +113,7 @@ const mockProPurchaseState = {
 
 vi.mock("@/components/ProPurchase", () => ({
   useProPurchase: () => ({
-    PurchaseModal: () => <div data-testid="purchase-modal" />,
+    purchaseModal: <div data-testid="purchase-modal" />,
     setProPurchaseModalOpen: mockProPurchaseState.setProPurchaseModalOpen,
   }),
 }));
@@ -217,7 +217,9 @@ describe("Settings Readers Integration", () => {
       renderComponent();
 
       expect(
-        screen.getByText(/settings.readers.continuousScan/i),
+        screen.getByRole("checkbox", {
+          name: /settings.readers.continuousScan/i,
+        }),
       ).toBeInTheDocument();
     });
   });
@@ -232,7 +234,9 @@ describe("Settings Readers Integration", () => {
         renderComponent();
 
         expect(
-          screen.getByText(/settings.readers.launchOnScan/i),
+          screen.getByRole("checkbox", {
+            name: /settings.readers.launchOnScan/i,
+          }),
         ).toBeInTheDocument();
       });
 
@@ -249,11 +253,11 @@ describe("Settings Readers Integration", () => {
         usePreferencesStore.setState({ launcherAccess: false });
         renderComponent();
 
-        // Pro badge should be visible for launch on scan
-        const launchOnScanLabel = screen.getByText(
-          /settings.readers.launchOnScan/i,
-        );
-        expect(launchOnScanLabel).toBeInTheDocument();
+        expect(
+          screen.getByRole("checkbox", {
+            name: /settings.readers.launchOnScan/i,
+          }),
+        ).toBeInTheDocument();
       });
 
       it("should toggle launch on scan setting", async () => {
@@ -278,7 +282,9 @@ describe("Settings Readers Integration", () => {
         renderComponent();
 
         expect(
-          screen.getByText(/settings.readers.preferExternalReader/i),
+          screen.getByRole("checkbox", {
+            name: /settings.readers.preferExternalReader/i,
+          }),
         ).toBeInTheDocument();
       });
 
@@ -320,7 +326,9 @@ describe("Settings Readers Integration", () => {
       renderComponent();
 
       expect(
-        screen.getByText(/settings.readers.shakeToLaunch/i),
+        screen.getByRole("checkbox", {
+          name: /settings.readers.shakeToLaunch/i,
+        }),
       ).toBeInTheDocument();
     });
 
@@ -346,8 +354,11 @@ describe("Settings Readers Integration", () => {
       usePreferencesStore.setState({ launcherAccess: false });
       renderComponent();
 
-      const shakeLabel = screen.getByText(/settings.readers.shakeToLaunch/i);
-      expect(shakeLabel).toBeInTheDocument();
+      expect(
+        screen.getByRole("checkbox", {
+          name: /settings.readers.shakeToLaunch/i,
+        }),
+      ).toBeInTheDocument();
     });
 
     it("should enable shake when toggle is clicked", async () => {
@@ -688,9 +699,10 @@ describe("Settings Readers Integration", () => {
     it("should render help icon for scan mode", () => {
       renderComponent();
 
-      // Look for setting help components - they should have aria-labels or test ids
       expect(
-        screen.getByText(/settings.readers.scanMode/i),
+        screen.getByRole("button", {
+          name: /Help for settings.readers.scanMode/i,
+        }),
       ).toBeInTheDocument();
     });
 
@@ -698,7 +710,9 @@ describe("Settings Readers Integration", () => {
       renderComponent();
 
       expect(
-        screen.getByText(/settings.readers.continuousScan/i),
+        screen.getByRole("button", {
+          name: /Help for settings.readers.continuousScan/i,
+        }),
       ).toBeInTheDocument();
     });
 
@@ -706,7 +720,9 @@ describe("Settings Readers Integration", () => {
       renderComponent();
 
       expect(
-        screen.getByText(/settings.readers.audioFeedback/i),
+        screen.getByRole("button", {
+          name: /Help for settings.readers.audioFeedback/i,
+        }),
       ).toBeInTheDocument();
     });
   });

--- a/src/__tests__/unit/App.firebase-auth.test.tsx
+++ b/src/__tests__/unit/App.firebase-auth.test.tsx
@@ -245,6 +245,10 @@ vi.mock("@/components/InboxModal", () => ({
   InboxModal: () => <div data-testid="inbox-modal" />,
 }));
 
+vi.mock("@/components/RequirementsModal", () => ({
+  RequirementsModal: () => null,
+}));
+
 vi.mock("@/components/AppBadgeManager", () => ({
   AppBadgeManager: () => <div data-testid="app-badge-manager" />,
 }));

--- a/src/__tests__/unit/App.integration.test.tsx
+++ b/src/__tests__/unit/App.integration.test.tsx
@@ -206,6 +206,10 @@ vi.mock("@/components/InboxModal", () => ({
   InboxModal: () => <div data-testid="inbox-modal" />,
 }));
 
+vi.mock("@/components/RequirementsModal", () => ({
+  RequirementsModal: () => null,
+}));
+
 vi.mock("@/components/AppBadgeManager", () => ({
   AppBadgeManager: () => <div data-testid="app-badge-manager" />,
 }));

--- a/src/__tests__/unit/components/MediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/MediaDetailsModal.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "@/test-utils";
+import { render, screen, within } from "@/test-utils";
 import { MediaDetailsModal } from "@/components/MediaDetailsModal";
 import { CoreAPI } from "@/lib/coreApi";
 import type { SearchResultGame } from "@/lib/models";
@@ -74,6 +74,41 @@ describe("MediaDetailsModal", () => {
       screen.getByText("/games/snes/Super Mario World.sfc"),
     ).toBeInTheDocument();
     expect(screen.getByText("@SNES/Super Mario World")).toBeInTheDocument();
+  });
+
+  it("should show labelled secondary actions before the primary action", () => {
+    renderModal({ onCopy: vi.fn(), onPreview: vi.fn() });
+
+    const favorite = screen.getByRole("button", {
+      name: "library.addFavorite",
+    });
+    const copy = screen.getByRole("button", {
+      name: "create.search.copyLabel",
+    });
+    const preview = screen.getByRole("button", {
+      name: "create.search.playLabel",
+    });
+    const write = screen.getByRole("button", {
+      name: "create.search.writeLabel",
+    });
+
+    const actions = screen.getByRole("group", {
+      name: "create.search.mediaActions",
+    });
+    expect(favorite).toHaveTextContent("library.favorite");
+    expect(copy).toHaveTextContent("create.search.copyLabel");
+    expect(preview).toHaveTextContent("create.search.playLabel");
+    expect(
+      within(actions).getByRole("button", { name: "library.addFavorite" }),
+    ).toBe(favorite);
+    expect(
+      within(actions).queryByRole("button", {
+        name: "create.search.writeLabel",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      copy.compareDocumentPosition(write) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("should add a favorite from indexed-media details", async () => {

--- a/src/__tests__/unit/components/MediaScrapeCard.test.tsx
+++ b/src/__tests__/unit/components/MediaScrapeCard.test.tsx
@@ -307,7 +307,7 @@ describe("MediaScrapeCard", () => {
     });
   });
 
-  it("should show a loading state while waiting for scrape status", async () => {
+  it("should disable and relabel the action while waiting for scrape status", async () => {
     const user = userEvent.setup();
     render(<MediaScrapeCard />);
 
@@ -322,12 +322,11 @@ describe("MediaScrapeCard", () => {
       screen.getByRole("button", { name: "settings.scrapeMedia" }),
     );
 
-    expect(
-      await screen.findByRole("button", {
-        name: "settings.scrapeMedia.starting",
-      }),
-    ).toBeDisabled();
-    expect(screen.getByRole("status", { name: "loading" })).toBeInTheDocument();
+    const startButton = await screen.findByRole("button", {
+      name: "settings.scrapeMedia.starting",
+    });
+    expect(startButton).toBeDisabled();
+    expect(startButton).toHaveTextContent("settings.scrapeMedia.starting");
   });
 
   it("should render one visible force toggle label", async () => {

--- a/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
+++ b/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
@@ -108,14 +108,13 @@ describe("OnlineDeviceSetup", () => {
     const user = userEvent.setup();
     render(<OnlineDeviceSetup connected={false} warpActive={false} />);
 
-    expect(
-      screen.queryByText("online.deviceLink.help"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     await user.click(
       screen.getByRole("button", {
         name: "Help for online.deviceLink.title",
       }),
     );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("online.deviceLink.help")).toBeInTheDocument();
     expect(mockSettings).not.toHaveBeenCalled();
     expect(mockBackupStatus).not.toHaveBeenCalled();

--- a/src/__tests__/unit/components/ProPurchase.test.tsx
+++ b/src/__tests__/unit/components/ProPurchase.test.tsx
@@ -177,6 +177,19 @@ function createOfferings(
   };
 }
 
+function ProPurchaseHarness() {
+  const { purchaseModal, setProPurchaseModalOpen } = useProPurchase();
+
+  return (
+    <>
+      <button type="button" onClick={() => setProPurchaseModalOpen(true)}>
+        Open Pro purchase
+      </button>
+      {purchaseModal}
+    </>
+  );
+}
+
 describe("useProPurchase", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -204,6 +217,19 @@ describe("useProPurchase", () => {
         },
       },
     } as any);
+  });
+
+  it("should slide the mounted purchase modal open", async () => {
+    const user = userEvent.setup();
+    render(<ProPurchaseHarness />);
+    const dialog = screen.getByRole("dialog", { hidden: true });
+
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
+
+    expect(screen.getByRole("dialog")).toBe(dialog);
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
   });
 
   it("should read proAccess from store", async () => {
@@ -316,8 +342,7 @@ describe("useProPurchase", () => {
       result.current.setProPurchaseModalOpen(true);
     });
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     expect(screen.getByText("scan.purchaseProUnavailable")).toBeInTheDocument();
     expect(
@@ -349,8 +374,7 @@ describe("useProPurchase", () => {
       result.current.setProPurchaseModalOpen(true);
     });
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     expect(
       screen.getByText("scan.purchaseProOfferingsError"),
@@ -376,8 +400,7 @@ describe("useProPurchase", () => {
       result.current.setProPurchaseModalOpen(true);
     });
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     expect(screen.getByText("scan.purchaseProP1 $6.99")).toBeInTheDocument();
     expect(
@@ -412,7 +435,7 @@ describe("useProPurchase", () => {
     const { result } = renderHook(() => useProPurchase());
     await waitFor(() => expect(Purchases.getOfferings).toHaveBeenCalled());
     act(() => result.current.setProPurchaseModalOpen(true));
-    render(<result.current.PurchaseModal />);
+    render(result.current.purchaseModal);
 
     await user.click(
       screen.getByRole("button", { name: "scan.purchaseProAction" }),
@@ -443,7 +466,7 @@ describe("useProPurchase", () => {
     const { result } = renderHook(() => useProPurchase());
     await waitFor(() => expect(Purchases.getOfferings).toHaveBeenCalled());
     act(() => result.current.setProPurchaseModalOpen(true));
-    render(<result.current.PurchaseModal />);
+    render(result.current.purchaseModal);
 
     await user.click(
       screen.getByRole("button", { name: "scan.purchaseProAction" }),
@@ -472,18 +495,16 @@ describe("useProPurchase", () => {
       result.current.setProPurchaseModalOpen(true);
     });
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     expect(screen.getByText("scan.purchaseProUnavailable")).toBeInTheDocument();
     expect(screen.queryByText(/\$6\.99/)).not.toBeInTheDocument();
   });
 
-  it("should render PurchaseModal component", async () => {
+  it("should render purchase modal", async () => {
     const { result } = renderHook(() => useProPurchase());
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     // Modal should not be visible initially (proPurchaseModalOpen is false)
     expect(
@@ -498,8 +519,7 @@ describe("useProPurchase", () => {
       result.current.setProPurchaseModalOpen(true);
     });
 
-    const PurchaseModalComponent = result.current.PurchaseModal;
-    render(<PurchaseModalComponent />);
+    render(result.current.purchaseModal);
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     // Title may appear multiple times due to test-utils wrapper

--- a/src/__tests__/unit/components/ProPurchase.test.tsx
+++ b/src/__tests__/unit/components/ProPurchase.test.tsx
@@ -432,7 +432,9 @@ describe("useProPurchase", () => {
       within(dialog).queryByRole("button", { name: "nav.close" }),
     ).not.toBeInTheDocument();
     await user.keyboard("{Escape}");
-    expect(dialog).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "scan.purchaseProTitle" })).toBe(
+      dialog,
+    );
 
     act(() => {
       resolvePurchase?.({

--- a/src/__tests__/unit/components/ProPurchase.test.tsx
+++ b/src/__tests__/unit/components/ProPurchase.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, renderHook, screen, waitFor } from "@/test-utils";
+import { act, render, renderHook, screen, waitFor, within } from "@/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { useProPurchase } from "@/components/ProPurchase";
@@ -315,11 +315,12 @@ describe("useProPurchase", () => {
   });
 
   it("should show unavailable state and report when offerings have no packages", async () => {
+    const user = userEvent.setup();
     const { Purchases } = await import("@revenuecat/purchases-capacitor");
     const { logger } = await import("@/lib/logger");
     vi.mocked(Purchases.getOfferings).mockResolvedValue(createOfferings());
 
-    const { result } = renderHook(() => useProPurchase());
+    render(<ProPurchaseHarness />);
 
     await waitFor(() => {
       expect(logger.error).toHaveBeenCalledWith(
@@ -337,12 +338,7 @@ describe("useProPurchase", () => {
         },
       );
     });
-
-    act(() => {
-      result.current.setProPurchaseModalOpen(true);
-    });
-
-    render(result.current.purchaseModal);
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
 
     expect(screen.getByText("scan.purchaseProUnavailable")).toBeInTheDocument();
     expect(
@@ -351,12 +347,13 @@ describe("useProPurchase", () => {
   });
 
   it("should show error state and report when offerings fail to load", async () => {
+    const user = userEvent.setup();
     const { Purchases } = await import("@revenuecat/purchases-capacitor");
     const { logger } = await import("@/lib/logger");
     const error = new Error("Network unavailable");
     vi.mocked(Purchases.getOfferings).mockRejectedValue(error);
 
-    const { result } = renderHook(() => useProPurchase());
+    render(<ProPurchaseHarness />);
 
     await waitFor(() => {
       expect(logger.error).toHaveBeenCalledWith(
@@ -369,12 +366,7 @@ describe("useProPurchase", () => {
         },
       );
     });
-
-    act(() => {
-      result.current.setProPurchaseModalOpen(true);
-    });
-
-    render(result.current.purchaseModal);
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
 
     expect(
       screen.getByText("scan.purchaseProOfferingsError"),
@@ -385,27 +377,73 @@ describe("useProPurchase", () => {
   });
 
   it("should show fetched package price and enable purchase action", async () => {
+    const user = userEvent.setup();
     const { Purchases } = await import("@revenuecat/purchases-capacitor");
     vi.mocked(Purchases.getOfferings).mockResolvedValue(
       createOfferings(createOffering([createPackage()])),
     );
 
-    const { result } = renderHook(() => useProPurchase());
+    render(<ProPurchaseHarness />);
 
     await waitFor(() => {
       expect(Purchases.getOfferings).toHaveBeenCalled();
     });
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
 
-    act(() => {
-      result.current.setProPurchaseModalOpen(true);
-    });
-
-    render(result.current.purchaseModal);
-
-    expect(screen.getByText("scan.purchaseProP1 $6.99")).toBeInTheDocument();
+    expect(
+      await screen.findByText("scan.purchaseProP1 $6.99"),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "scan.purchaseProAction" }),
     ).toBeEnabled();
+  });
+
+  it("should ignore repeat activations and block dismissal while purchasing", async () => {
+    const user = userEvent.setup();
+    const { Purchases } = await import("@revenuecat/purchases-capacitor");
+    let resolvePurchase:
+      | ((value: Awaited<ReturnType<typeof Purchases.purchasePackage>>) => void)
+      | undefined;
+    vi.mocked(Purchases.getOfferings).mockResolvedValue(
+      createOfferings(createOffering([createPackage()])),
+    );
+    vi.mocked(Purchases.purchasePackage).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePurchase = resolve;
+      }) as ReturnType<typeof Purchases.purchasePackage>,
+    );
+
+    render(<ProPurchaseHarness />);
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
+    const purchaseButton = await screen.findByRole("button", {
+      name: "scan.purchaseProAction",
+    });
+    const dialog = screen.getByRole("dialog", {
+      name: "scan.purchaseProTitle",
+    });
+
+    await user.dblClick(purchaseButton);
+
+    expect(Purchases.purchasePackage).toHaveBeenCalledTimes(1);
+    expect(
+      within(dialog).getByRole("button", { name: "loading" }),
+    ).toBeDisabled();
+    expect(
+      within(dialog).queryByRole("button", { name: "nav.close" }),
+    ).not.toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(dialog).toBeInTheDocument();
+
+    act(() => {
+      resolvePurchase?.({
+        customerInfo: {
+          entitlements: { active: { tapto_launcher: {} } },
+        },
+      } as never);
+    });
+    await waitFor(() => {
+      expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+    });
   });
 
   it("should never buy the current Warp package as Pro", async () => {
@@ -432,13 +470,12 @@ describe("useProPurchase", () => {
       },
     } as never);
 
-    const { result } = renderHook(() => useProPurchase());
+    render(<ProPurchaseHarness />);
+    const dialog = screen.getByRole("dialog", { hidden: true });
     await waitFor(() => expect(Purchases.getOfferings).toHaveBeenCalled());
-    act(() => result.current.setProPurchaseModalOpen(true));
-    render(result.current.purchaseModal);
-
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
     await user.click(
-      screen.getByRole("button", { name: "scan.purchaseProAction" }),
+      await screen.findByRole("button", { name: "scan.purchaseProAction" }),
     );
 
     const { usePreferencesStore } = await import("@/lib/preferencesStore");
@@ -448,8 +485,11 @@ describe("useProPurchase", () => {
       });
       expect(usePreferencesStore.getState().lifetimeProAccess).toBe(true);
       expect(mockSetLaunchOnScan).toHaveBeenCalledWith(true);
-      expect(result.current.proPurchaseModalOpen).toBe(false);
+      expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
     });
+    expect(
+      screen.queryByRole("dialog", { name: "scan.purchaseProTitle" }),
+    ).not.toBeInTheDocument();
   });
 
   it("should show a purchase error without enabling launch on scan", async () => {
@@ -463,20 +503,23 @@ describe("useProPurchase", () => {
       new Error("payment declined"),
     );
 
-    const { result } = renderHook(() => useProPurchase());
+    render(<ProPurchaseHarness />);
     await waitFor(() => expect(Purchases.getOfferings).toHaveBeenCalled());
-    act(() => result.current.setProPurchaseModalOpen(true));
-    render(result.current.purchaseModal);
-
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
     await user.click(
-      screen.getByRole("button", { name: "scan.purchaseProAction" }),
+      await screen.findByRole("button", { name: "scan.purchaseProAction" }),
     );
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("scan.purchaseProFailed");
     });
     expect(mockSetLaunchOnScan).not.toHaveBeenCalled();
-    expect(result.current.proPurchaseModalOpen).toBe(true);
+    expect(
+      screen.getByRole("dialog", { name: "scan.purchaseProTitle" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "scan.purchaseProAction" }),
+    ).toBeEnabled();
   });
 
   it("should show unsupported state on web platform", async () => {
@@ -485,45 +528,23 @@ describe("useProPurchase", () => {
     vi.mocked(Capacitor.getPlatform).mockReturnValue("web");
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
 
-    const { result } = renderHook(() => useProPurchase());
+    const user = userEvent.setup();
+    render(<ProPurchaseHarness />);
 
     await waitFor(() => {
       expect(Purchases.getOfferings).not.toHaveBeenCalled();
     });
-
-    act(() => {
-      result.current.setProPurchaseModalOpen(true);
-    });
-
-    render(result.current.purchaseModal);
+    await user.click(screen.getByRole("button", { name: "Open Pro purchase" }));
 
     expect(screen.getByText("scan.purchaseProUnavailable")).toBeInTheDocument();
     expect(screen.queryByText(/\$6\.99/)).not.toBeInTheDocument();
   });
 
-  it("should render purchase modal", async () => {
-    const { result } = renderHook(() => useProPurchase());
+  it("should keep purchase modal hidden until opened", () => {
+    render(<ProPurchaseHarness />);
 
-    render(result.current.purchaseModal);
-
-    // Modal should not be visible initially (proPurchaseModalOpen is false)
     expect(
       screen.queryByRole("dialog", { name: /scan\.purchaseProTitle/i }),
     ).not.toBeInTheDocument();
-  });
-
-  it("should open purchase modal", async () => {
-    const { result } = renderHook(() => useProPurchase());
-
-    act(() => {
-      result.current.setProPurchaseModalOpen(true);
-    });
-
-    render(result.current.purchaseModal);
-
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-    // Title may appear multiple times due to test-utils wrapper
-    const titles = screen.getAllByText("scan.purchaseProTitle");
-    expect(titles.length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/unit/components/ProfileManager.test.tsx
+++ b/src/__tests__/unit/components/ProfileManager.test.tsx
@@ -382,9 +382,11 @@ describe("ProfileManager", () => {
         name: "settings.core.profiles.openProfile",
       }),
     );
-    await user.click(
-      screen.getByRole("button", { name: "settings.core.profiles.delete" }),
-    );
+    const deleteAction = screen.getByRole("button", {
+      name: "settings.core.profiles.delete",
+    });
+    expect(deleteAction).toHaveTextContent("settings.core.profiles.delete");
+    await user.click(deleteAction);
     const deleteDialog = screen.getByRole("dialog", {
       name: "settings.core.profiles.deleteTitle",
     });

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -214,6 +214,7 @@ describe("RequirementsModal", () => {
   });
 
   it("should enable continue when legal consent is checked", async () => {
+    const user = userEvent.setup();
     const requirements: PendingRequirement[] = [
       {
         type: "terms_acceptance",
@@ -238,7 +239,7 @@ describe("RequirementsModal", () => {
     expect(logoutButton).toHaveTextContent("requirements.logout");
     expect(continueButton).toBeDisabled();
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
     );
 
@@ -269,7 +270,9 @@ describe("RequirementsModal", () => {
     expect(continueButton).toBeDisabled();
 
     // Check age
-    fireEvent.click(screen.getByLabelText(/requirements\.ageLabel/));
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "requirements.ageLabel" }),
+    );
 
     await waitFor(() => {
       expect(continueButton).not.toBeDisabled();
@@ -277,6 +280,7 @@ describe("RequirementsModal", () => {
   });
 
   it("should submit only pending legal requirements", async () => {
+    const user = userEvent.setup();
     const requirements: PendingRequirement[] = [
       {
         type: "terms_acceptance",
@@ -292,10 +296,10 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole("button", { name: /requirements\.continue/i }),
     );
 

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "../../../test-utils";
+import { act, render, screen, fireEvent, waitFor } from "../../../test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { RequirementsModal } from "@/components/RequirementsModal";
@@ -79,11 +79,27 @@ describe("RequirementsModal", () => {
     });
   });
 
-  it("should not render when closed", () => {
+  it("should stay mounted and slide open for new requirements", () => {
     render(<RequirementsModal />);
-    expect(
-      screen.queryByRole("dialog", { name: /requirements\.title/i }),
-    ).not.toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { hidden: true });
+
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+
+    act(() => {
+      useRequirementsStore.setState({
+        isOpen: true,
+        pendingRequirements: [
+          {
+            type: "terms_acceptance",
+            description: "Accept terms",
+            endpoint: "/account/requirements",
+          },
+        ],
+      });
+    });
+
+    expect(screen.getByRole("dialog")).toBe(dialog);
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
   });
 
   it("should render when open with TOS requirement", () => {
@@ -173,9 +189,13 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
+    const logoutButton = screen.getByRole("button", {
+      name: /requirements\.logout/i,
+    });
     const saveButton = screen.getByRole("button", {
       name: /requirements\.save/i,
     });
+    expect(logoutButton).toHaveTextContent("requirements.logout");
     expect(saveButton).toBeDisabled();
 
     // Check TOS - get first matching element
@@ -356,7 +376,11 @@ describe("RequirementsModal", () => {
       expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
     });
 
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalledWith(
+      "RevenueCat logout failed:",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("should log unexpected RevenueCat logout errors", async () => {

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, fireEvent, waitFor } from "../../../test-utils";
+import { act, render, screen, fireEvent, waitFor } from "@/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { RequirementsModal } from "@/components/RequirementsModal";
@@ -129,6 +129,38 @@ describe("RequirementsModal", () => {
       /requirements\.privacyLabel/,
     );
     expect(privacyLabels.length).toBeGreaterThan(0);
+  });
+
+  it("should expose legal agreements as links outside checkbox labels", () => {
+    useRequirementsStore.setState({
+      isOpen: true,
+      pendingRequirements: [
+        {
+          type: "terms_acceptance",
+          description: "Accept terms",
+          endpoint: "/account/requirements",
+        },
+      ],
+    });
+
+    render(<RequirementsModal />);
+
+    const termsLink = screen.getByRole("link", {
+      name: /requirements\.tosLink/,
+    });
+    const privacyLink = screen.getByRole("link", {
+      name: /requirements\.privacyLink/,
+    });
+    expect(termsLink).toHaveAttribute("href", "https://zaparoo.com/terms");
+    expect(privacyLink).toHaveAttribute("href", "https://zaparoo.com/privacy");
+    expect(termsLink.closest("label")).toBeNull();
+    expect(privacyLink.closest("label")).toBeNull();
+    expect(
+      screen.getByRole("checkbox", { name: "requirements.tosLabel" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "requirements.privacyLabel" }),
+    ).toBeInTheDocument();
   });
 
   it("should render age verification checkbox when required", () => {
@@ -381,6 +413,7 @@ describe("RequirementsModal", () => {
       expect.anything(),
       expect.anything(),
     );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it("should log unexpected RevenueCat logout errors", async () => {

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -68,6 +68,14 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+vi.mock("@/hooks/useHaptics", () => ({
+  useHaptics: () => ({
+    impact: vi.fn(),
+    notification: vi.fn(),
+    vibrate: vi.fn(),
+  }),
+}));
+
 describe("RequirementsModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,16 +130,13 @@ describe("RequirementsModal", () => {
     // Title may appear multiple times due to test-utils wrapper
     const titles = screen.getAllByText("requirements.title");
     expect(titles.length).toBeGreaterThan(0);
-    // Checkboxes have their labels - may have multiple due to wrapper
-    const tosLabels = screen.getAllByLabelText(/requirements\.tosLabel/);
-    expect(tosLabels.length).toBeGreaterThan(0);
-    const privacyLabels = screen.getAllByLabelText(
-      /requirements\.privacyLabel/,
-    );
-    expect(privacyLabels.length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
+    ).toBeInTheDocument();
   });
 
-  it("should expose legal agreements as links outside checkbox labels", () => {
+  it("should expose legal links without toggling combined consent", async () => {
+    const user = userEvent.setup();
     useRequirementsStore.setState({
       isOpen: true,
       pendingRequirements: [
@@ -155,12 +160,15 @@ describe("RequirementsModal", () => {
     expect(privacyLink).toHaveAttribute("href", "https://zaparoo.com/privacy");
     expect(termsLink.closest("label")).toBeNull();
     expect(privacyLink.closest("label")).toBeNull();
-    expect(
-      screen.getByRole("checkbox", { name: "requirements.tosLabel" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: "requirements.privacyLabel" }),
-    ).toBeInTheDocument();
+    const legalCheckbox = screen.getByRole("checkbox", {
+      name: "requirements.legalLabel",
+    });
+    expect(screen.getAllByRole("checkbox")).toHaveLength(1);
+
+    await user.click(termsLink);
+    expect(legalCheckbox).not.toBeChecked();
+    await user.click(privacyLink);
+    expect(legalCheckbox).not.toBeChecked();
   });
 
   it("should render age verification checkbox when required", () => {
@@ -205,7 +213,7 @@ describe("RequirementsModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("should enable save button when TOS and privacy are checked", async () => {
+  it("should enable continue when legal consent is checked", async () => {
     const requirements: PendingRequirement[] = [
       {
         type: "terms_acceptance",
@@ -224,27 +232,22 @@ describe("RequirementsModal", () => {
     const logoutButton = screen.getByRole("button", {
       name: /requirements\.logout/i,
     });
-    const saveButton = screen.getByRole("button", {
-      name: /requirements\.save/i,
+    const continueButton = screen.getByRole("button", {
+      name: /requirements\.continue/i,
     });
     expect(logoutButton).toHaveTextContent("requirements.logout");
-    expect(saveButton).toBeDisabled();
+    expect(continueButton).toBeDisabled();
 
-    // Check TOS - get first matching element
-    const tosCheckboxes = screen.getAllByLabelText(/requirements\.tosLabel/);
-    fireEvent.click(tosCheckboxes[0]!);
-    // Check Privacy - get first matching element
-    const privacyCheckboxes = screen.getAllByLabelText(
-      /requirements\.privacyLabel/,
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
     );
-    fireEvent.click(privacyCheckboxes[0]!);
 
     await waitFor(() => {
-      expect(saveButton).not.toBeDisabled();
+      expect(continueButton).not.toBeDisabled();
     });
   });
 
-  it("should enable save button when age is checked", async () => {
+  it("should enable continue when age is checked", async () => {
     const requirements: PendingRequirement[] = [
       {
         type: "age_verified",
@@ -260,20 +263,20 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    const saveButton = screen.getByRole("button", {
-      name: /requirements\.save/i,
+    const continueButton = screen.getByRole("button", {
+      name: /requirements\.continue/i,
     });
-    expect(saveButton).toBeDisabled();
+    expect(continueButton).toBeDisabled();
 
     // Check age
     fireEvent.click(screen.getByLabelText(/requirements\.ageLabel/));
 
     await waitFor(() => {
-      expect(saveButton).not.toBeDisabled();
+      expect(continueButton).not.toBeDisabled();
     });
   });
 
-  it("should call updateRequirements when save is clicked", async () => {
+  it("should submit only pending legal requirements", async () => {
     const requirements: PendingRequirement[] = [
       {
         type: "terms_acceptance",
@@ -289,27 +292,58 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    // Check required checkboxes - get first matching elements
-    const tosCheckboxes = screen.getAllByLabelText(/requirements\.tosLabel/);
-    fireEvent.click(tosCheckboxes[0]!);
-    const privacyCheckboxes = screen.getAllByLabelText(
-      /requirements\.privacyLabel/,
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
     );
-    fireEvent.click(privacyCheckboxes[0]!);
-
-    // Click save
-    const saveButton = screen.getByRole("button", {
-      name: /requirements\.save/i,
-    });
-    fireEvent.click(saveButton);
+    fireEvent.click(
+      screen.getByRole("button", { name: /requirements\.continue/i }),
+    );
 
     const { updateRequirements } = await import("@/lib/onlineApi");
     await waitFor(() => {
       expect(updateRequirements).toHaveBeenCalledWith({
         accept_tos: true,
         accept_privacy: true,
-        age_verified: false,
       });
+    });
+  });
+
+  it("should submit legal and age requirements together", async () => {
+    const user = userEvent.setup();
+    useRequirementsStore.setState({
+      isOpen: true,
+      pendingRequirements: [
+        {
+          type: "terms_acceptance",
+          description: "Accept terms",
+          endpoint: "/account/requirements",
+        },
+        {
+          type: "age_verified",
+          description: "Verify age",
+          endpoint: "/account/requirements",
+        },
+      ],
+    });
+
+    render(<RequirementsModal />);
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
+    );
+    await user.click(
+      screen.getByRole("checkbox", { name: "requirements.ageLabel" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "requirements.continue" }),
+    );
+
+    const { updateRequirements } = await import("@/lib/onlineApi");
+    expect(updateRequirements).toHaveBeenCalledOnce();
+    expect(updateRequirements).toHaveBeenCalledWith({
+      accept_tos: true,
+      accept_privacy: true,
+      age_verified: true,
     });
   });
 
@@ -541,15 +575,12 @@ describe("RequirementsModal", () => {
 
     render(<RequirementsModal />);
 
-    // All sections should be visible - use getAllBy since multiple may exist
-    const tosLabels = screen.getAllByLabelText(/requirements\.tosLabel/);
-    expect(tosLabels.length).toBeGreaterThan(0);
-    const privacyLabels = screen.getAllByLabelText(
-      /requirements\.privacyLabel/,
-    );
-    expect(privacyLabels.length).toBeGreaterThan(0);
-    const ageLabels = screen.getAllByLabelText(/requirements\.ageLabel/);
-    expect(ageLabels.length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("checkbox", { name: "requirements.legalLabel" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "requirements.ageLabel" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: /requirements\.sendVerificationEmail/i,
@@ -574,12 +605,11 @@ describe("RequirementsModal", () => {
 
     const { rerender } = render(<RequirementsModal />);
 
-    // Use getByRole to get the checkbox element with role="checkbox"
-    const tosCheckbox = screen.getByRole("checkbox", {
-      name: /requirements\.tosLabel/,
+    const legalCheckbox = screen.getByRole("checkbox", {
+      name: "requirements.legalLabel",
     });
-    fireEvent.click(tosCheckbox);
-    expect(tosCheckbox).toBeChecked();
+    fireEvent.click(legalCheckbox);
+    expect(legalCheckbox).toBeChecked();
 
     // Close modal
     useRequirementsStore.setState({
@@ -598,10 +628,10 @@ describe("RequirementsModal", () => {
     rerender(<RequirementsModal />);
 
     // Checkbox should be unchecked again - get by role again after rerender
-    const reopenedTosCheckbox = screen.getByRole("checkbox", {
-      name: /requirements\.tosLabel/,
+    const reopenedLegalCheckbox = screen.getByRole("checkbox", {
+      name: "requirements.legalLabel",
     });
-    expect(reopenedTosCheckbox).not.toBeChecked();
+    expect(reopenedLegalCheckbox).not.toBeChecked();
   });
 
   describe("email verification check flow", () => {

--- a/src/__tests__/unit/components/SlideModal.test.tsx
+++ b/src/__tests__/unit/components/SlideModal.test.tsx
@@ -121,11 +121,7 @@ function BlockingModalHarness() {
 
   return (
     <>
-      <button
-        type="button"
-        data-testid="trigger-later-modal"
-        onClick={() => setLaterOpen(true)}
-      >
+      <button type="button" onClick={() => setLaterOpen(true)}>
         Trigger later modal
       </button>
       <SlideModal
@@ -243,22 +239,26 @@ describe("SlideModal", () => {
     expect(closeMock).toHaveBeenCalled();
   });
 
-  it("closes modal when close button is clicked", () => {
+  it("closes modal when close button is clicked", async () => {
+    const user = userEvent.setup();
     const closeMock = vi.fn();
     render(<SlideModal {...mockProps} isOpen={true} close={closeMock} />);
 
     // There are two close buttons (drag handle on mobile, X button on desktop)
     const closeButtons = screen.getAllByRole("button", { name: "nav.close" });
     expect(closeButtons.length).toBe(2);
-    fireEvent.click(closeButtons[0]!);
+    await user.click(closeButtons[0]!);
 
     expect(closeMock).toHaveBeenCalled();
   });
 
-  it("keeps a blocking modal active when a later modal is requested", () => {
+  it("keeps a blocking modal active when a later modal is requested", async () => {
+    const user = userEvent.setup();
     render(<BlockingModalHarness />);
 
-    fireEvent.click(screen.getByTestId("trigger-later-modal"));
+    await user.click(
+      screen.getByRole("button", { name: "Trigger later modal" }),
+    );
 
     expect(
       screen.getByRole("dialog", { name: "Mandatory blocker" }),

--- a/src/__tests__/unit/components/SlideModal.test.tsx
+++ b/src/__tests__/unit/components/SlideModal.test.tsx
@@ -1,3 +1,4 @@
+import { createRef, useState } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   createEvent,
@@ -8,6 +9,16 @@ import {
 } from "@/test-utils";
 import userEvent from "@testing-library/user-event";
 import { SlideModal } from "@/components/SlideModal";
+
+const backButtonMock = vi.hoisted(() => ({
+  handler: undefined as (() => boolean | void) | undefined,
+}));
+
+vi.mock("@/hooks/useBackButtonHandler", () => ({
+  useBackButtonHandler: (_id: string, handler: () => boolean | void): void => {
+    backButtonMock.handler = handler;
+  },
+}));
 
 // Mock store for safe insets
 vi.mock("@/lib/store", () => ({
@@ -105,10 +116,46 @@ function withTimeStamp<T extends Event>(event: T, timeStamp: number): T {
   return event;
 }
 
+function BlockingModalHarness() {
+  const [laterOpen, setLaterOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="trigger-later-modal"
+        onClick={() => setLaterOpen(true)}
+      >
+        Trigger later modal
+      </button>
+      <SlideModal
+        isOpen
+        close={vi.fn()}
+        title="Mandatory blocker"
+        dismissible={false}
+      >
+        <p>Complete requirements</p>
+      </SlideModal>
+      <SlideModal
+        isOpen={laterOpen}
+        close={() => setLaterOpen(false)}
+        title="Later modal"
+      >
+        <button type="button">Later action</button>
+      </SlideModal>
+    </>
+  );
+}
+
 describe("SlideModal", () => {
   it("should have no detectable accessibility violations while open", async () => {
     const { baseElement } = render(
-      <SlideModal isOpen close={vi.fn()} title="Accessible dialog">
+      <SlideModal
+        isOpen
+        close={vi.fn()}
+        title="Accessible dialog"
+        footer={<button type="button">Persistent action</button>}
+      >
         <button type="button">Dialog action</button>
       </SlideModal>,
     );
@@ -126,6 +173,7 @@ describe("SlideModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockScreenReaderEnabled = false;
+    backButtonMock.handler = undefined;
   });
 
   afterEach(() => {
@@ -147,6 +195,40 @@ describe("SlideModal", () => {
     const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("slides from its mounted closed state when opened", () => {
+    const { rerender } = render(<SlideModal {...mockProps} />);
+    const dialog = screen.getByRole("dialog", { hidden: true });
+
+    expect(dialog).toHaveStyle({
+      transform: "translate3d(0, 100%, 0)",
+      transition: "transform 0.2s ease-in-out",
+    });
+
+    rerender(<SlideModal {...mockProps} isOpen />);
+
+    expect(screen.getByRole("dialog")).toBe(dialog);
+    expect(dialog).toHaveStyle({
+      transform: "translate3d(0, 0, 0)",
+      transition: "transform 0.2s ease-in-out",
+    });
+  });
+
+  it("caps content-sized and requested-height modals at 80 percent", () => {
+    const { rerender } = render(<SlideModal {...mockProps} isOpen={true} />);
+
+    expect(screen.getByRole("dialog").style.maxHeight).toBe(
+      "min(80vh, calc(100vh - 44px - 75px))",
+    );
+    expect(screen.getByRole("dialog").style.height).toBe("");
+
+    rerender(<SlideModal {...mockProps} isOpen={true} fixedHeight="90vh" />);
+
+    expect(screen.getByRole("dialog").style.height).toBe("90vh");
+    expect(screen.getByRole("dialog").style.maxHeight).toBe(
+      "min(80vh, calc(100vh - 44px - 75px))",
+    );
   });
 
   it("closes modal when overlay is clicked", () => {
@@ -171,6 +253,59 @@ describe("SlideModal", () => {
     fireEvent.click(closeButtons[0]!);
 
     expect(closeMock).toHaveBeenCalled();
+  });
+
+  it("keeps a blocking modal active when a later modal is requested", () => {
+    render(<BlockingModalHarness />);
+
+    fireEvent.click(screen.getByTestId("trigger-later-modal"));
+
+    expect(
+      screen.getByRole("dialog", { name: "Mandatory blocker" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Later modal" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Later action" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks every passive dismissal path when non-dismissible", async () => {
+    const user = userEvent.setup();
+    const closeMock = vi.fn();
+    render(
+      <SlideModal
+        {...mockProps}
+        isOpen={true}
+        close={closeMock}
+        dismissible={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "nav.close" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("modal-overlay"));
+    await user.keyboard("{Escape}");
+
+    const content = screen.getByText("Test Content");
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 100, clientY: 20 }],
+    });
+    fireEvent.touchMove(content, {
+      touches: [{ clientX: 100, clientY: 160 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 100, clientY: 160 }],
+    });
+
+    expect(backButtonMock.handler?.()).toBe(true);
+    expect(closeMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toHaveStyle({
+      transform: "translate3d(0, 0, 0)",
+    });
   });
 
   it("should close when swiping down from the modal title", () => {
@@ -515,17 +650,31 @@ describe("SlideModal", () => {
     expect(dialog).toHaveClass("custom-class");
   });
 
-  it("renders footer when provided", () => {
+  it("keeps footer actions interactive outside the scrollable body", async () => {
+    const user = userEvent.setup();
+    const action = vi.fn();
+    const scrollRef = createRef<HTMLDivElement>();
     render(
       <SlideModal
         {...mockProps}
         isOpen={true}
-        footer={<button>Footer Button</button>}
+        scrollRef={scrollRef}
+        footerSkipLabel="Skip to actions"
+        footer={
+          <button type="button" onClick={action}>
+            Footer Button
+          </button>
+        }
       />,
     );
 
-    expect(
-      screen.getByRole("button", { name: "Footer Button" }),
-    ).toBeInTheDocument();
+    const footerButton = screen.getByRole("button", { name: "Footer Button" });
+    expect(scrollRef.current).not.toContainElement(footerButton);
+
+    await user.click(screen.getByRole("link", { name: "Skip to actions" }));
+    expect(footerButton.parentElement).toHaveFocus();
+
+    await user.click(footerButton);
+    expect(action).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/unit/components/SlideModalProvider.test.tsx
+++ b/src/__tests__/unit/components/SlideModalProvider.test.tsx
@@ -152,6 +152,43 @@ describe("SlideModalProvider", () => {
     expect(mockClose3).toHaveBeenCalled();
   });
 
+  it("should reject later modals while a blocking modal is registered", () => {
+    const blockingClose = vi.fn();
+    const laterClose = vi.fn();
+    let accepted: boolean | undefined;
+
+    function TestComponent() {
+      const manager = useContext(SlideModalContext);
+
+      return (
+        <button
+          onClick={() => {
+            manager?.registerModal("blocking", blockingClose, {
+              blocking: true,
+            });
+            accepted = manager?.closeAllExcept("later");
+            if (accepted) manager?.registerModal("later", laterClose);
+          }}
+          data-testid="try-later-modal"
+        >
+          Try later modal
+        </button>
+      );
+    }
+
+    render(
+      <SlideModalProvider>
+        <TestComponent />
+      </SlideModalProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("try-later-modal"));
+
+    expect(accepted).toBe(false);
+    expect(blockingClose).not.toHaveBeenCalled();
+    expect(laterClose).not.toHaveBeenCalled();
+  });
+
   it("should handle closeAllExcept when no modals are registered", () => {
     function TestComponent() {
       const manager = useContext(SlideModalContext);

--- a/src/__tests__/unit/components/SlideModalProvider.test.tsx
+++ b/src/__tests__/unit/components/SlideModalProvider.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "../../../test-utils";
+import userEvent from "@testing-library/user-event";
 import { useContext } from "react";
 import { SlideModalProvider } from "@/components/SlideModalProvider";
 import { SlideModalContext } from "@/hooks/useSlideModalManager";
@@ -152,7 +153,8 @@ describe("SlideModalProvider", () => {
     expect(mockClose3).toHaveBeenCalled();
   });
 
-  it("should reject later modals while a blocking modal is registered", () => {
+  it("should reject later modals while a blocking modal is registered", async () => {
+    const user = userEvent.setup();
     const blockingClose = vi.fn();
     const laterClose = vi.fn();
     let accepted: boolean | undefined;
@@ -169,7 +171,6 @@ describe("SlideModalProvider", () => {
             accepted = manager?.closeAllExcept("later");
             if (accepted) manager?.registerModal("later", laterClose);
           }}
-          data-testid="try-later-modal"
         >
           Try later modal
         </button>
@@ -182,22 +183,21 @@ describe("SlideModalProvider", () => {
       </SlideModalProvider>,
     );
 
-    fireEvent.click(screen.getByTestId("try-later-modal"));
+    await user.click(screen.getByRole("button", { name: "Try later modal" }));
 
     expect(accepted).toBe(false);
     expect(blockingClose).not.toHaveBeenCalled();
     expect(laterClose).not.toHaveBeenCalled();
   });
 
-  it("should handle closeAllExcept when no modals are registered", () => {
+  it("should handle closeAllExcept when no modals are registered", async () => {
+    const user = userEvent.setup();
+
     function TestComponent() {
       const manager = useContext(SlideModalContext);
 
       return (
-        <button
-          onClick={() => manager?.closeAllExcept("nonexistent")}
-          data-testid="close-nonexistent"
-        >
+        <button onClick={() => manager?.closeAllExcept("nonexistent")}>
           Close All Except Nonexistent
         </button>
       );
@@ -209,9 +209,12 @@ describe("SlideModalProvider", () => {
       </SlideModalProvider>,
     );
 
-    // Should not throw error when no modals are registered
-    expect(() => {
-      fireEvent.click(screen.getByTestId("close-nonexistent"));
-    }).not.toThrow();
+    await user.click(
+      screen.getByRole("button", { name: "Close All Except Nonexistent" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Close All Except Nonexistent" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/unit/components/SystemSelector.test.tsx
+++ b/src/__tests__/unit/components/SystemSelector.test.tsx
@@ -646,6 +646,18 @@ describe("SystemSelector", () => {
       expect(onSelect).toHaveBeenCalledWith([]);
     });
 
+    it("should keep clear all mounted and disabled without a selection", () => {
+      render(
+        <SystemSelector {...defaultProps} mode="multi" selectedSystems={[]} />,
+      );
+
+      const clearButton = screen.getByRole("button", {
+        name: "systemSelector.clearAll",
+      });
+      expect(clearButton).toBeDisabled();
+      expect(clearButton).toHaveTextContent("systemSelector.clearAll");
+    });
+
     it("should close modal when apply clicked", async () => {
       // Arrange
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/src/__tests__/unit/components/TagSelector.test.tsx
+++ b/src/__tests__/unit/components/TagSelector.test.tsx
@@ -600,6 +600,20 @@ describe("TagSelector", () => {
       expect(onSelect).toHaveBeenCalledWith([]);
     });
 
+    it("should keep clear all mounted and disabled without a selection", async () => {
+      vi.mocked(CoreAPI.mediaTags).mockResolvedValue({
+        tags: createMockTags(),
+      });
+
+      render(<TagSelector {...defaultProps} selectedTags={[]} />);
+
+      const clearButton = await screen.findByRole("button", {
+        name: /tagSelector\.clearAll/i,
+      });
+      expect(clearButton).toBeDisabled();
+      expect(clearButton).toHaveTextContent("tagSelector.clearAll");
+    });
+
     it("should close modal when apply clicked", async () => {
       // Arrange
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/src/__tests__/unit/components/WarpSubscription.test.tsx
+++ b/src/__tests__/unit/components/WarpSubscription.test.tsx
@@ -91,12 +91,16 @@ describe("WarpSubscription", () => {
   it("should open checkout with annual selected and localized full price", async () => {
     const user = userEvent.setup();
     render(<WarpSubscription appUserID="user-123" />);
+    const dialog = screen.getByRole("dialog", { hidden: true });
+
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
 
     await user.click(screen.getByRole("button", { name: "online.warp.get" }));
 
     expect(
       screen.getByRole("dialog", { name: "online.warp.purchaseTitle" }),
-    ).toBeInTheDocument();
+    ).toBe(dialog);
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
     expect(
       screen.getByRole("radio", { name: "online.warp.annual" }),
     ).toHaveAttribute("aria-checked", "true");
@@ -235,7 +239,7 @@ describe("WarpSubscription", () => {
 
     expect(screen.getByText("$3.99")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "nav.close" }));
+    await user.click(screen.getAllByRole("button", { name: "nav.close" })[0]!);
 
     expect(
       screen.queryByRole("dialog", { name: "online.warp.purchaseTitle" }),

--- a/src/__tests__/unit/components/WarpSubscription.test.tsx
+++ b/src/__tests__/unit/components/WarpSubscription.test.tsx
@@ -137,7 +137,25 @@ describe("WarpSubscription", () => {
     ).toBeDisabled();
 
     await user.keyboard("{Escape}");
-    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "online.warp.purchaseTitle" }),
+    ).toBe(dialog);
+  });
+
+  it("should prevent opening checkout during another subscription action", async () => {
+    const user = userEvent.setup();
+    mockUseWarpSubscription.mockReturnValue(hookState({ action: "restore" }));
+
+    render(<WarpSubscription appUserID="user-123" />);
+
+    const checkoutButton = screen.getByRole("button", {
+      name: "online.warp.get",
+    });
+    expect(checkoutButton).toBeDisabled();
+    await user.click(checkoutButton);
+    expect(
+      screen.queryByRole("dialog", { name: "online.warp.purchaseTitle" }),
+    ).not.toBeInTheDocument();
   });
 
   it("should allow selecting monthly plan", async () => {

--- a/src/__tests__/unit/components/WarpSubscription.test.tsx
+++ b/src/__tests__/unit/components/WarpSubscription.test.tsx
@@ -151,11 +151,16 @@ describe("WarpSubscription", () => {
     const checkoutButton = screen.getByRole("button", {
       name: "online.warp.get",
     });
+    const dialog = screen.getByRole("dialog", { hidden: true });
     expect(checkoutButton).toBeDisabled();
+    expect(dialog).toHaveAttribute("aria-hidden", "true");
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+
     await user.click(checkoutButton);
-    expect(
-      screen.queryByRole("dialog", { name: "online.warp.purchaseTitle" }),
-    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole("dialog", { hidden: true })).toBe(dialog);
+    expect(dialog).toHaveAttribute("aria-hidden", "true");
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
   });
 
   it("should allow selecting monthly plan", async () => {

--- a/src/__tests__/unit/components/WarpSubscription.test.tsx
+++ b/src/__tests__/unit/components/WarpSubscription.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import toast from "react-hot-toast";
 import type { PurchasesPackage } from "@revenuecat/purchases-capacitor";
-import { render, screen, waitFor } from "@/test-utils";
+import { render, screen, waitFor, within } from "@/test-utils";
 import { usePurchasePreviewStore } from "@/lib/purchasePreviewStore";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 
@@ -114,6 +114,30 @@ describe("WarpSubscription", () => {
     expect(
       screen.getByText("online.warp.benefitDevelopment"),
     ).toBeInTheDocument();
+  });
+
+  it("should block dismissal while a purchase is pending", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<WarpSubscription appUserID="user-123" />);
+    await user.click(screen.getByRole("button", { name: "online.warp.get" }));
+    const dialog = screen.getByRole("dialog", {
+      name: "online.warp.purchaseTitle",
+    });
+
+    mockUseWarpSubscription.mockReturnValue(hookState({ action: "purchase" }));
+    rerender(<WarpSubscription appUserID="user-123" />);
+
+    expect(
+      within(dialog).queryByRole("button", { name: "nav.close" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("button", {
+        name: "online.warp.purchasing",
+      }),
+    ).toBeDisabled();
+
+    await user.keyboard("{Escape}");
+    expect(dialog).toBeInTheDocument();
   });
 
   it("should allow selecting monthly plan", async () => {
@@ -239,7 +263,12 @@ describe("WarpSubscription", () => {
 
     expect(screen.getByText("$3.99")).toBeInTheDocument();
 
-    await user.click(screen.getAllByRole("button", { name: "nav.close" })[0]!);
+    const dialog = screen.getByRole("dialog", {
+      name: "online.warp.purchaseTitle",
+    });
+    await user.click(
+      within(dialog).getAllByRole("button", { name: "nav.close" })[0]!,
+    );
 
     expect(
       screen.queryByRole("dialog", { name: "online.warp.purchaseTitle" }),

--- a/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
+++ b/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { act, render, screen, waitFor } from "@/test-utils";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WhatsNewDialog } from "@/components/WhatsNewDialog";
 import { WhatsNewInitializer } from "@/components/WhatsNewInitializer";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import {
@@ -23,6 +25,23 @@ const announcement = buildWhatsNewAnnouncement({
   releaseKeys: [identity.releaseKey],
 });
 
+function WhatsNewHarness() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open announcement
+      </button>
+      <WhatsNewDialog
+        isOpen={open}
+        announcement={announcement}
+        onDismiss={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
 function setPreferencesState(
   values: Partial<ReturnType<typeof usePreferencesStore.getState>>,
 ) {
@@ -43,6 +62,21 @@ describe("WhatsNewInitializer", () => {
     whatsNewMock.resolveRuntimeReleaseIdentity.mockResolvedValue(identity);
     whatsNewMock.getWhatsNewAnnouncement.mockReturnValue(announcement);
     setPreferencesState({});
+  });
+
+  it("should slide the mounted announcement open", async () => {
+    const user = userEvent.setup();
+    render(<WhatsNewHarness />);
+    const dialog = screen.getByRole("dialog", { hidden: true });
+
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+
+    await user.click(screen.getByRole("button", { name: "Open announcement" }));
+
+    expect(screen.getByRole("dialog", { name: announcement.title })).toBe(
+      dialog,
+    );
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
   });
 
   it("should seed fresh installs without showing the dialog", async () => {

--- a/src/__tests__/unit/components/library/FavoriteButton.test.tsx
+++ b/src/__tests__/unit/components/library/FavoriteButton.test.tsx
@@ -141,7 +141,24 @@ describe("FavoriteButton", () => {
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("should omit favorite controls on unsupported Core", () => {
+  it("should keep a stable visible label with a state-specific accessible name", () => {
+    render(
+      <FavoriteButton
+        entry={mediaEntry()}
+        fallbackSystemId="SNES"
+        deviceKey="device-a"
+        displayLabel="library.favorite"
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "library.addFavorite",
+    });
+    expect(button).toHaveTextContent("library.favorite");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("should keep favorite controls disabled on unsupported Core", () => {
     useStatusStore.setState({ coreVersion: "2.14.9" });
 
     render(
@@ -153,7 +170,7 @@ describe("FavoriteButton", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "library.addFavorite" }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "library.addFavorite" }),
+    ).toBeDisabled();
   });
 });

--- a/src/__tests__/unit/components/library/FavoriteButton.test.tsx
+++ b/src/__tests__/unit/components/library/FavoriteButton.test.tsx
@@ -141,7 +141,12 @@ describe("FavoriteButton", () => {
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("should keep a stable visible label with a state-specific accessible name", () => {
+  it("should keep a stable visible label with a state-specific accessible name", async () => {
+    vi.spyOn(CoreAPI, "mediaTagsUpdate").mockResolvedValue({
+      tags: [{ type: "user", tag: "favorite" }],
+    });
+    const user = userEvent.setup();
+
     render(
       <FavoriteButton
         entry={mediaEntry()}
@@ -156,6 +161,14 @@ describe("FavoriteButton", () => {
     });
     expect(button).toHaveTextContent("library.favorite");
     expect(button).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(button);
+
+    const favoritedButton = await screen.findByRole("button", {
+      name: "library.removeFavorite",
+    });
+    expect(favoritedButton).toHaveTextContent("library.favorite");
+    expect(favoritedButton).toHaveAttribute("aria-pressed", "true");
   });
 
   it("should keep favorite controls disabled on unsupported Core", () => {

--- a/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryArtwork.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, waitFor } from "@/test-utils";
 import { LibraryArtwork } from "@/components/library/LibraryArtwork";
 import { requestLibraryImage } from "@/lib/libraryImages";
 import { CoreAPI } from "@/lib/coreApi";
@@ -12,6 +12,63 @@ describe("LibraryArtwork", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     CoreAPI.reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should use a delayed spinner for detail artwork loading", () => {
+    vi.useFakeTimers();
+    vi.mocked(requestLibraryImage).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(
+      <LibraryArtwork
+        entry={{
+          mediaId: 42,
+          name: "Super Game",
+          path: "/roms/SNES/Super Game.sfc",
+          type: "media",
+          systemId: "SNES",
+        }}
+        systemId="SNES"
+        deviceKey="device-a"
+        maxSize={512}
+        priority="detail"
+      />,
+    );
+
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("should retain a skeleton for thumbnail artwork loading", () => {
+    vi.useFakeTimers();
+    vi.mocked(requestLibraryImage).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(
+      <LibraryArtwork
+        entry={{
+          mediaId: 42,
+          name: "Super Game",
+          path: "/roms/SNES/Super Game.sfc",
+          type: "media",
+          systemId: "SNES",
+        }}
+        systemId="SNES"
+        deviceKey="device-a"
+        maxSize={320}
+        priority="thumbnail"
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(container.querySelector("span > div")).toBeInTheDocument();
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
 
   it("should report unavailable artwork when the image request fails", async () => {

--- a/src/__tests__/unit/components/library/LibraryMediaDetailsModal.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryMediaDetailsModal.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen, waitFor } from "@/test-utils";
+import { render, screen, waitFor, within } from "@/test-utils";
 import { CoreAPI } from "@/lib/coreApi";
 import type { MediaBrowseEntry, MediaMetaResponse } from "@/lib/models";
 import { usePreferencesStore } from "@/lib/preferencesStore";
@@ -112,12 +112,15 @@ describe("LibraryMediaDetailsModal", () => {
     useStatusStore.getState().setWriteQueue("");
   });
 
-  it("should prioritize actions and render curated game metadata", async () => {
+  it("should render persistent actions and curated game metadata", async () => {
     const user = userEvent.setup();
     renderModal();
 
     expect(
       await screen.findByRole("dialog", { name: "Super Game" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "accessibility.skipToActions" }),
     ).toBeInTheDocument();
     expect(
       await screen.findByText("A platform adventure."),
@@ -149,11 +152,29 @@ describe("LibraryMediaDetailsModal", () => {
       screen.queryByLabelText("scraper.gamelist.xml scraped"),
     ).not.toBeInTheDocument();
 
+    const actions = screen.getByRole("group", {
+      name: "library.mediaActions",
+    });
+    const favorite = screen.getByRole("button", {
+      name: "library.addFavorite",
+    });
+    const write = screen.getByRole("button", { name: "library.write" });
     const launch = screen.getByRole("button", { name: "library.launch" });
     const cover = screen.getByRole("img", { name: "library.imageAlt" });
+    expect(favorite).toHaveTextContent("library.favorite");
+    expect(write).toHaveTextContent("library.writeAction");
+    expect(within(actions).getByRole("button", { name: "library.write" })).toBe(
+      write,
+    );
     expect(
-      launch.compareDocumentPosition(cover) & Node.DOCUMENT_POSITION_FOLLOWING,
+      within(actions).queryByRole("button", { name: "library.launch" }),
+    ).not.toBeInTheDocument();
+    expect(write).toBeDisabled();
+    expect(
+      write.compareDocumentPosition(launch) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    expect(launch).toBeVisible();
+    expect(launch).toBeEnabled();
     expect(cover).toHaveAttribute("src", "data:image/webp;base64,AAAA");
 
     const path = screen.getByText("/roms/SNES/Super Game.sfc");
@@ -163,6 +184,33 @@ describe("LibraryMediaDetailsModal", () => {
     );
     expect(path).toBeVisible();
     expect(screen.getByText("RetroArch")).toBeVisible();
+  });
+
+  it("should retain full content while the sheet closes", async () => {
+    const view = renderModal();
+    const dialog = await screen.findByRole("dialog", { name: "Super Game" });
+    await screen.findByText("A platform adventure.");
+
+    view.rerender(
+      <LibraryMediaDetailsModal
+        {...view.props}
+        isOpen={false}
+        entry={null}
+        systemId=""
+      />,
+    );
+
+    const closingDialog = screen.getByRole("dialog", { hidden: true });
+    expect(closingDialog).toBe(dialog);
+    expect(closingDialog).toHaveStyle({
+      transform: "translate3d(0, 100%, 0)",
+      transition: "transform 0.2s ease-in-out",
+    });
+    expect(closingDialog).toHaveTextContent("Super Game");
+    expect(closingDialog).toHaveTextContent("A platform adventure.");
+    expect(
+      screen.getByRole("button", { name: "library.launch", hidden: true }),
+    ).toBeInTheDocument();
   });
 
   it("should represent favorite state as an action, not a metadata tag", async () => {
@@ -183,7 +231,7 @@ describe("LibraryMediaDetailsModal", () => {
       name: "library.removeFavorite",
     });
     expect(favoriteButton).toHaveAccessibleName("library.removeFavorite");
-    expect(favoriteButton).not.toHaveTextContent("library.removeFavorite");
+    expect(favoriteButton).toHaveTextContent("library.favorite");
     expect(screen.queryByLabelText("user favorite")).not.toBeInTheDocument();
   });
 
@@ -281,7 +329,7 @@ describe("LibraryMediaDetailsModal", () => {
     });
   });
 
-  it("should omit NFC writing when no writer is available", async () => {
+  it("should keep writing disabled when no writer is available", async () => {
     renderModal();
 
     await screen.findByRole("dialog", { name: "Super Game" });
@@ -289,8 +337,8 @@ describe("LibraryMediaDetailsModal", () => {
       expect(CoreAPI.hasWriteCapableReader).toHaveBeenCalled(),
     );
     expect(
-      screen.queryByRole("button", { name: "library.write" }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "library.write" }),
+    ).toBeDisabled();
   });
 
   it("should retain browse details and launch action when metadata fails", async () => {

--- a/src/__tests__/unit/components/library/LibraryMediaOptionsModal.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryMediaOptionsModal.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { LibraryMediaOptionsModal } from "@/components/library/LibraryMediaOptionsModal";
+
+describe("LibraryMediaOptionsModal", () => {
+  it("keeps Go to letter mounted and disables it when unavailable", () => {
+    render(
+      <LibraryMediaOptionsModal
+        isOpen
+        close={vi.fn()}
+        value="name-asc"
+        onChange={vi.fn()}
+        canGoToLetter={false}
+        onGoToLetter={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "library.goToTitle" }),
+    ).toBeDisabled();
+  });
+
+  it("runs Go to letter when available", async () => {
+    const user = userEvent.setup();
+    const onGoToLetter = vi.fn();
+    render(
+      <LibraryMediaOptionsModal
+        isOpen
+        close={vi.fn()}
+        value="name-asc"
+        onChange={vi.fn()}
+        canGoToLetter
+        onGoToLetter={onGoToLetter}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "library.goToTitle" }));
+    expect(onGoToLetter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/unit/components/library/LibraryMediaOptionsModal.test.tsx
+++ b/src/__tests__/unit/components/library/LibraryMediaOptionsModal.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@/test-utils";
 import { LibraryMediaOptionsModal } from "@/components/library/LibraryMediaOptionsModal";
 
 describe("LibraryMediaOptionsModal", () => {
-  it("keeps Go to letter mounted and disables it when unavailable", () => {
+  it("should keep Go to letter mounted and disable it when unavailable", () => {
     render(
       <LibraryMediaOptionsModal
         isOpen
@@ -21,7 +21,7 @@ describe("LibraryMediaOptionsModal", () => {
     ).toBeDisabled();
   });
 
-  it("runs Go to letter when available", async () => {
+  it("should run Go to letter when available", async () => {
     const user = userEvent.setup();
     const onGoToLetter = vi.fn();
     render(

--- a/src/__tests__/unit/components/library/LibrarySystemFiltersModal.test.tsx
+++ b/src/__tests__/unit/components/library/LibrarySystemFiltersModal.test.tsx
@@ -28,7 +28,7 @@ function renderModal(
 }
 
 describe("LibrarySystemFiltersModal", () => {
-  it("shows labelled Reset before the primary action", () => {
+  it("should show labelled Reset before the primary action", () => {
     renderModal();
 
     const reset = screen.getByRole("button", {
@@ -45,7 +45,7 @@ describe("LibrarySystemFiltersModal", () => {
     ).toBeTruthy();
   });
 
-  it("enables and runs Reset when draft filters differ", async () => {
+  it("should enable and run Reset when draft filters differ", async () => {
     const user = userEvent.setup();
     const { props } = renderModal({ selectedManufacturer: "Nintendo" });
 

--- a/src/__tests__/unit/components/library/LibrarySystemFiltersModal.test.tsx
+++ b/src/__tests__/unit/components/library/LibrarySystemFiltersModal.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { LibrarySystemFiltersModal } from "@/components/library/LibrarySystemFiltersModal";
+
+function renderModal(
+  overrides: Partial<
+    React.ComponentProps<typeof LibrarySystemFiltersModal>
+  > = {},
+) {
+  const props: React.ComponentProps<typeof LibrarySystemFiltersModal> = {
+    isOpen: true,
+    close: vi.fn(),
+    manufacturers: ["Nintendo"],
+    selectedManufacturer: "",
+    onSelectedManufacturerChange: vi.fn(),
+    releasePeriod: "any",
+    onReleasePeriodChange: vi.fn(),
+    sort: "name-asc",
+    onSortChange: vi.fn(),
+    resultCount: 12,
+    onReset: vi.fn(),
+    onApply: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<LibrarySystemFiltersModal {...props} />), props };
+}
+
+describe("LibrarySystemFiltersModal", () => {
+  it("shows labelled Reset before the primary action", () => {
+    renderModal();
+
+    const reset = screen.getByRole("button", {
+      name: "library.resetOptions",
+    });
+    const apply = screen.getByRole("button", {
+      name: "library.showSystems",
+    });
+
+    expect(reset).toBeDisabled();
+    expect(reset).toHaveTextContent("library.resetOptions");
+    expect(
+      reset.compareDocumentPosition(apply) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("enables and runs Reset when draft filters differ", async () => {
+    const user = userEvent.setup();
+    const { props } = renderModal({ selectedManufacturer: "Nintendo" });
+
+    await user.click(
+      screen.getByRole("button", { name: "library.resetOptions" }),
+    );
+
+    expect(props.onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/unit/components/wui/ModalActionBar.test.tsx
+++ b/src/__tests__/unit/components/wui/ModalActionBar.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test-utils";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
+
+describe("ModalActionBar", () => {
+  it("should preserve renderable falsy secondary content", () => {
+    render(
+      <ModalActionBar
+        secondaryAction={0}
+        primaryAction={<button type="button">Continue</button>}
+      />,
+    );
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Continue" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/components/wui/ModalActionRail.test.tsx
+++ b/src/__tests__/unit/components/wui/ModalActionRail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "../../../../test-utils";
+import { render, screen, within } from "@/test-utils";
 import { describe, expect, it } from "vitest";
 import { ModalActionRail } from "@/components/wui/ModalActionRail";
 import { Button } from "@/components/wui/Button";
@@ -19,7 +19,7 @@ function renderRail() {
 }
 
 describe("ModalActionRail", () => {
-  it("groups direct actions separately from the primary action", () => {
+  it("should group direct actions separately from the primary action", () => {
     renderRail();
 
     const actions = screen.getByRole("group", { name: "Media actions" });
@@ -35,7 +35,7 @@ describe("ModalActionRail", () => {
     expect(screen.getByRole("button", { name: "Launch" })).toBeVisible();
   });
 
-  it("keeps larger action sets directly available", () => {
+  it("should keep larger action sets directly available", () => {
     render(
       <ModalActionRail
         aria-label="Media actions"
@@ -50,7 +50,7 @@ describe("ModalActionRail", () => {
     expect(within(actions).getAllByRole("button")).toHaveLength(7);
   });
 
-  it("preserves secondary-to-primary focus order", () => {
+  it("should preserve secondary-to-primary focus order", () => {
     renderRail();
 
     const favorite = screen.getByRole("button", { name: "Favorite" });

--- a/src/__tests__/unit/components/wui/ModalActionRail.test.tsx
+++ b/src/__tests__/unit/components/wui/ModalActionRail.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, within } from "../../../../test-utils";
+import { describe, expect, it } from "vitest";
+import { ModalActionRail } from "@/components/wui/ModalActionRail";
+import { Button } from "@/components/wui/Button";
+
+function renderRail() {
+  return render(
+    <ModalActionRail
+      aria-label="Media actions"
+      actions={
+        <>
+          <Button label="Favorite" icon={<span>heart</span>} />
+          <Button label="Write" icon={<span>NFC</span>} />
+        </>
+      }
+      primaryAction={<Button label="Launch" />}
+    />,
+  );
+}
+
+describe("ModalActionRail", () => {
+  it("groups direct actions separately from the primary action", () => {
+    renderRail();
+
+    const actions = screen.getByRole("group", { name: "Media actions" });
+    expect(
+      within(actions).getByRole("button", { name: "Favorite" }),
+    ).toBeVisible();
+    expect(
+      within(actions).getByRole("button", { name: "Write" }),
+    ).toBeVisible();
+    expect(
+      within(actions).queryByRole("button", { name: "Launch" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Launch" })).toBeVisible();
+  });
+
+  it("keeps larger action sets directly available", () => {
+    render(
+      <ModalActionRail
+        aria-label="Media actions"
+        actions={Array.from({ length: 7 }, (_, index) => (
+          <Button key={index} label={`Action ${index + 1}`} />
+        ))}
+        primaryAction={<Button label="Launch" />}
+      />,
+    );
+
+    const actions = screen.getByRole("group", { name: "Media actions" });
+    expect(within(actions).getAllByRole("button")).toHaveLength(7);
+  });
+
+  it("preserves secondary-to-primary focus order", () => {
+    renderRail();
+
+    const favorite = screen.getByRole("button", { name: "Favorite" });
+    const write = screen.getByRole("button", { name: "Write" });
+    const launch = screen.getByRole("button", { name: "Launch" });
+
+    expect(
+      favorite.compareDocumentPosition(write) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      write.compareDocumentPosition(launch) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/src/__tests__/unit/components/wui/SettingHelp.test.tsx
+++ b/src/__tests__/unit/components/wui/SettingHelp.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen, waitFor } from "@/test-utils";
+import { render, screen, waitFor, within } from "@/test-utils";
 import { SettingHelp } from "@/components/wui/SettingHelp";
 
 describe("SettingHelp", () => {
-  it("opens formatted help in a slide modal and restores trigger focus", async () => {
+  it("should open formatted help in a slide modal and restore trigger focus", async () => {
     const user = userEvent.setup();
     render(
       <SettingHelp
@@ -27,7 +27,9 @@ describe("SettingHelp", () => {
     expect(screen.getByText("reader mode").tagName).toBe("STRONG");
     expect(screen.getByText("Second paragraph.")).toBeInTheDocument();
 
-    await user.click(screen.getAllByRole("button", { name: "nav.close" })[0]!);
+    await user.click(
+      within(dialog).getAllByRole("button", { name: "nav.close" })[0]!,
+    );
 
     expect(
       screen.queryByRole("dialog", { name: "Reader mode" }),

--- a/src/__tests__/unit/components/wui/SettingHelp.test.tsx
+++ b/src/__tests__/unit/components/wui/SettingHelp.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/test-utils";
+import { SettingHelp } from "@/components/wui/SettingHelp";
+
+describe("SettingHelp", () => {
+  it("opens formatted help in a slide modal and restores trigger focus", async () => {
+    const user = userEvent.setup();
+    render(
+      <SettingHelp
+        title="Reader mode"
+        description={"Use **reader mode** here.\n\nSecond paragraph."}
+        ariaLabel="Explain reader mode"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Explain reader mode",
+    });
+    const dialog = screen.getByRole("dialog", { hidden: true });
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
+
+    await user.click(trigger);
+
+    expect(screen.getByRole("dialog", { name: "Reader mode" })).toBe(dialog);
+    expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
+    expect(screen.getByText("reader mode").tagName).toBe("STRONG");
+    expect(screen.getByText("Second paragraph.")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "nav.close" })[0]!);
+
+    expect(
+      screen.queryByRole("dialog", { name: "Reader mode" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});

--- a/src/__tests__/unit/routes/settings.advanced.test.tsx
+++ b/src/__tests__/unit/routes/settings.advanced.test.tsx
@@ -168,7 +168,9 @@ describe("Settings Advanced Route", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("settings.advanced.errorReporting"),
+          screen.getByRole("checkbox", {
+            name: "settings.advanced.errorReporting",
+          }),
         ).toBeInTheDocument();
       });
     });
@@ -178,7 +180,9 @@ describe("Settings Advanced Route", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("settings.advanced.debugLogging"),
+          screen.getByRole("checkbox", {
+            name: "settings.advanced.debugLogging",
+          }),
         ).toBeInTheDocument();
       });
     });
@@ -188,7 +192,9 @@ describe("Settings Advanced Route", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("settings.advanced.showFilenames"),
+          screen.getByRole("checkbox", {
+            name: "settings.advanced.showFilenames",
+          }),
         ).toBeInTheDocument();
       });
     });

--- a/src/__tests__/unit/routes/settings.devices.test.tsx
+++ b/src/__tests__/unit/routes/settings.devices.test.tsx
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, waitFor } from "@/test-utils";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Preferences } from "@capacitor/preferences";
 import {
   credentialKeyForRecord,
   credentialStore,
   type StoredCredentials,
 } from "@/lib/crypto/credentials";
+import { CoreAPI } from "@/lib/coreApi";
 import { deviceRegistry } from "@/lib/devices/deviceRegistry";
+import { ConnectionState, useStatusStore } from "@/lib/store";
 import {
   mockDeviceRecord,
   seedDeviceRegistry,
@@ -89,17 +92,42 @@ async function seedRecords(
 }
 
 describe("Settings Devices Route", () => {
+  let queryClient: QueryClient;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    CoreAPI.reset();
+    useStatusStore.setState({
+      connected: false,
+      connectionState: ConnectionState.IDLE,
+      connectionError: "",
+      coreVersion: null,
+      corePlatform: null,
+      coreVersionPending: false,
+      currentClient: null,
+      encryptionState: "unknown",
+      pairingRequired: false,
+    });
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    queryClient.clear();
   });
 
   const renderRoute = () => {
     const Devices = getDevices();
-    return render(<Devices />);
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <Devices />
+      </QueryClientProvider>,
+    );
   };
 
   it("should render the empty state when no devices are saved", async () => {
@@ -252,18 +280,129 @@ describe("Settings Devices Route", () => {
     ).toHaveAttribute("href", `/settings/devices/${record!.recordId}`);
   });
 
-  it("should not expose manual device-combining controls", async () => {
-    await seedRecords([
-      { address: "steamdeck.local", name: "Steamdeck" },
-      { address: "10.0.0.206", name: "Steamdeck alias" },
-    ]);
-
+  it("should combine two manually selected records after confirmation", async () => {
+    const user = userEvent.setup();
+    const [hostname, activeIp] = await seedRecords(
+      [
+        { address: "steamdeck.local", name: "Steamdeck" },
+        { address: "10.0.0.206", name: "Steamdeck" },
+      ],
+      1,
+    );
+    queryClient.setQueryData(["library", hostname!.recordId], "hostname cache");
+    queryClient.setQueryData(["library", activeIp!.recordId], "ip cache");
     renderRoute();
 
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
+    );
+    const selections = screen.getAllByRole("checkbox", {
+      name: "settings.deviceCombine.select",
+    });
+    await user.click(selections[0]!);
+    await user.click(selections[1]!);
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
+    );
+    expect(screen.getByText("settings.deviceCombine.body")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
+    );
+
+    await waitFor(() => {
+      expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual([
+        activeIp!.recordId,
+      ]);
+    });
+    expect(deviceRegistry.getSnapshot().activeRecordId).toBe(
+      activeIp!.recordId,
+    );
     expect(
-      await screen.findAllByLabelText("settings.deviceDetails"),
-    ).toHaveLength(2);
-    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+      deviceRegistry.getSnapshot().records[activeIp!.recordId]?.endpoints,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ host: "steamdeck.local" }),
+        expect.objectContaining({ host: "10.0.0.206" }),
+      ]),
+    );
+    expect(
+      queryClient.getQueryData(["library", hostname!.recordId]),
+    ).toBeUndefined();
+    expect(
+      queryClient.getQueryData(["library", activeIp!.recordId]),
+    ).toBeUndefined();
+  });
+
+  it("should keep the paired indicator after moving source credentials", async () => {
+    const user = userEvent.setup();
+    const [activeTarget, pairedSource] = await seedRecords(
+      [
+        { address: "steamdeck.local", name: "Steamdeck" },
+        { address: "10.0.0.206", name: "Steamdeck alias" },
+      ],
+      0,
+    );
+    await credentialStore.set(
+      credentialKeyForRecord(pairedSource!.recordId),
+      credentials,
+    );
+    renderRoute();
+    expect(
+      await screen.findByLabelText("connection.encrypted"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
+    );
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      await user.click(checkbox);
+    }
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
+    );
+
+    await waitFor(() => {
+      expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual([
+        activeTarget!.recordId,
+      ]);
+    });
+    expect(screen.getByLabelText("connection.encrypted")).toBeInTheDocument();
+  });
+
+  it("should retain both selected records when combining fails", async () => {
+    const user = userEvent.setup();
+    const records = await seedRecords([
+      { address: "steamdeck.local", name: "Steamdeck" },
+      { address: "10.0.0.206", name: "Steamdeck" },
+    ]);
+    vi.spyOn(deviceRegistry, "mergeRecords").mockRejectedValueOnce(
+      new Error("keychain locked"),
+    );
+    renderRoute();
+
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
+    );
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      await user.click(checkbox);
+    }
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
+    );
+
+    expect(
+      await screen.findByText("settings.deviceCombine.failed"),
+    ).toHaveAttribute("role", "alert");
+    expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual(
+      records.map((record) => record.recordId),
+    );
   });
 
   it("should navigate to Settings without resetting scroll", async () => {

--- a/src/__tests__/unit/routes/settings.devices.test.tsx
+++ b/src/__tests__/unit/routes/settings.devices.test.tsx
@@ -373,6 +373,59 @@ describe("Settings Devices Route", () => {
     expect(screen.getByLabelText("connection.encrypted")).toBeInTheDocument();
   });
 
+  it("should keep shared legacy pairing visible on an unmerged record", async () => {
+    const user = userEvent.setup();
+    const sharedLegacyKey = "shared-device-key";
+    const [activeTarget, , sharedOwner] = await seedRecords(
+      [
+        { address: "steamdeck.local", name: "A target" },
+        {
+          address: "10.0.0.206",
+          name: "B source",
+          legacyCredentialKey: sharedLegacyKey,
+        },
+        {
+          address: "10.0.0.207",
+          name: "C shared owner",
+          legacyCredentialKey: sharedLegacyKey,
+        },
+      ],
+      0,
+    );
+    await credentialStore.set(sharedLegacyKey, credentials);
+    renderRoute();
+
+    expect(
+      await screen.findAllByLabelText("connection.encrypted"),
+    ).toHaveLength(2);
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
+    );
+    const selections = screen.getAllByRole("checkbox", {
+      name: "settings.deviceCombine.select",
+    });
+    await user.click(selections[0]!);
+    await user.click(selections[1]!);
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
+    );
+
+    await waitFor(() => {
+      expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual([
+        activeTarget!.recordId,
+        sharedOwner!.recordId,
+      ]);
+    });
+    expect(await credentialStore.get(sharedLegacyKey)).toEqual(credentials);
+    expect(
+      await credentialStore.get(credentialKeyForRecord(activeTarget!.recordId)),
+    ).toEqual(credentials);
+    expect(screen.getAllByLabelText("connection.encrypted")).toHaveLength(2);
+  });
+
   it("should retain both selected records when combining fails", async () => {
     const user = userEvent.setup();
     const records = await seedRecords([

--- a/src/__tests__/unit/routes/settings.devices.test.tsx
+++ b/src/__tests__/unit/routes/settings.devices.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, waitFor } from "@/test-utils";
 import userEvent from "@testing-library/user-event";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Preferences } from "@capacitor/preferences";
 import {
   credentialKeyForRecord,
@@ -90,30 +89,17 @@ async function seedRecords(
 }
 
 describe("Settings Devices Route", () => {
-  let queryClient: QueryClient;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: { retry: false },
-        mutations: { retry: false },
-      },
-    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    queryClient.clear();
   });
 
   const renderRoute = () => {
     const Devices = getDevices();
-    return render(
-      <QueryClientProvider client={queryClient}>
-        <Devices />
-      </QueryClientProvider>,
-    );
+    return render(<Devices />);
   };
 
   it("should render the empty state when no devices are saved", async () => {
@@ -266,129 +252,18 @@ describe("Settings Devices Route", () => {
     ).toHaveAttribute("href", `/settings/devices/${record!.recordId}`);
   });
 
-  it("should combine two manually selected records after confirmation", async () => {
-    const user = userEvent.setup();
-    const [hostname, activeIp] = await seedRecords(
-      [
-        { address: "steamdeck.local", name: "Steamdeck" },
-        { address: "10.0.0.206", name: "Steamdeck" },
-      ],
-      1,
-    );
-    queryClient.setQueryData(["library", hostname!.recordId], "hostname cache");
-    queryClient.setQueryData(["library", activeIp!.recordId], "ip cache");
-    renderRoute();
-
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
-    );
-    const selections = screen.getAllByRole("checkbox", {
-      name: "settings.deviceCombine.select",
-    });
-    await user.click(selections[0]!);
-    await user.click(selections[1]!);
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
-    );
-    expect(screen.getByText("settings.deviceCombine.body")).toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
-    );
-
-    await waitFor(() => {
-      expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual([
-        activeIp!.recordId,
-      ]);
-    });
-    expect(deviceRegistry.getSnapshot().activeRecordId).toBe(
-      activeIp!.recordId,
-    );
-    expect(
-      deviceRegistry.getSnapshot().records[activeIp!.recordId]?.endpoints,
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ host: "steamdeck.local" }),
-        expect.objectContaining({ host: "10.0.0.206" }),
-      ]),
-    );
-    expect(
-      queryClient.getQueryData(["library", hostname!.recordId]),
-    ).toBeUndefined();
-    expect(
-      queryClient.getQueryData(["library", activeIp!.recordId]),
-    ).toBeUndefined();
-  });
-
-  it("should keep the paired indicator after moving source credentials", async () => {
-    const user = userEvent.setup();
-    const [activeTarget, pairedSource] = await seedRecords(
-      [
-        { address: "steamdeck.local", name: "Steamdeck" },
-        { address: "10.0.0.206", name: "Steamdeck alias" },
-      ],
-      0,
-    );
-    await credentialStore.set(
-      credentialKeyForRecord(pairedSource!.recordId),
-      credentials,
-    );
-    renderRoute();
-    expect(
-      await screen.findByLabelText("connection.encrypted"),
-    ).toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
-    );
-    for (const checkbox of screen.getAllByRole("checkbox")) {
-      await user.click(checkbox);
-    }
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
-    );
-
-    await waitFor(() => {
-      expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual([
-        activeTarget!.recordId,
-      ]);
-    });
-    expect(screen.getByLabelText("connection.encrypted")).toBeInTheDocument();
-  });
-
-  it("should retain both selected records when combining fails", async () => {
-    const user = userEvent.setup();
-    const records = await seedRecords([
+  it("should not expose manual device-combining controls", async () => {
+    await seedRecords([
       { address: "steamdeck.local", name: "Steamdeck" },
-      { address: "10.0.0.206", name: "Steamdeck" },
+      { address: "10.0.0.206", name: "Steamdeck alias" },
     ]);
-    vi.spyOn(deviceRegistry, "mergeRecords").mockRejectedValueOnce(
-      new Error("keychain locked"),
-    );
+
     renderRoute();
 
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.edit" }),
-    );
-    for (const checkbox of screen.getAllByRole("checkbox")) {
-      await user.click(checkbox);
-    }
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.action" }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: "settings.deviceCombine.confirm" }),
-    );
-
     expect(
-      await screen.findByText("settings.deviceCombine.failed"),
-    ).toHaveAttribute("role", "alert");
-    expect(Object.keys(deviceRegistry.getSnapshot().records)).toEqual(
-      records.map((record) => record.recordId),
-    );
+      await screen.findAllByLabelText("settings.deviceDetails"),
+    ).toHaveLength(2);
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
   it("should navigate to Settings without resetting scroll", async () => {

--- a/src/__tests__/unit/routes/settings.index.test.tsx
+++ b/src/__tests__/unit/routes/settings.index.test.tsx
@@ -110,7 +110,7 @@ vi.mock("@/lib/preferencesStore", () => ({
 const mockSetProPurchaseModalOpen = vi.fn();
 vi.mock("@/components/ProPurchase.tsx", () => ({
   useProPurchase: () => ({
-    PurchaseModal: () => null,
+    purchaseModal: null,
     setProPurchaseModalOpen: mockSetProPurchaseModalOpen,
     proAccess: false,
   }),

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -749,14 +749,21 @@ describe("Settings Online Route", () => {
     it("should open delete confirmation dialog", async () => {
       const user = userEvent.setup();
       renderComponent();
+      const dialog = screen
+        .getByText("online.deleteAccountConfirmTitle", { selector: "h2" })
+        .closest('[role="dialog"]')!;
+      expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
 
       await user.click(
         screen.getByRole("button", { name: "online.deleteAccount" }),
       );
 
       expect(
-        screen.getByText("online.deleteAccountConfirmTitle"),
-      ).toBeInTheDocument();
+        screen.getByRole("dialog", {
+          name: "online.deleteAccountConfirmTitle",
+        }),
+      ).toBe(dialog);
+      expect(dialog).toHaveStyle({ transform: "translate3d(0, 0, 0)" });
       expect(
         screen.getByText("online.deleteAccountConfirmMessage"),
       ).toBeInTheDocument();
@@ -820,7 +827,9 @@ describe("Settings Online Route", () => {
       await user.click(screen.getByRole("button", { name: "nav.cancel" }));
 
       expect(
-        screen.queryByText("online.deleteAccountConfirmTitle"),
+        screen.queryByRole("dialog", {
+          name: "online.deleteAccountConfirmTitle",
+        }),
       ).not.toBeInTheDocument();
     });
   });
@@ -1571,7 +1580,9 @@ describe("Settings Online Route", () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText("online.deleteAccountConfirmTitle"),
+          screen.queryByRole("dialog", {
+            name: "online.deleteAccountConfirmTitle",
+          }),
         ).not.toBeInTheDocument();
       });
 

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -749,9 +749,7 @@ describe("Settings Online Route", () => {
     it("should open delete confirmation dialog", async () => {
       const user = userEvent.setup();
       renderComponent();
-      const dialog = screen
-        .getByText("online.deleteAccountConfirmTitle", { selector: "h2" })
-        .closest('[role="dialog"]')!;
+      const dialog = screen.getByRole("dialog", { hidden: true });
       expect(dialog).toHaveStyle({ transform: "translate3d(0, 100%, 0)" });
 
       await user.click(

--- a/src/__tests__/unit/routes/settings.play-controls.test.tsx
+++ b/src/__tests__/unit/routes/settings.play-controls.test.tsx
@@ -188,7 +188,9 @@ describe("Settings Play Controls Route", () => {
       renderComponent();
 
       expect(
-        screen.getByText("settings.core.playtime.enabled"),
+        screen.getByRole("button", {
+          name: "Help for settings.core.playtime.enabled",
+        }),
       ).toBeInTheDocument();
     });
 
@@ -210,10 +212,14 @@ describe("Settings Play Controls Route", () => {
         await screen.findByText("settings.core.launchGuard.title"),
       ).toBeInTheDocument();
       expect(
-        screen.getByText("settings.core.launchGuard.enabled"),
+        screen.getByRole("button", {
+          name: "Help for settings.core.launchGuard.enabled",
+        }),
       ).toBeInTheDocument();
       expect(
-        screen.getByText("settings.core.launchGuard.requireConfirm"),
+        screen.getByRole("button", {
+          name: "Help for settings.core.launchGuard.requireConfirm",
+        }),
       ).toBeInTheDocument();
       expect(
         screen.getByText("settings.core.launchGuard.timeout"),
@@ -232,11 +238,10 @@ describe("Settings Play Controls Route", () => {
         );
       });
 
-      const launchGuardToggle = screen
-        .getAllByLabelText("settings.core.launchGuard.enabled")
-        .find((element) => element.tagName === "INPUT");
-      expect(launchGuardToggle).toBeDefined();
-      fireEvent.click(launchGuardToggle!);
+      const launchGuardToggle = screen.getByRole("checkbox", {
+        name: "settings.core.launchGuard.enabled",
+      });
+      fireEvent.click(launchGuardToggle);
 
       await waitFor(() => {
         expect(mockSettingsUpdate).toHaveBeenCalledWith({

--- a/src/__tests__/unit/routes/settings.readers.test.tsx
+++ b/src/__tests__/unit/routes/settings.readers.test.tsx
@@ -112,7 +112,7 @@ vi.mock("@capacitor/core", () => ({
 // Mock Pro purchase hook
 vi.mock("@/components/ProPurchase", () => ({
   useProPurchase: () => ({
-    PurchaseModal: () => null,
+    purchaseModal: null,
     setProPurchaseModalOpen: vi.fn(),
   }),
 }));
@@ -267,7 +267,11 @@ describe("Settings Readers Route", () => {
     it("should render scan mode section", () => {
       renderComponent();
 
-      expect(screen.getByText("settings.readers.scanMode")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", {
+          name: "Help for settings.readers.scanMode",
+        }),
+      ).toBeInTheDocument();
     });
 
     it("should render tap and hold mode buttons", async () => {
@@ -359,7 +363,9 @@ describe("Settings Readers Route", () => {
       renderComponent();
 
       expect(
-        screen.getByText("settings.readers.audioFeedback"),
+        screen.getByRole("button", {
+          name: "Help for settings.readers.audioFeedback",
+        }),
       ).toBeInTheDocument();
     });
 
@@ -367,7 +373,9 @@ describe("Settings Readers Route", () => {
       renderComponent();
 
       expect(
-        screen.getByText("settings.readers.autoDetectReaders"),
+        screen.getByRole("button", {
+          name: "Help for settings.readers.autoDetectReaders",
+        }),
       ).toBeInTheDocument();
     });
   });
@@ -377,7 +385,9 @@ describe("Settings Readers Route", () => {
       renderComponent();
 
       expect(
-        screen.getByText("settings.readers.continuousScan"),
+        screen.getByRole("button", {
+          name: "Help for settings.readers.continuousScan",
+        }),
       ).toBeInTheDocument();
     });
   });

--- a/src/__tests__/validation/translation-parity.test.ts
+++ b/src/__tests__/validation/translation-parity.test.ts
@@ -40,18 +40,19 @@ function interpolationVariables(value: string): string[] {
 }
 
 const sourceTranslations = loadTranslations(sourceLocale);
-const sourceKeys = [...sourceTranslations.keys()].sort();
 
 describe.each(localeFiles)("%s translation parity", (localeFile) => {
   const translations = loadTranslations(localeFile);
 
-  it("should match the source locale keys and value types", () => {
-    expect([...translations.keys()].sort()).toEqual(sourceKeys);
+  it("should only contain source locale keys with matching value types", () => {
+    const unknownKeys = [...translations.keys()].filter(
+      (key) => !sourceTranslations.has(key),
+    );
+    expect(unknownKeys).toEqual([]);
 
-    const typeMismatches = [...sourceTranslations]
+    const typeMismatches = [...translations]
       .filter(
-        ([key, sourceValue]) =>
-          typeof translations.get(key) !== typeof sourceValue,
+        ([key, value]) => typeof value !== typeof sourceTranslations.get(key),
       )
       .map(([key]) => key);
     expect(typeMismatches).toEqual([]);
@@ -66,9 +67,9 @@ describe.each(localeFiles)("%s translation parity", (localeFile) => {
   });
 
   it("should preserve interpolation variables", () => {
-    const interpolationMismatches = [...sourceTranslations]
-      .filter(([key, sourceValue]) => {
-        const translatedValue = translations.get(key);
+    const interpolationMismatches = [...translations]
+      .filter(([key, translatedValue]) => {
+        const sourceValue = sourceTranslations.get(key);
         if (
           typeof sourceValue !== "string" ||
           typeof translatedValue !== "string"

--- a/src/__tests__/validation/translation-parity.test.ts
+++ b/src/__tests__/validation/translation-parity.test.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+type TranslationValue = string | number | boolean | null;
+
+const translationsDirectory = resolve(__dirname, "../../translations");
+const sourceLocale = "en-US.json";
+const localeFiles = readdirSync(translationsDirectory)
+  .filter((file) => file.endsWith(".json") && file !== sourceLocale)
+  .sort();
+
+function flattenTranslations(
+  value: unknown,
+  prefix = "",
+  result = new Map<string, TranslationValue>(),
+): Map<string, TranslationValue> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      flattenTranslations(child, prefix ? `${prefix}.${key}` : key, result);
+    }
+    return result;
+  }
+
+  result.set(prefix, value as TranslationValue);
+  return result;
+}
+
+function loadTranslations(file: string): Map<string, TranslationValue> {
+  return flattenTranslations(
+    JSON.parse(readFileSync(resolve(translationsDirectory, file), "utf8")),
+  );
+}
+
+function interpolationVariables(value: string): string[] {
+  return Array.from(
+    value.matchAll(/\{\{\s*([^},\s]+)[^}]*\}\}/g),
+    (match) => match[1]!,
+  ).sort();
+}
+
+const sourceTranslations = loadTranslations(sourceLocale);
+const sourceKeys = [...sourceTranslations.keys()].sort();
+
+describe.each(localeFiles)("%s translation parity", (localeFile) => {
+  const translations = loadTranslations(localeFile);
+
+  it("should match the source locale keys and value types", () => {
+    expect([...translations.keys()].sort()).toEqual(sourceKeys);
+
+    const typeMismatches = [...sourceTranslations]
+      .filter(
+        ([key, sourceValue]) =>
+          typeof translations.get(key) !== typeof sourceValue,
+      )
+      .map(([key]) => key);
+    expect(typeMismatches).toEqual([]);
+  });
+
+  it("should not contain blank translations", () => {
+    const blankKeys = [...translations]
+      .filter(([, value]) => typeof value === "string" && value.trim() === "")
+      .map(([key]) => key);
+
+    expect(blankKeys).toEqual([]);
+  });
+
+  it("should preserve interpolation variables", () => {
+    const interpolationMismatches = [...sourceTranslations]
+      .filter(([key, sourceValue]) => {
+        const translatedValue = translations.get(key);
+        if (
+          typeof sourceValue !== "string" ||
+          typeof translatedValue !== "string"
+        ) {
+          return false;
+        }
+
+        return (
+          interpolationVariables(translatedValue).join("|") !==
+          interpolationVariables(sourceValue).join("|")
+        );
+      })
+      .map(([key]) => key);
+
+    expect(interpolationMismatches).toEqual([]);
+  });
+});

--- a/src/components/AppBadgeManager.tsx
+++ b/src/components/AppBadgeManager.tsx
@@ -56,7 +56,7 @@ export function AppBadgeManager() {
         footer={
           <Button
             label={t("nav.close")}
-            className="mx-auto"
+            className="mx-auto w-fit"
             onClick={dismissPermissionDeniedHelp}
           />
         }

--- a/src/components/AppBadgeManager.tsx
+++ b/src/components/AppBadgeManager.tsx
@@ -21,9 +21,7 @@ export function AppBadgeManager() {
         isOpen={showPermissionRationale}
         close={dismissPermissionRationale}
         title={t("appBadge.title")}
-      >
-        <div className="flex flex-col gap-4 p-4">
-          <p className="text-center">{t("appBadge.description")}</p>
+        footer={
           <div className="flex flex-row gap-2">
             <Button
               label={t("appBadge.noThanks")}
@@ -44,6 +42,10 @@ export function AppBadgeManager() {
               disabled={isRequestingPermission}
             />
           </div>
+        }
+      >
+        <div className="p-4">
+          <p className="text-center">{t("appBadge.description")}</p>
         </div>
       </SlideModal>
 
@@ -51,14 +53,16 @@ export function AppBadgeManager() {
         isOpen={showPermissionDeniedHelp}
         close={dismissPermissionDeniedHelp}
         title={t("appBadge.title")}
-      >
-        <div className="flex flex-col gap-4 p-4">
-          <p className="text-center">{t("appBadge.deniedDescription")}</p>
+        footer={
           <Button
             label={t("nav.close")}
-            className="self-center"
+            className="mx-auto"
             onClick={dismissPermissionDeniedHelp}
           />
+        }
+      >
+        <div className="p-4">
+          <p className="text-center">{t("appBadge.deniedDescription")}</p>
         </div>
       </SlideModal>
     </>

--- a/src/components/ConfirmClearModal.tsx
+++ b/src/components/ConfirmClearModal.tsx
@@ -13,8 +13,7 @@ export function ConfirmClearModal(props: {
       isOpen={props.isOpen}
       close={props.close}
       title={t("create.custom.clearConfirmTitle")}
-    >
-      <div className="flex flex-col gap-4 py-4">
+      footer={
         <div className="flex gap-2">
           <Button
             variant="outline"
@@ -33,7 +32,9 @@ export function ConfirmClearModal(props: {
             className="border-error text-error flex-1"
           />
         </div>
-      </div>
+      }
+    >
+      <div className="py-2" />
     </SlideModal>
   );
 }

--- a/src/components/DeepLinkConfirmModal.tsx
+++ b/src/components/DeepLinkConfirmModal.tsx
@@ -21,7 +21,7 @@ export function DeepLinkConfirmModal(props: {
       title={t("deepLinks.confirmTitle")}
       fixedHeight="auto"
       footer={
-        <div className="flex gap-3 pt-4">
+        <div className="flex gap-3">
           <Button
             variant="outline"
             label={t("nav.cancel")}

--- a/src/components/InboxModal.tsx
+++ b/src/components/InboxModal.tsx
@@ -188,7 +188,7 @@ export function InboxModal() {
 
   const footer =
     messages.length > 0 ? (
-      <div className="flex flex-col gap-2 pt-3">
+      <div className="flex flex-col gap-2">
         {confirmingClear ? (
           <>
             <p className="text-center text-sm">{t("inbox.confirmClear")}</p>

--- a/src/components/MediaDatabaseCard.tsx
+++ b/src/components/MediaDatabaseCard.tsx
@@ -619,11 +619,7 @@ export function MediaDatabaseCard({
           isOpen={cleanConfirmOpen}
           close={() => setCleanConfirmOpen(false)}
           title={t("settings.updateDb.cleanOrphansConfirmTitle")}
-        >
-          <div className="flex flex-col gap-4 py-4">
-            <p className="text-muted-foreground text-sm">
-              {t("settings.updateDb.cleanOrphansConfirmDescription")}
-            </p>
+          footer={
             <div className="flex gap-2">
               <Button
                 label={t("nav.cancel")}
@@ -641,6 +637,12 @@ export function MediaDatabaseCard({
                 onClick={handleCleanConfirm}
               />
             </div>
+          }
+        >
+          <div className="py-4">
+            <p className="text-muted-foreground text-sm">
+              {t("settings.updateDb.cleanOrphansConfirmDescription")}
+            </p>
           </div>
         </SlideModal>
       ) : null}

--- a/src/components/MediaDetailsModal.tsx
+++ b/src/components/MediaDetailsModal.tsx
@@ -13,6 +13,7 @@ import { useActiveDeviceKey } from "@/hooks/useActiveDeviceKey";
 import { SlideModal } from "@/components/SlideModal";
 import { TagBadge } from "@/components/TagBadge";
 import { Button } from "@/components/wui/Button";
+import { ModalActionRail } from "@/components/wui/ModalActionRail";
 import { FavoriteButton } from "@/components/library/FavoriteButton";
 import {
   buildTitleZapScript,
@@ -99,11 +100,67 @@ export function MediaDetailsModal({
       ? filenameFromPath(media.path) || media.name
       : media.name
     : "";
+  const hasSecondaryActions = Boolean(favoriteEntry || onCopy || onPreview);
+  const primaryAction = media ? (
+    <Button
+      label={primaryActionLabel ?? t("create.search.writeLabel")}
+      icon={primaryActionIcon ?? <CreateIcon size="20" />}
+      intent="primary"
+      onClick={() => void onWrite(selectedValue)}
+    />
+  ) : undefined;
+  const footer =
+    media && primaryAction ? (
+      hasSecondaryActions ? (
+        <ModalActionRail
+          aria-label={t("create.search.mediaActions")}
+          actions={
+            <>
+              {favoriteEntry && (
+                <FavoriteButton
+                  entry={favoriteEntry}
+                  fallbackSystemId={media.system.id}
+                  deviceKey={deviceKey}
+                  displayLabel={t("library.favorite")}
+                  layout="responsive"
+                  variant="text"
+                  className="w-full whitespace-nowrap"
+                />
+              )}
+              {onCopy && (
+                <Button
+                  label={t("create.search.copyLabel")}
+                  icon={<Copy size="20" />}
+                  layout="responsive"
+                  variant="text"
+                  className="whitespace-nowrap"
+                  onClick={() => void onCopy(selectedValue)}
+                />
+              )}
+              {onPreview && (
+                <Button
+                  label={t("create.search.playLabel")}
+                  icon={<PlayIcon size="20" />}
+                  layout="responsive"
+                  variant="text"
+                  className="whitespace-nowrap"
+                  disabled={previewDisabled}
+                  onClick={() => void onPreview(selectedValue)}
+                />
+              )}
+            </>
+          }
+          primaryAction={primaryAction}
+        />
+      ) : (
+        primaryAction
+      )
+    ) : undefined;
 
   return (
-    <SlideModal isOpen={isOpen} close={close} title={title}>
+    <SlideModal isOpen={isOpen} close={close} title={title} footer={footer}>
       {media && (
-        <div className="flex flex-col gap-4 pt-2">
+        <div className="flex flex-col gap-4 py-2">
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
               <div className="flex items-center gap-2 sm:min-w-[100px]">
@@ -296,46 +353,6 @@ export function MediaDetailsModal({
               </div>
             )}
           </fieldset>
-
-          <div className="flex flex-col gap-2 pt-2">
-            {favoriteEntry && (
-              <FavoriteButton
-                entry={favoriteEntry}
-                fallbackSystemId={media.system.id}
-                deviceKey={deviceKey}
-              />
-            )}
-            <Button
-              label={primaryActionLabel ?? t("create.search.writeLabel")}
-              icon={primaryActionIcon ?? <CreateIcon size="20" />}
-              intent="primary"
-              onClick={() => void onWrite(selectedValue)}
-              className="w-full"
-            />
-            {(onCopy || onPreview) && (
-              <div className="flex flex-row gap-2">
-                {onCopy && (
-                  <Button
-                    label={t("create.search.copyLabel")}
-                    icon={<Copy size="20" />}
-                    variant="outline"
-                    onClick={() => void onCopy(selectedValue)}
-                    className="flex-1"
-                  />
-                )}
-                {onPreview && (
-                  <Button
-                    label={t("create.search.playLabel")}
-                    icon={<PlayIcon size="20" />}
-                    variant="outline"
-                    disabled={previewDisabled}
-                    onClick={() => void onPreview(selectedValue)}
-                    className="flex-1"
-                  />
-                )}
-              </div>
-            )}
-          </div>
         </div>
       )}
     </SlideModal>

--- a/src/components/PairingModal.tsx
+++ b/src/components/PairingModal.tsx
@@ -149,15 +149,13 @@ export function PairingModal({
       close={close}
       title={t("pairing.title")}
       footer={
-        <div className="pt-3">
-          <Button
-            label={isPairing ? t("pairing.pairing") : t("pairing.startPairing")}
-            disabled={isPairing || pin.length !== 6 || !address || !recordId}
-            onClick={() => void handlePair()}
-            intent="primary"
-            className="w-full"
-          />
-        </div>
+        <Button
+          label={isPairing ? t("pairing.pairing") : t("pairing.startPairing")}
+          disabled={isPairing || pin.length !== 6 || !address || !recordId}
+          onClick={() => void handlePair()}
+          intent="primary"
+          className="w-full"
+        />
       }
     >
       <div className="flex flex-col gap-4 py-4">

--- a/src/components/ProPurchase.tsx
+++ b/src/components/ProPurchase.tsx
@@ -3,7 +3,7 @@ import {
   Purchases,
   type PurchasesPackage,
 } from "@revenuecat/purchases-capacitor";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import toast from "react-hot-toast";
 import { SlideModal } from "@/components/SlideModal";
@@ -69,9 +69,14 @@ const ProPurchaseModal = (props: {
   offeringsStatus: OfferingsStatus;
   setLifetimeProAccess: (access: boolean) => void;
 }) => {
-  const handlePurchase = () => {
-    if (!props.purchasePackage) return;
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const purchasePendingRef = useRef(false);
 
+  const handlePurchase = () => {
+    if (!props.purchasePackage || purchasePendingRef.current) return;
+
+    purchasePendingRef.current = true;
+    setIsPurchasing(true);
     const purchasePackage = props.purchasePackage;
     const user = useStatusStore.getState().loggedInUser;
     void (async () => {
@@ -101,6 +106,9 @@ const ProPurchaseModal = (props: {
           severity: "warning",
         });
         toast.error(t("scan.purchaseProFailed"));
+      } finally {
+        purchasePendingRef.current = false;
+        setIsPurchasing(false);
       }
     })();
   };
@@ -108,12 +116,21 @@ const ProPurchaseModal = (props: {
   return (
     <SlideModal
       isOpen={props.proPurchaseModalOpen}
-      close={() => props.setProPurchaseModalOpen(false)}
+      close={() => {
+        if (!purchasePendingRef.current) {
+          props.setProPurchaseModalOpen(false);
+        }
+      }}
+      dismissible={!isPurchasing}
       title={t("scan.purchaseProTitle")}
       footer={
         <Button
-          label={getPurchaseActionLabel(props.offeringsStatus)}
-          disabled={!props.purchasePackage}
+          label={
+            isPurchasing
+              ? t("loading")
+              : getPurchaseActionLabel(props.offeringsStatus)
+          }
+          disabled={!props.purchasePackage || isPurchasing}
           onClick={handlePurchase}
           intent="primary"
           className="w-full"

--- a/src/components/ProPurchase.tsx
+++ b/src/components/ProPurchase.tsx
@@ -6,13 +6,7 @@ import {
 import { useEffect, useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import toast from "react-hot-toast";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 import { logger } from "@/lib/logger";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { useStatusStore } from "@/lib/store";
@@ -75,66 +69,62 @@ const ProPurchaseModal = (props: {
   offeringsStatus: OfferingsStatus;
   setLifetimeProAccess: (access: boolean) => void;
 }) => {
+  const handlePurchase = () => {
+    if (!props.purchasePackage) return;
+
+    const purchasePackage = props.purchasePackage;
+    const user = useStatusStore.getState().loggedInUser;
+    void (async () => {
+      try {
+        const purchase = await runPurchasesOperation(user?.uid ?? null, () =>
+          Purchases.purchasePackage({
+            aPackage: purchasePackage,
+          }),
+        );
+        const access = getPurchaseAccess(purchase.customerInfo);
+        props.setLifetimeProAccess(access.lifetimePro);
+        if (access.lifetimePro) {
+          usePreferencesStore.getState().setLaunchOnScan(true);
+        }
+        props.setProPurchaseModalOpen(false);
+        logger.log("Pro purchase completed", {
+          platform: Capacitor.getPlatform(),
+          packageIdentifier: purchasePackage.identifier,
+        });
+      } catch (e) {
+        const wrappedError = wrapPurchaseError(e);
+        if (wrappedError instanceof PurchaseCancelledError) return;
+
+        logger.error("Pro purchase failed", wrappedError, {
+          category: "purchase",
+          action: "purchasePackage",
+          severity: "warning",
+        });
+        toast.error(t("scan.purchaseProFailed"));
+      }
+    })();
+  };
+
   return (
-    <Dialog
-      open={props.proPurchaseModalOpen}
-      onOpenChange={props.setProPurchaseModalOpen}
-    >
-      <DialogContent onOpenChange={props.setProPurchaseModalOpen}>
-        <DialogHeader>
-          <DialogTitle>{t("scan.purchaseProTitle")}</DialogTitle>
-          <DialogDescription asChild>
-            <div className="flex flex-col gap-3">
-              <p>
-                {getPurchaseBody(props.offeringsStatus, props.purchasePackage)}
-              </p>
-              <p>{t("scan.purchaseProP2")}</p>
-            </div>
-          </DialogDescription>
-        </DialogHeader>
+    <SlideModal
+      isOpen={props.proPurchaseModalOpen}
+      close={() => props.setProPurchaseModalOpen(false)}
+      title={t("scan.purchaseProTitle")}
+      footer={
         <Button
           label={getPurchaseActionLabel(props.offeringsStatus)}
           disabled={!props.purchasePackage}
-          onClick={() => {
-            if (!props.purchasePackage) return;
-
-            const purchasePackage = props.purchasePackage;
-            const user = useStatusStore.getState().loggedInUser;
-            void (async () => {
-              try {
-                const purchase = await runPurchasesOperation(
-                  user?.uid ?? null,
-                  () =>
-                    Purchases.purchasePackage({
-                      aPackage: purchasePackage,
-                    }),
-                );
-                const access = getPurchaseAccess(purchase.customerInfo);
-                props.setLifetimeProAccess(access.lifetimePro);
-                if (access.lifetimePro) {
-                  usePreferencesStore.getState().setLaunchOnScan(true);
-                }
-                props.setProPurchaseModalOpen(false);
-                logger.log("Pro purchase completed", {
-                  platform: Capacitor.getPlatform(),
-                  packageIdentifier: purchasePackage.identifier,
-                });
-              } catch (e) {
-                const wrappedError = wrapPurchaseError(e);
-                if (wrappedError instanceof PurchaseCancelledError) return;
-
-                logger.error("Pro purchase failed", wrappedError, {
-                  category: "purchase",
-                  action: "purchasePackage",
-                  severity: "warning",
-                });
-                toast.error(t("scan.purchaseProFailed"));
-              }
-            })();
-          }}
+          onClick={handlePurchase}
+          intent="primary"
+          className="w-full"
         />
-      </DialogContent>
-    </Dialog>
+      }
+    >
+      <div className="text-muted-foreground flex flex-col gap-3 py-2">
+        <p>{getPurchaseBody(props.offeringsStatus, props.purchasePackage)}</p>
+        <p>{t("scan.purchaseProP2")}</p>
+      </div>
+    </SlideModal>
   );
 };
 
@@ -224,7 +214,7 @@ export const useProPurchase = () => {
 
   return {
     proAccess,
-    PurchaseModal: () => (
+    purchaseModal: (
       <ProPurchaseModal
         proPurchaseModalOpen={proPurchaseModalOpen}
         setProPurchaseModalOpen={setProPurchaseModalOpen}

--- a/src/components/ProfileManager.tsx
+++ b/src/components/ProfileManager.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, Trash2Icon } from "lucide-react";
 import classNames from "classnames";
 import toast from "react-hot-toast";
 import { CoreAPI } from "@/lib/coreApi";
@@ -20,6 +20,7 @@ import { Segmented } from "@/components/wui/Segmented";
 import { TextInput } from "@/components/wui/TextInput";
 import { ToggleSwitch } from "@/components/wui/ToggleSwitch";
 import { SettingHelp } from "@/components/wui/SettingHelp";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { SlideModal } from "@/components/SlideModal";
 import { NextIcon } from "@/lib/images";
 import { formatDuration, parseDuration } from "@/lib/utils";
@@ -469,28 +470,34 @@ export function ProfileManager(props: {
         )}
         footer={
           editor && (
-            <div className="flex gap-2 pt-3">
-              {editor.action === "edit" && (
+            <ModalActionBar
+              secondaryAction={
+                editor.action === "edit" ? (
+                  <Button
+                    label={t("settings.core.profiles.delete")}
+                    icon={<Trash2Icon size={20} />}
+                    variant="outline"
+                    intent="destructive"
+                    className="border-error text-error"
+                    onClick={() => {
+                      setDeleteTarget(editor.profile);
+                      setEditor(null);
+                    }}
+                    disabled={
+                      saveMutation.isPending || deleteMutation.isPending
+                    }
+                  />
+                ) : undefined
+              }
+              primaryAction={
                 <Button
-                  label={t("settings.core.profiles.delete")}
-                  variant="outline"
-                  intent="destructive"
-                  className="border-error text-error flex-1"
-                  onClick={() => {
-                    setDeleteTarget(editor.profile);
-                    setEditor(null);
-                  }}
-                  disabled={saveMutation.isPending || deleteMutation.isPending}
+                  label={t("save")}
+                  intent="primary"
+                  onClick={() => editor && saveMutation.mutate(editor)}
+                  disabled={validationError !== null || saveMutation.isPending}
                 />
-              )}
-              <Button
-                label={t("save")}
-                intent="primary"
-                className="flex-1"
-                onClick={() => editor && saveMutation.mutate(editor)}
-                disabled={validationError !== null || saveMutation.isPending}
-              />
-            </div>
+              }
+            />
           )
         }
       >
@@ -728,13 +735,7 @@ export function ProfileManager(props: {
         isOpen={deleteTarget !== null}
         close={() => setDeleteTarget(null)}
         title={t("settings.core.profiles.deleteTitle")}
-      >
-        <div className="flex flex-col gap-4 py-4">
-          <p className="text-center">
-            {t("settings.core.profiles.deleteConfirm", {
-              name: deleteTarget?.name,
-            })}
-          </p>
+        footer={
           <div className="flex gap-2">
             <Button
               label={t("nav.cancel")}
@@ -753,6 +754,14 @@ export function ProfileManager(props: {
               disabled={deleteMutation.isPending}
             />
           </div>
+        }
+      >
+        <div className="py-4">
+          <p className="text-center">
+            {t("settings.core.profiles.deleteConfirm", {
+              name: deleteTarget?.name,
+            })}
+          </p>
         </div>
       </SlideModal>
 
@@ -760,13 +769,7 @@ export function ProfileManager(props: {
         isOpen={resetCardTarget !== null}
         close={() => setResetCardTarget(null)}
         title={t("settings.core.profiles.resetCardsTitle")}
-      >
-        <div className="flex flex-col gap-4 py-4">
-          <p className="text-center">
-            {t("settings.core.profiles.resetCardsConfirm", {
-              name: resetCardTarget?.name,
-            })}
-          </p>
+        footer={
           <div className="flex gap-2">
             <Button
               label={t("nav.cancel")}
@@ -786,6 +789,14 @@ export function ProfileManager(props: {
               disabled={resetCardMutation.isPending}
             />
           </div>
+        }
+      >
+        <div className="py-4">
+          <p className="text-center">
+            {t("settings.core.profiles.resetCardsConfirm", {
+              name: resetCardTarget?.name,
+            })}
+          </p>
         </div>
       </SlideModal>
 
@@ -793,6 +804,15 @@ export function ProfileManager(props: {
         isOpen={switchProfile !== null}
         close={() => selectSwitchProfile(null)}
         title={t("settings.core.profiles.switch")}
+        footer={
+          <Button
+            label={t("settings.core.profiles.switch")}
+            intent="primary"
+            className="w-full"
+            onClick={() => switchMutation.mutate()}
+            disabled={!canSubmitSwitch || switchMutation.isPending}
+          />
+        }
       >
         <div className="flex flex-col gap-3 py-4">
           <div className="flex flex-col">
@@ -847,13 +867,6 @@ export function ProfileManager(props: {
               autoComplete="current-password"
             />
           )}
-          <Button
-            label={t("settings.core.profiles.switch")}
-            intent="primary"
-            className="w-full"
-            onClick={() => switchMutation.mutate()}
-            disabled={!canSubmitSwitch || switchMutation.isPending}
-          />
         </div>
       </SlideModal>
     </section>

--- a/src/components/RecentSearchesModal.tsx
+++ b/src/components/RecentSearchesModal.tsx
@@ -41,6 +41,17 @@ export function RecentSearchesModal({
       isOpen={isOpen}
       close={onClose}
       title={t("create.search.recentSearches")}
+      footer={
+        recentSearches.length > 0 ? (
+          <Button
+            label={t("create.search.clearHistory")}
+            icon={<Trash2 size="20" />}
+            variant="outline"
+            onClick={handleClearHistory}
+            className="w-full"
+          />
+        ) : undefined
+      }
     >
       <div className="flex flex-col gap-3 pt-2">
         {recentSearches.length === 0 ? (
@@ -49,44 +60,32 @@ export function RecentSearchesModal({
             description={t("create.search.noRecentSearchesHint")}
           />
         ) : (
-          <>
-            <div className="flex flex-col gap-2">
-              {recentSearches.map((search, index) => (
-                <Card
-                  key={index}
-                  className="cursor-pointer"
-                  onClick={() => handleSearchSelect(search)}
-                >
-                  <div className="flex flex-row items-center gap-3">
-                    <span
-                      aria-hidden="true"
-                      className="bg-button-pattern border-bd-filled text-primary-foreground flex h-10 w-10 min-w-10 items-center justify-center rounded-full border border-solid px-1.5"
-                    >
-                      <SearchIcon size="20" />
+          <div className="flex flex-col gap-2">
+            {recentSearches.map((search, index) => (
+              <Card
+                key={index}
+                className="cursor-pointer"
+                onClick={() => handleSearchSelect(search)}
+              >
+                <div className="flex flex-row items-center gap-3">
+                  <span
+                    aria-hidden="true"
+                    className="bg-button-pattern border-bd-filled text-primary-foreground flex h-10 w-10 min-w-10 items-center justify-center rounded-full border border-solid px-1.5"
+                  >
+                    <SearchIcon size="20" />
+                  </span>
+                  <div className="flex grow flex-col">
+                    <span className="text-sm font-semibold">
+                      {getSearchDisplayText(search)}
                     </span>
-                    <div className="flex grow flex-col">
-                      <span className="text-sm font-semibold">
-                        {getSearchDisplayText(search)}
-                      </span>
-                      <span className="text-muted-foreground text-xs">
-                        {new Date(search.timestamp).toLocaleString()}
-                      </span>
-                    </div>
+                    <span className="text-muted-foreground text-xs">
+                      {new Date(search.timestamp).toLocaleString()}
+                    </span>
                   </div>
-                </Card>
-              ))}
-            </div>
-
-            <div className="border-foreground-muted/20 border-t pt-3">
-              <Button
-                label={t("create.search.clearHistory")}
-                icon={<Trash2 size="20" />}
-                variant="outline"
-                onClick={handleClearHistory}
-                className="w-full"
-              />
-            </div>
-          </>
+                </div>
+              </Card>
+            ))}
+          </div>
         )}
       </div>
     </SlideModal>

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/wui/Button";
 import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import { updateRequirements, getRequirements } from "@/lib/onlineApi";
+import type { UpdateRequirementsRequest } from "@/lib/models";
 import { useStatusStore } from "@/lib/store";
 import { logger } from "@/lib/logger";
 import { isExpectedRevenueCatLogoutError } from "@/lib/errors";
@@ -24,8 +25,7 @@ export function RequirementsModal() {
   const setLoggedInUser = useStatusStore((state) => state.setLoggedInUser);
 
   // Local checkbox state - NOT live updating
-  const [tosChecked, setTosChecked] = useState(false);
-  const [privacyChecked, setPrivacyChecked] = useState(false);
+  const [legalChecked, setLegalChecked] = useState(false);
   const [ageChecked, setAgeChecked] = useState(false);
 
   // Email verification state
@@ -55,8 +55,7 @@ export function RequirementsModal() {
   useEffect(() => {
     if (isOpen) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Start each modal session with a clean requirements form.
-      setTosChecked(false);
-      setPrivacyChecked(false);
+      setLegalChecked(false);
       setAgeChecked(false);
       setEmailSent(false);
       setEmailVerifying(false);
@@ -65,8 +64,7 @@ export function RequirementsModal() {
   }, [isOpen]);
 
   // Check if Save button should be enabled
-  const canSave =
-    (!needsTos || (tosChecked && privacyChecked)) && (!needsAge || ageChecked);
+  const canSave = (!needsTos || legalChecked) && (!needsAge || ageChecked);
 
   // Check if there are checkbox-based requirements (not just email)
   const hasCheckboxRequirements = needsTos || needsAge;
@@ -75,11 +73,15 @@ export function RequirementsModal() {
     setIsSaving(true);
     setStatusMessage(null);
     try {
-      await updateRequirements({
-        accept_tos: tosChecked,
-        accept_privacy: privacyChecked,
-        age_verified: ageChecked,
-      });
+      const requirements: UpdateRequirementsRequest = {};
+      if (needsTos) {
+        requirements.accept_tos = true;
+        requirements.accept_privacy = true;
+      }
+      if (needsAge) {
+        requirements.age_verified = true;
+      }
+      await updateRequirements(requirements);
 
       // If email verification is still needed, don't close yet
       if (needsEmailVerification) {
@@ -240,7 +242,7 @@ export function RequirementsModal() {
               }
               primaryAction={
                 <Button
-                  label={isSaving ? t("loading") : t("requirements.save")}
+                  label={isSaving ? t("loading") : t("requirements.continue")}
                   onClick={handleSave}
                   disabled={!canSave || isSaving}
                   intent="primary"
@@ -263,53 +265,36 @@ export function RequirementsModal() {
       <div className="flex flex-col gap-4 py-2">
         {/* Legal Agreements Section */}
         {needsTos && (
-          <div className="flex flex-col gap-3">
-            {/* Terms of Service */}
-            <div className="flex items-start gap-3">
-              <Checkbox
-                id="tos"
-                checked={tosChecked}
-                onCheckedChange={(checked) => setTosChecked(checked === true)}
-              />
-              <div className="text-sm leading-tight text-white">
-                <Label htmlFor="tos" className="inline leading-tight">
-                  {t("requirements.tosLabel")}
-                </Label>{" "}
-                <a
-                  href={TOS_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
-                >
-                  {t("requirements.tosLink")}
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </div>
-            </div>
-
-            {/* Privacy Policy */}
-            <div className="flex items-start gap-3">
-              <Checkbox
-                id="privacy"
-                checked={privacyChecked}
-                onCheckedChange={(checked) =>
-                  setPrivacyChecked(checked === true)
-                }
-              />
-              <div className="text-sm leading-tight text-white">
-                <Label htmlFor="privacy" className="inline leading-tight">
-                  {t("requirements.privacyLabel")}
-                </Label>{" "}
-                <a
-                  href={PRIVACY_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
-                >
-                  {t("requirements.privacyLink")}
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              </div>
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="legal"
+              checked={legalChecked}
+              onCheckedChange={(checked) => setLegalChecked(checked === true)}
+              aria-label={t("requirements.legalLabel")}
+            />
+            <div className="text-sm leading-tight text-white">
+              <Label htmlFor="legal" className="inline leading-tight">
+                {t("requirements.legalPrefix")}
+              </Label>{" "}
+              <a
+                href={TOS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+              >
+                {t("requirements.tosLink")}
+                <ExternalLinkIcon className="h-3 w-3" />
+              </a>{" "}
+              {t("requirements.legalAnd")}{" "}
+              <a
+                href={PRIVACY_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+              >
+                {t("requirements.privacyLink")}
+                <ExternalLinkIcon className="h-3 w-3" />
+              </a>
             </div>
           </div>
         )}

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -20,7 +20,7 @@ const TOS_URL = "https://zaparoo.com/terms";
 const PRIVACY_URL = "https://zaparoo.com/privacy";
 
 export function RequirementsModal() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { isOpen, pendingRequirements, close } = useRequirementsStore();
   const setLoggedInUser = useStatusStore((state) => state.setLoggedInUser);
 
@@ -65,6 +65,11 @@ export function RequirementsModal() {
 
   // Check if Save button should be enabled
   const canSave = (!needsTos || legalChecked) && (!needsAge || ageChecked);
+  const legalSeparator = /^(ja|zh)(-|$)/i.test(
+    i18n.resolvedLanguage ?? i18n.language,
+  )
+    ? ""
+    : " ";
 
   // Check if there are checkbox-based requirements (not just email)
   const hasCheckboxRequirements = needsTos || needsAge;
@@ -275,7 +280,8 @@ export function RequirementsModal() {
             <div className="text-sm leading-tight text-white">
               <Label htmlFor="legal" className="inline leading-tight">
                 {t("requirements.legalPrefix")}
-              </Label>{" "}
+              </Label>
+              {legalSeparator}
               <a
                 href={TOS_URL}
                 target="_blank"
@@ -284,8 +290,10 @@ export function RequirementsModal() {
               >
                 {t("requirements.tosLink")}
                 <ExternalLinkIcon className="h-3 w-3" />
-              </a>{" "}
-              {t("requirements.legalAnd")}{" "}
+              </a>
+              {legalSeparator}
+              {t("requirements.legalAnd")}
+              {legalSeparator}
               <a
                 href={PRIVACY_URL}
                 target="_blank"

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -219,10 +219,6 @@ export function RequirementsModal() {
     }
   }, [close, pendingRequirements, setLoggedInUser, t]);
 
-  const openExternalLink = (url: string) => {
-    window.open(url, "_blank", "noopener,noreferrer");
-  };
-
   return (
     <SlideModal
       isOpen={isOpen}
@@ -275,17 +271,20 @@ export function RequirementsModal() {
                 checked={tosChecked}
                 onCheckedChange={(checked) => setTosChecked(checked === true)}
               />
-              <Label htmlFor="tos" className="text-sm leading-tight text-white">
-                {t("requirements.tosLabel")}{" "}
-                <button
-                  type="button"
-                  onClick={() => openExternalLink(TOS_URL)}
-                  className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
+              <div className="text-sm leading-tight text-white">
+                <Label htmlFor="tos" className="inline leading-tight">
+                  {t("requirements.tosLabel")}
+                </Label>{" "}
+                <a
+                  href={TOS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                 >
                   {t("requirements.tosLink")}
                   <ExternalLinkIcon className="h-3 w-3" />
-                </button>
-              </Label>
+                </a>
+              </div>
             </div>
 
             {/* Privacy Policy */}
@@ -297,20 +296,20 @@ export function RequirementsModal() {
                   setPrivacyChecked(checked === true)
                 }
               />
-              <Label
-                htmlFor="privacy"
-                className="text-sm leading-tight text-white"
-              >
-                {t("requirements.privacyLabel")}{" "}
-                <button
-                  type="button"
-                  onClick={() => openExternalLink(PRIVACY_URL)}
-                  className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
+              <div className="text-sm leading-tight text-white">
+                <Label htmlFor="privacy" className="inline leading-tight">
+                  {t("requirements.privacyLabel")}
+                </Label>{" "}
+                <a
+                  href={PRIVACY_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-sm text-blue-400 underline hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                 >
                   {t("requirements.privacyLink")}
                   <ExternalLinkIcon className="h-3 w-3" />
-                </button>
-              </Label>
+                </a>
+              </div>
             </div>
           </div>
         )}
@@ -359,7 +358,7 @@ export function RequirementsModal() {
                 <button
                   type="button"
                   onClick={handleSendVerificationEmail}
-                  className="text-muted-foreground text-center text-sm underline hover:text-white"
+                  className="text-muted-foreground rounded-sm text-center text-sm underline hover:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                 >
                   {t("requirements.resendEmail")}
                 </button>

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -4,15 +4,11 @@ import { FirebaseAuthentication } from "@capacitor-firebase/authentication";
 import { Purchases } from "@revenuecat/purchases-capacitor";
 import { Capacitor } from "@capacitor/core";
 import { LogOutIcon, ExternalLinkIcon, MailIcon } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/wui/Button";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import { updateRequirements, getRequirements } from "@/lib/onlineApi";
 import { useStatusStore } from "@/lib/store";
@@ -227,157 +223,35 @@ export function RequirementsModal() {
     window.open(url, "_blank", "noopener,noreferrer");
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <Dialog open={isOpen} onOpenChange={() => {}}>
-      <DialogContent
-        className="max-w-[340px]"
-        onEscapeKeyDown={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => e.preventDefault()}
-        onInteractOutside={(e) => e.preventDefault()}
-      >
-        {/* Hide the default close button */}
-        <style>{`.absolute.top-4.right-4 { display: none; }`}</style>
-
-        <DialogHeader>
-          <DialogTitle>{t("requirements.title")}</DialogTitle>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-4">
-          {/* Legal Agreements Section */}
-          {needsTos && (
-            <div className="flex flex-col gap-3">
-              {/* Terms of Service */}
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="tos"
-                  checked={tosChecked}
-                  onCheckedChange={(checked) => setTosChecked(checked === true)}
-                />
-                <Label
-                  htmlFor="tos"
-                  className="text-sm leading-tight text-white"
-                >
-                  {t("requirements.tosLabel")}{" "}
-                  <button
-                    type="button"
-                    onClick={() => openExternalLink(TOS_URL)}
-                    className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
-                  >
-                    {t("requirements.tosLink")}
-                    <ExternalLinkIcon className="h-3 w-3" />
-                  </button>
-                </Label>
-              </div>
-
-              {/* Privacy Policy */}
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="privacy"
-                  checked={privacyChecked}
-                  onCheckedChange={(checked) =>
-                    setPrivacyChecked(checked === true)
-                  }
-                />
-                <Label
-                  htmlFor="privacy"
-                  className="text-sm leading-tight text-white"
-                >
-                  {t("requirements.privacyLabel")}{" "}
-                  <button
-                    type="button"
-                    onClick={() => openExternalLink(PRIVACY_URL)}
-                    className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
-                  >
-                    {t("requirements.privacyLink")}
-                    <ExternalLinkIcon className="h-3 w-3" />
-                  </button>
-                </Label>
-              </div>
-            </div>
-          )}
-
-          {/* Age Verification */}
-          {needsAge && (
-            <div className="flex items-start gap-3">
-              <Checkbox
-                id="age"
-                checked={ageChecked}
-                onCheckedChange={(checked) => setAgeChecked(checked === true)}
-              />
-              <Label htmlFor="age" className="text-sm leading-tight text-white">
-                {t("requirements.ageLabel")}
-              </Label>
-            </div>
-          )}
-
-          {/* Email Verification */}
-          {needsEmailVerification && (
-            <div className="flex flex-col gap-2">
-              {!emailSent ? (
+    <SlideModal
+      isOpen={isOpen}
+      close={close}
+      dismissible={false}
+      title={t("requirements.title")}
+      footer={
+        <div className="flex flex-col gap-2">
+          {hasCheckboxRequirements ? (
+            <ModalActionBar
+              secondaryAction={
                 <Button
-                  label={t("requirements.sendVerificationEmail")}
-                  icon={<MailIcon size={18} />}
+                  label={isLoggingOut ? t("loading") : t("requirements.logout")}
+                  icon={<LogOutIcon size={18} />}
                   variant="outline"
-                  onClick={handleSendVerificationEmail}
-                  className="w-full"
+                  onClick={handleLogout}
+                  disabled={isLoggingOut}
                 />
-              ) : (
-                <>
-                  <p className="text-muted-foreground text-sm">
-                    {t("requirements.emailSentMessage")}
-                  </p>
-                  <Button
-                    label={
-                      emailVerifying
-                        ? t("requirements.checking")
-                        : t("requirements.checkEmailVerified")
-                    }
-                    variant="outline"
-                    onClick={handleCheckEmailVerified}
-                    disabled={emailVerifying}
-                    className="w-full"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleSendVerificationEmail}
-                    className="text-muted-foreground text-center text-sm underline hover:text-white"
-                  >
-                    {t("requirements.resendEmail")}
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-
-          {/* Inline status message */}
-          {statusMessage && (
-            <p
-              className={
-                statusMessage.type === "error"
-                  ? "text-sm text-red-400"
-                  : "text-sm text-green-400"
               }
-            >
-              {statusMessage.text}
-            </p>
-          )}
-
-          {/* Action Buttons */}
-          <div className="mt-2 flex flex-col gap-3">
-            {hasCheckboxRequirements && (
-              <Button
-                label={isSaving ? t("loading") : t("requirements.save")}
-                onClick={handleSave}
-                disabled={!canSave || isSaving}
-                intent="primary"
-                className="w-full"
-              />
-            )}
-
+              primaryAction={
+                <Button
+                  label={isSaving ? t("loading") : t("requirements.save")}
+                  onClick={handleSave}
+                  disabled={!canSave || isSaving}
+                  intent="primary"
+                />
+              }
+            />
+          ) : (
             <Button
               label={isLoggingOut ? t("loading") : t("requirements.logout")}
               icon={<LogOutIcon size={18} />}
@@ -386,9 +260,127 @@ export function RequirementsModal() {
               disabled={isLoggingOut}
               className="w-full"
             />
-          </div>
+          )}
         </div>
-      </DialogContent>
-    </Dialog>
+      }
+    >
+      <div className="flex flex-col gap-4 py-2">
+        {/* Legal Agreements Section */}
+        {needsTos && (
+          <div className="flex flex-col gap-3">
+            {/* Terms of Service */}
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="tos"
+                checked={tosChecked}
+                onCheckedChange={(checked) => setTosChecked(checked === true)}
+              />
+              <Label htmlFor="tos" className="text-sm leading-tight text-white">
+                {t("requirements.tosLabel")}{" "}
+                <button
+                  type="button"
+                  onClick={() => openExternalLink(TOS_URL)}
+                  className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
+                >
+                  {t("requirements.tosLink")}
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </button>
+              </Label>
+            </div>
+
+            {/* Privacy Policy */}
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="privacy"
+                checked={privacyChecked}
+                onCheckedChange={(checked) =>
+                  setPrivacyChecked(checked === true)
+                }
+              />
+              <Label
+                htmlFor="privacy"
+                className="text-sm leading-tight text-white"
+              >
+                {t("requirements.privacyLabel")}{" "}
+                <button
+                  type="button"
+                  onClick={() => openExternalLink(PRIVACY_URL)}
+                  className="inline-flex items-center gap-1 text-blue-400 underline hover:text-blue-300"
+                >
+                  {t("requirements.privacyLink")}
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </button>
+              </Label>
+            </div>
+          </div>
+        )}
+
+        {/* Age Verification */}
+        {needsAge && (
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="age"
+              checked={ageChecked}
+              onCheckedChange={(checked) => setAgeChecked(checked === true)}
+            />
+            <Label htmlFor="age" className="text-sm leading-tight text-white">
+              {t("requirements.ageLabel")}
+            </Label>
+          </div>
+        )}
+
+        {/* Email Verification */}
+        {needsEmailVerification && (
+          <div className="flex flex-col gap-2">
+            {!emailSent ? (
+              <Button
+                label={t("requirements.sendVerificationEmail")}
+                icon={<MailIcon size={18} />}
+                variant="outline"
+                onClick={handleSendVerificationEmail}
+                className="w-full"
+              />
+            ) : (
+              <>
+                <p className="text-muted-foreground text-sm">
+                  {t("requirements.emailSentMessage")}
+                </p>
+                <Button
+                  label={
+                    emailVerifying
+                      ? t("requirements.checking")
+                      : t("requirements.checkEmailVerified")
+                  }
+                  variant="outline"
+                  onClick={handleCheckEmailVerified}
+                  disabled={emailVerifying}
+                  className="w-full"
+                />
+                <button
+                  type="button"
+                  onClick={handleSendVerificationEmail}
+                  className="text-muted-foreground text-center text-sm underline hover:text-white"
+                >
+                  {t("requirements.resendEmail")}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Inline status message */}
+        {statusMessage && (
+          <p
+            className={
+              statusMessage.type === "error"
+                ? "text-sm text-red-400"
+                : "text-sm text-green-400"
+            }
+          >
+            {statusMessage.text}
+          </p>
+        )}
+      </div>
+    </SlideModal>
   );
 }

--- a/src/components/ScanSpinner.tsx
+++ b/src/components/ScanSpinner.tsx
@@ -53,6 +53,7 @@ export function ScanSpinner(props: {
           </div>
           <Button
             icon={<SettingsIcon size="24" />}
+            aria-label={t("spinner.openNfcSettings")}
             variant="text"
             onClick={() => Nfc.openSettings()}
           />

--- a/src/components/SlideModal.tsx
+++ b/src/components/SlideModal.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, RefObject, useEffect, useId, useRef } from "react";
+import {
+  ReactNode,
+  RefObject,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import classNames from "classnames";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -8,6 +15,7 @@ import { useSlideModalManager } from "@/hooks/useSlideModalManager";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useScreenReaderEnabled } from "@/hooks/useScreenReaderEnabled";
+import { SkipLink } from "@/components/SkipLink";
 
 const OPEN_TRANSFORM = "translate3d(0, 0, 0)";
 const CLOSED_TRANSFORM = "translate3d(0, 100%, 0)";
@@ -83,11 +91,17 @@ export function SlideModal(props: {
   children: ReactNode;
   className?: string;
   scrollRef?: RefObject<HTMLDivElement | null>;
+  /** Persistent actions shown below the body, with overflow fallback on short viewports. */
   footer?: ReactNode;
+  /** Optional label for an early link that moves focus to a long modal's footer. */
+  footerSkipLabel?: string;
+  /** Whether overlay, Escape, back, close buttons, and drag may dismiss the modal. */
+  dismissible?: boolean;
   fixedHeight?: string;
 }) {
   const { t } = useTranslation();
   const modalId = useId();
+  const footerId = `${modalId}-footer`;
   const modalManager = useSlideModalManager();
   const modalRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
@@ -95,6 +109,9 @@ export function SlideModal(props: {
   const { impact } = useHaptics();
   const screenReaderEnabled = useScreenReaderEnabled();
   const wasOpenRef = useRef(props.isOpen);
+  const dismissible = props.dismissible ?? true;
+  const requestedOpen = props.isOpen;
+  const requestClose = props.close;
 
   useEffect(() => {
     closeRef.current = props.close;
@@ -114,7 +131,7 @@ export function SlideModal(props: {
     containerRef: modalRef,
     restoreFocus: true,
     autoFocus: false, // The dialog heading receives initial focus.
-    onEscape: props.close,
+    onEscape: dismissible ? props.close : undefined,
   });
 
   // Focus the title when modal opens (better for screen readers)
@@ -126,7 +143,7 @@ export function SlideModal(props: {
     const modal = modalRef.current;
     if (!modal) return;
 
-    if (!props.isOpen || screenReaderEnabled) {
+    if (!props.isOpen || screenReaderEnabled || !dismissible) {
       modal.removeAttribute("data-dragging");
       modal.style.transition = DRAG_TRANSITION;
       modal.style.transform = props.isOpen ? OPEN_TRANSFORM : CLOSED_TRANSFORM;
@@ -280,14 +297,14 @@ export function SlideModal(props: {
       modal.removeEventListener("touchend", handleTouchEnd);
       modal.removeEventListener("touchcancel", handleTouchCancel);
     };
-  }, [props.isOpen, screenReaderEnabled, impact]);
+  }, [props.isOpen, screenReaderEnabled, dismissible, impact]);
 
   // Handle Android back button
   useBackButtonHandler(
     "slide-modal",
     () => {
       if (props.isOpen) {
-        props.close();
+        if (dismissible) props.close();
         return true; // Consume the event
       }
       return false; // Let other handlers process it
@@ -296,26 +313,31 @@ export function SlideModal(props: {
     props.isOpen, // Only active when modal is open
   );
 
-  // Register/unregister modal with manager and handle auto-close
-  useEffect(() => {
-    if (props.isOpen) {
-      // Close any other open modals before opening this one
-      modalManager.closeAllExcept(modalId);
+  // Register before paint so a blocking modal can reject later sheets without a visible or focusable flash.
+  useLayoutEffect(() => {
+    if (requestedOpen) {
+      const accepted = modalManager.closeAllExcept(modalId);
+      if (!accepted) {
+        requestClose();
+        return;
+      }
 
-      // Register this modal
-      modalManager.registerModal(modalId, props.close);
+      modalManager.registerModal(modalId, requestClose, {
+        blocking: !dismissible,
+      });
 
-      // Cleanup function to unregister when modal closes
       return () => {
         modalManager.unregisterModal(modalId);
       };
-    } else {
-      // Unregister when modal closes
-      modalManager.unregisterModal(modalId);
     }
-  }, [props.isOpen, modalId, modalManager, props.close]);
 
-  const safeInsets = useStatusStore((state) => state.safeInsets);
+    modalManager.unregisterModal(modalId);
+  }, [requestedOpen, requestClose, modalId, modalManager, dismissible]);
+
+  const safeInsets = useStatusStore((state) => state.safeInsets) ?? {
+    top: "0px",
+    bottom: "0px",
+  };
 
   return (
     <>
@@ -328,7 +350,7 @@ export function SlideModal(props: {
           opacity: props.isOpen ? 1 : 0,
           pointerEvents: props.isOpen ? "auto" : "none",
         }}
-        onClick={props.close}
+        onClick={dismissible ? props.close : undefined}
         aria-hidden="true"
       />
 
@@ -371,28 +393,29 @@ export function SlideModal(props: {
           willChange: props.isOpen ? "transform" : "auto",
           pointerEvents: props.isOpen ? "auto" : "none",
           paddingBottom: `calc(${safeInsets.bottom} + 0.75rem)`,
-          ...(props.fixedHeight
-            ? { height: props.fixedHeight }
-            : { maxHeight: `calc(100vh - ${safeInsets.top} - 75px)` }),
+          maxHeight: `min(80vh, calc(100vh - ${safeInsets.top} - 75px))`,
+          ...(props.fixedHeight ? { height: props.fixedHeight } : {}),
         }}
       >
         {/* Swipeable handle and title area */}
         <div style={{ touchAction: "pan-x pinch-zoom" }}>
           {/* Mobile drag handle */}
-          <div className="-mt-3 sm:hidden">
-            <button
-              type="button"
-              onClick={props.close}
-              aria-label={t("nav.close")}
-              data-slide-modal-drag-handle
-              className="flex h-[29px] w-full items-center justify-center bg-transparent focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
-            >
-              <span
-                aria-hidden="true"
-                className="h-[5px] w-[80px] rounded-full bg-[#00E0FF]"
-              />
-            </button>
-          </div>
+          {dismissible && (
+            <div className="-mt-3 sm:hidden">
+              <button
+                type="button"
+                onClick={props.close}
+                aria-label={t("nav.close")}
+                data-slide-modal-drag-handle
+                className="flex h-[29px] w-full items-center justify-center bg-transparent focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+              >
+                <span
+                  aria-hidden="true"
+                  className="h-[5px] w-[80px] rounded-full bg-[#00E0FF]"
+                />
+              </button>
+            </div>
+          )}
           {/* Shared visible title and desktop close action */}
           <div className="relative pb-2">
             <h2
@@ -403,21 +426,34 @@ export function SlideModal(props: {
             >
               {props.title}
             </h2>
-            <button
-              type="button"
-              onClick={props.close}
-              className="absolute top-[-5px] right-0 hidden h-8 w-8 items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-white/10 hover:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none sm:flex"
-              aria-label={t("nav.close")}
-            >
-              <X className="h-5 w-5" aria-hidden="true" />
-            </button>
+            {dismissible && (
+              <button
+                type="button"
+                onClick={props.close}
+                className="absolute top-[-5px] right-0 hidden h-8 w-8 items-center justify-center rounded-md opacity-70 transition-opacity hover:bg-white/10 hover:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none sm:flex"
+                aria-label={t("nav.close")}
+              >
+                <X className="h-5 w-5" aria-hidden="true" />
+              </button>
+            )}
           </div>
         </div>
+        {props.footer && props.footerSkipLabel && (
+          <SkipLink targetId={footerId} label={props.footerSkipLabel} />
+        )}
         {/* eslint-disable react-hooks/refs -- False positives: scrollRef is passed as ref prop, children/footer are ReactNode props */}
         <div ref={props.scrollRef} className="flex-1 overflow-y-auto">
           {props.children}
         </div>
-        {props.footer && <div className="flex-shrink-0">{props.footer}</div>}
+        {props.footer && (
+          <div
+            id={footerId}
+            tabIndex={props.footerSkipLabel ? -1 : undefined}
+            className="max-h-[33dvh] flex-shrink-0 overflow-y-auto overscroll-contain border-t border-solid border-[rgba(255,255,255,0.13)] pt-3"
+          >
+            {props.footer}
+          </div>
+        )}
         {/* eslint-enable react-hooks/refs */}
       </div>
     </>

--- a/src/components/SlideModalProvider.tsx
+++ b/src/components/SlideModalProvider.tsx
@@ -2,25 +2,42 @@ import { useRef, useCallback, ReactNode } from "react";
 import {
   SlideModalContext,
   SlideModalManager,
+  type SlideModalRegistrationOptions,
 } from "@/hooks/useSlideModalManager";
 
 export const SlideModalProvider = ({ children }: { children: ReactNode }) => {
-  const modals = useRef<Map<string, () => void>>(new Map());
+  const modals = useRef<
+    Map<string, { closeFunction: () => void; blocking: boolean }>
+  >(new Map());
 
-  const registerModal = useCallback((id: string, closeFunction: () => void) => {
-    modals.current.set(id, closeFunction);
-  }, []);
+  const registerModal = useCallback(
+    (
+      id: string,
+      closeFunction: () => void,
+      options?: SlideModalRegistrationOptions,
+    ) => {
+      modals.current.set(id, {
+        closeFunction,
+        blocking: options?.blocking === true,
+      });
+    },
+    [],
+  );
 
   const unregisterModal = useCallback((id: string) => {
     modals.current.delete(id);
   }, []);
 
-  const closeAllExcept = useCallback((exceptId: string) => {
-    modals.current.forEach((closeFunction, id) => {
-      if (id !== exceptId) {
-        closeFunction();
-      }
+  const closeAllExcept = useCallback((exceptId: string): boolean => {
+    const blocked = Array.from(modals.current.entries()).some(
+      ([id, modal]) => id !== exceptId && modal.blocking,
+    );
+    if (blocked) return false;
+
+    modals.current.forEach((modal, id) => {
+      if (id !== exceptId) modal.closeFunction();
     });
+    return true;
   }, []);
 
   const manager: SlideModalManager = {

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { Check } from "lucide-react";
+import { Check, Trash2 } from "lucide-react";
 import { useDebounce } from "use-debounce";
 import classNames from "classnames";
 import { CoreAPI } from "@/lib/coreApi";
@@ -20,6 +20,7 @@ import { SystemFilterControls } from "@/components/SystemFilterControls";
 import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
+import { ModalActionBar } from "./wui/ModalActionBar";
 import { BackToTop } from "./BackToTop";
 
 export type { System } from "@/lib/models";
@@ -165,7 +166,7 @@ export function SystemSelector({
   // Footer for multi-select mode
   const footer =
     mode === "multi" ? (
-      <div className="border-border flex flex-col gap-3 border-t p-2">
+      <div className="flex flex-col gap-3 px-2 pb-2">
         <div className="text-center">
           <span className="text-muted-foreground text-sm">
             {t("systemSelector.selectedCount", {
@@ -173,23 +174,24 @@ export function SystemSelector({
             })}
           </span>
         </div>
-        <div className="flex items-center gap-3">
-          {selectedSystems.length > 0 && (
-            <button
+        <ModalActionBar
+          secondaryAction={
+            <Button
+              label={t("systemSelector.clearAll")}
+              icon={<Trash2 size={20} />}
+              variant="outline"
               onClick={handleClearAll}
-              className="text-muted-foreground hover:text-foreground text-sm underline"
-              type="button"
-            >
-              {t("systemSelector.clearAll")}
-            </button>
-          )}
-          <Button
-            label={t("systemSelector.apply")}
-            onClick={handleApply}
-            className="flex-1"
-            disabled={selectedSystems.length === 0 && !includeAllOption}
-          />
-        </div>
+              disabled={selectedSystems.length === 0}
+            />
+          }
+          primaryAction={
+            <Button
+              label={t("systemSelector.apply")}
+              onClick={handleApply}
+              disabled={selectedSystems.length === 0 && !includeAllOption}
+            />
+          }
+        />
       </div>
     ) : undefined;
 

--- a/src/components/SystemSelector.tsx
+++ b/src/components/SystemSelector.tsx
@@ -17,10 +17,10 @@ import { useHapticPress } from "@/hooks/useHapticPress";
 import { EmptyState } from "@/components/wui/EmptyState";
 import { getTabBarPanelId, getTabBarTabId } from "@/components/wui/tabBarIds";
 import { SystemFilterControls } from "@/components/SystemFilterControls";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
-import { ModalActionBar } from "./wui/ModalActionBar";
 import { BackToTop } from "./BackToTop";
 
 export type { System } from "@/lib/models";

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -10,12 +10,12 @@ import { useActiveDeviceKey } from "@/hooks/useActiveDeviceKey";
 import { compareStrings } from "@/lib/utils";
 import { TagInfo } from "@/lib/models";
 import { EmptyState } from "@/components/wui/EmptyState";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { useAccessibleLists } from "@/hooks/useAccessibleLists";
 import { useHapticPress } from "@/hooks/useHapticPress";
 import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
-import { ModalActionBar } from "./wui/ModalActionBar";
 import { BackToTop } from "./BackToTop";
 import {
   Accordion,

--- a/src/components/TagSelector.tsx
+++ b/src/components/TagSelector.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Search, Check, X, ChevronUp, ChevronDown } from "lucide-react";
+import { Search, Check, X, ChevronUp, ChevronDown, Trash2 } from "lucide-react";
 import { useDebounce } from "use-debounce";
 import classNames from "classnames";
 import { CoreAPI } from "@/lib/coreApi";
@@ -15,6 +15,7 @@ import { useHapticPress } from "@/hooks/useHapticPress";
 import { useAnnouncer } from "./A11yAnnouncer";
 import { SlideModal } from "./SlideModal";
 import { Button } from "./wui/Button";
+import { ModalActionBar } from "./wui/ModalActionBar";
 import { BackToTop } from "./BackToTop";
 import {
   Accordion,
@@ -254,7 +255,7 @@ export function TagSelector({
 
   // Footer for multi-select mode
   const footer = (
-    <div className="border-border flex flex-col gap-3 border-t p-2">
+    <div className="flex flex-col gap-3 px-2 pb-2">
       <div className="text-center">
         <span className="text-muted-foreground text-sm">
           {t("tagSelector.selectedCount", {
@@ -262,22 +263,20 @@ export function TagSelector({
           })}
         </span>
       </div>
-      <div className="flex items-center gap-3">
-        {selectedTags.length > 0 && (
-          <button
+      <ModalActionBar
+        secondaryAction={
+          <Button
+            label={t("tagSelector.clearAll")}
+            icon={<Trash2 size={20} />}
+            variant="outline"
             onClick={handleClearAll}
-            className="text-muted-foreground hover:text-foreground text-sm underline"
-            type="button"
-          >
-            {t("tagSelector.clearAll")}
-          </button>
-        )}
-        <Button
-          label={t("tagSelector.apply")}
-          onClick={handleApply}
-          className="flex-1"
-        />
-      </div>
+            disabled={selectedTags.length === 0}
+          />
+        }
+        primaryAction={
+          <Button label={t("tagSelector.apply")} onClick={handleApply} />
+        }
+      />
     </div>
   );
 

--- a/src/components/WarpSubscription.tsx
+++ b/src/components/WarpSubscription.tsx
@@ -69,7 +69,7 @@ function WarpPurchaseModal({
     <SlideModal
       isOpen={open}
       close={() => onOpenChange(false)}
-      dismissible={action === null}
+      dismissible={action !== "purchase"}
       title={t("online.warp.purchaseTitle")}
       footer={
         <Button
@@ -441,7 +441,10 @@ function LiveWarpSubscription({ appUserID }: WarpSubscriptionProps) {
       {!checkoutSuppressed && packages && (
         <Button
           label={t("online.warp.get")}
-          onClick={() => setPurchaseDialogOpen(true)}
+          onClick={() => {
+            if (action === null) setPurchaseDialogOpen(true);
+          }}
+          disabled={action !== null}
           intent="primary"
           className="w-full"
         />
@@ -513,7 +516,7 @@ function LiveWarpSubscription({ appUserID }: WarpSubscriptionProps) {
       <WarpPurchaseModal
         open={purchaseDialogOpen && Boolean(packages)}
         onOpenChange={(open) => {
-          if (action === null) setPurchaseDialogOpen(open);
+          if (action !== "purchase") setPurchaseDialogOpen(open);
         }}
         selectedPlan={selectedPlan}
         setSelectedPlan={setSelectedPlan}

--- a/src/components/WarpSubscription.tsx
+++ b/src/components/WarpSubscription.tsx
@@ -69,6 +69,7 @@ function WarpPurchaseModal({
     <SlideModal
       isOpen={open}
       close={() => onOpenChange(false)}
+      dismissible={action === null}
       title={t("online.warp.purchaseTitle")}
       footer={
         <Button

--- a/src/components/WarpSubscription.tsx
+++ b/src/components/WarpSubscription.tsx
@@ -4,13 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/wui/Button";
 import { Segmented } from "@/components/wui/Segmented";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 import {
   useWarpSubscription,
   type WarpAction,
@@ -48,7 +42,7 @@ export function WarpSubscription(props: WarpSubscriptionProps) {
   );
 }
 
-interface WarpPurchaseDialogProps {
+interface WarpPurchaseModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   selectedPlan: WarpPlan;
@@ -59,7 +53,7 @@ interface WarpPurchaseDialogProps {
   purchaseEnabled: boolean;
 }
 
-function WarpPurchaseDialog({
+function WarpPurchaseModal({
   open,
   onOpenChange,
   selectedPlan,
@@ -68,18 +62,32 @@ function WarpPurchaseDialog({
   action,
   onPurchase,
   purchaseEnabled,
-}: WarpPurchaseDialogProps) {
+}: WarpPurchaseModalProps) {
   const { t } = useTranslation();
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent onOpenChange={onOpenChange}>
-        <DialogHeader>
-          <DialogTitle>{t("online.warp.purchaseTitle")}</DialogTitle>
-          <DialogDescription>
-            {t("online.warp.purchaseDescription")}
-          </DialogDescription>
-        </DialogHeader>
+    <SlideModal
+      isOpen={open}
+      close={() => onOpenChange(false)}
+      title={t("online.warp.purchaseTitle")}
+      footer={
+        <Button
+          label={
+            action === "purchase"
+              ? t("online.warp.purchasing")
+              : t("online.warp.subscribe")
+          }
+          onClick={onPurchase}
+          disabled={action !== null || !purchaseEnabled}
+          intent="primary"
+          className="w-full"
+        />
+      }
+    >
+      <div className="flex flex-col gap-4 py-2">
+        <p className="text-muted-foreground text-sm">
+          {t("online.warp.purchaseDescription")}
+        </p>
 
         <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
           <li>{t("online.warp.benefitBackup")}</li>
@@ -133,20 +141,8 @@ function WarpPurchaseDialog({
           </a>
           .
         </p>
-
-        <Button
-          label={
-            action === "purchase"
-              ? t("online.warp.purchasing")
-              : t("online.warp.subscribe")
-          }
-          onClick={onPurchase}
-          disabled={action !== null || !purchaseEnabled}
-          intent="primary"
-          className="w-full"
-        />
-      </DialogContent>
-    </Dialog>
+      </div>
+    </SlideModal>
   );
 }
 
@@ -253,7 +249,7 @@ function WarpSubscriptionPreview({
         />
       )}
 
-      <WarpPurchaseDialog
+      <WarpPurchaseModal
         open={state === "checkout" && purchaseDialogOpen}
         onOpenChange={setPurchaseDialogOpen}
         selectedPlan={selectedPlan}
@@ -513,7 +509,7 @@ function LiveWarpSubscription({ appUserID }: WarpSubscriptionProps) {
         />
       )}
 
-      <WarpPurchaseDialog
+      <WarpPurchaseModal
         open={purchaseDialogOpen && Boolean(packages)}
         onOpenChange={(open) => {
           if (action === null) setPurchaseDialogOpen(open);

--- a/src/components/WhatsNewDialog.tsx
+++ b/src/components/WhatsNewDialog.tsx
@@ -1,10 +1,5 @@
 import { useTranslation } from "react-i18next";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 import { Button } from "@/components/wui/Button";
 import type { WhatsNewAnnouncement } from "@/lib/whatsNew";
 
@@ -18,30 +13,24 @@ export function WhatsNewDialog(props: {
   if (!props.announcement) return null;
 
   return (
-    <Dialog
-      open={props.isOpen}
-      onOpenChange={(open) => !open && props.onDismiss()}
-    >
-      <DialogContent
-        className="max-w-[340px] gap-5"
-        aria-describedby={undefined}
-        onOpenChange={(open) => !open && props.onDismiss()}
-      >
-        <DialogHeader>
-          <DialogTitle>{props.announcement.title}</DialogTitle>
-        </DialogHeader>
-        <ul className="text-muted-foreground list-disc space-y-2 pl-5 text-sm">
-          {props.announcement.items.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+    <SlideModal
+      isOpen={props.isOpen}
+      close={props.onDismiss}
+      title={props.announcement.title}
+      footer={
         <Button
           label={t("whatsNew.gotIt")}
           intent="primary"
           onClick={props.onDismiss}
           className="w-full"
         />
-      </DialogContent>
-    </Dialog>
+      }
+    >
+      <ul className="text-muted-foreground list-disc space-y-2 py-2 pl-5 text-sm">
+        {props.announcement.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </SlideModal>
   );
 }

--- a/src/components/WhatsNewInitializer.tsx
+++ b/src/components/WhatsNewInitializer.tsx
@@ -36,6 +36,7 @@ export function WhatsNewInitializer() {
   const [isOpen, setIsOpen] = useState(false);
   const processedRuntimeKeyRef = useRef<string | null>(null);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissingRef = useRef(false);
 
   useEffect(() => {
     if (!hasHydrated) return;
@@ -94,7 +95,14 @@ export function WhatsNewInitializer() {
   ]);
 
   useEffect(() => {
-    if (!pendingAnnouncement || !tourCompleted || isOpen) return;
+    if (
+      !pendingAnnouncement ||
+      !tourCompleted ||
+      isOpen ||
+      dismissingRef.current
+    ) {
+      return;
+    }
 
     const timer = setTimeout(() => {
       setIsOpen(true);
@@ -111,6 +119,7 @@ export function WhatsNewInitializer() {
   );
 
   const handleDismiss = useCallback(() => {
+    dismissingRef.current = true;
     if (pendingAnnouncement && pendingRuntimeKey) {
       markWhatsNewSeen(pendingAnnouncement.id, pendingRuntimeKey);
     }
@@ -119,6 +128,7 @@ export function WhatsNewInitializer() {
     dismissTimerRef.current = setTimeout(() => {
       setPendingAnnouncement(null);
       setPendingRuntimeKey(null);
+      dismissingRef.current = false;
       dismissTimerRef.current = null;
     }, MODAL_TRANSITION_MS);
   }, [markWhatsNewSeen, pendingAnnouncement, pendingRuntimeKey]);

--- a/src/components/WhatsNewInitializer.tsx
+++ b/src/components/WhatsNewInitializer.tsx
@@ -7,6 +7,8 @@ import {
   type WhatsNewAnnouncement,
 } from "@/lib/whatsNew";
 
+const MODAL_TRANSITION_MS = 200;
+
 export function WhatsNewInitializer() {
   const hasHydrated = usePreferencesStore((state) => state._hasHydrated);
   const tourCompleted = usePreferencesStore((state) => state.tourCompleted);
@@ -33,6 +35,7 @@ export function WhatsNewInitializer() {
   );
   const [isOpen, setIsOpen] = useState(false);
   const processedRuntimeKeyRef = useRef<string | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!hasHydrated) return;
@@ -100,13 +103,24 @@ export function WhatsNewInitializer() {
     return () => clearTimeout(timer);
   }, [isOpen, pendingAnnouncement, tourCompleted]);
 
+  useEffect(
+    () => () => {
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    },
+    [],
+  );
+
   const handleDismiss = useCallback(() => {
     if (pendingAnnouncement && pendingRuntimeKey) {
       markWhatsNewSeen(pendingAnnouncement.id, pendingRuntimeKey);
     }
     setIsOpen(false);
-    setPendingAnnouncement(null);
-    setPendingRuntimeKey(null);
+    if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    dismissTimerRef.current = setTimeout(() => {
+      setPendingAnnouncement(null);
+      setPendingRuntimeKey(null);
+      dismissTimerRef.current = null;
+    }, MODAL_TRANSITION_MS);
   }, [markWhatsNewSeen, pendingAnnouncement, pendingRuntimeKey]);
 
   return (

--- a/src/components/home/StagedTokenModal.tsx
+++ b/src/components/home/StagedTokenModal.tsx
@@ -115,7 +115,7 @@ export function StagedTokenModal() {
       title={t("tokenStaging.title")}
       fixedHeight="auto"
       footer={
-        <div className="flex gap-3 pt-4">
+        <div className="flex gap-3">
           <Button
             variant="outline"
             label={t("tokenStaging.dismiss")}

--- a/src/components/home/StopConfirmModal.tsx
+++ b/src/components/home/StopConfirmModal.tsx
@@ -18,13 +18,19 @@ export function StopConfirmModal({
   const { t } = useTranslation();
 
   return (
-    <SlideModal isOpen={isOpen} close={onClose} title={t("create.nfc.confirm")}>
-      <div className="flex flex-col gap-4 p-4">
-        <p className="text-center">{description ?? t("stopPlaying")}</p>
+    <SlideModal
+      isOpen={isOpen}
+      close={onClose}
+      title={t("create.nfc.confirm")}
+      footer={
         <div className="flex flex-row justify-center gap-4">
           <Button label={t("nav.cancel")} variant="outline" onClick={onClose} />
           <Button label={t("yes")} intent="primary" onClick={onConfirm} />
         </div>
+      }
+    >
+      <div className="p-4">
+        <p className="text-center">{description ?? t("stopPlaying")}</p>
       </div>
     </SlideModal>
   );

--- a/src/components/library/FavoriteButton.tsx
+++ b/src/components/library/FavoriteButton.tsx
@@ -14,7 +14,7 @@ import type { MediaBrowseEntry, TagInfo } from "@/lib/models";
 import { useStatusStore } from "@/lib/store";
 import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 import { useCoreFeature } from "@/hooks/useCoreFeature";
-import { Button } from "@/components/wui/Button";
+import { Button, type ButtonLayout } from "@/components/wui/Button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
 export function FavoriteButton(props: {
@@ -24,6 +24,9 @@ export function FavoriteButton(props: {
   metadataTags?: TagInfo[];
   className?: string;
   iconOnly?: boolean;
+  displayLabel?: string;
+  layout?: ButtonLayout;
+  variant?: "fill" | "outline" | "text";
 }) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -91,8 +94,6 @@ export function FavoriteButton(props: {
     },
   });
 
-  if (!feature.available) return null;
-
   const actionLabel = mutation.isPending
     ? t("library.updatingFavorite")
     : favorite
@@ -101,7 +102,7 @@ export function FavoriteButton(props: {
 
   return (
     <Button
-      label={props.iconOnly ? undefined : actionLabel}
+      label={props.iconOnly ? undefined : (props.displayLabel ?? actionLabel)}
       aria-label={actionLabel}
       icon={
         mutation.isPending ? (
@@ -110,10 +111,13 @@ export function FavoriteButton(props: {
           <Heart size={20} fill={favorite ? "currentColor" : "none"} />
         )
       }
-      variant="outline"
+      variant={props.variant ?? "outline"}
       size={props.iconOnly ? "lg" : "default"}
+      layout={props.layout}
       aria-pressed={favorite}
-      disabled={!connected || !canUpdate || mutation.isPending}
+      disabled={
+        !feature.available || !connected || !canUpdate || mutation.isPending
+      }
       onClick={() => mutation.mutate(!favorite)}
       className={props.className ?? (props.iconOnly ? undefined : "w-full")}
     />

--- a/src/components/library/LibraryArtwork.tsx
+++ b/src/components/library/LibraryArtwork.tsx
@@ -6,6 +6,7 @@ import { requestLibraryImage } from "@/lib/libraryImages";
 import { LIBRARY_QUERY_KEYS, mediaRefKey } from "@/lib/libraryMedia";
 import type { MediaBrowseEntry } from "@/lib/models";
 import { Skeleton } from "@/components/ui/skeleton";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { DelayedLoading } from "@/components/DelayedLoading";
 
 export function LibraryArtwork(props: {
@@ -70,11 +71,19 @@ export function LibraryArtwork(props: {
   if (enabled && imageQuery.isLoading) {
     return (
       <span
-        className={`${props.className ?? ""} block overflow-hidden bg-white/5`}
+        className={`${props.className ?? ""} flex items-center justify-center overflow-hidden bg-white/5`}
         aria-hidden="true"
       >
         <DelayedLoading>
-          <Skeleton className="h-full w-full" />
+          {props.priority === "detail" ? (
+            <LoadingSpinner
+              size={20}
+              className="text-muted-foreground"
+              decorative
+            />
+          ) : (
+            <Skeleton className="h-full w-full" />
+          )}
         </DelayedLoading>
       </span>
     );

--- a/src/components/library/LibraryMediaDetailsModal.tsx
+++ b/src/components/library/LibraryMediaDetailsModal.tsx
@@ -25,9 +25,10 @@ import { showRateLimitedErrorToast } from "@/lib/toastUtils";
 import { SlideModal } from "@/components/SlideModal";
 import { TagBadge } from "@/components/TagBadge";
 import { Button } from "@/components/wui/Button";
+import { ModalActionRail } from "@/components/wui/ModalActionRail";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { DelayedLoading } from "@/components/DelayedLoading";
-import { NfcIcon } from "@/lib/images";
+import { CreateIcon } from "@/lib/images";
 import { LibraryArtwork } from "@/components/library/LibraryArtwork";
 import { FavoriteButton } from "@/components/library/FavoriteButton";
 
@@ -113,16 +114,32 @@ export function LibraryMediaDetailsModal(props: {
   const writeControllerRef = useRef<AbortController | null>(null);
   const previousImageButtonRef = useRef<HTMLButtonElement>(null);
   const nextImageButtonRef = useRef<HTMLButtonElement>(null);
-  const entry = props.entry;
+  const [retainedSelection, setRetainedSelection] = useState<{
+    entry: MediaBrowseEntry;
+    systemId: string;
+  } | null>(() =>
+    props.entry ? { entry: props.entry, systemId: props.systemId } : null,
+  );
+  const entry = props.entry ?? retainedSelection?.entry ?? null;
+  const systemId = props.entry
+    ? props.systemId
+    : (retainedSelection?.systemId ?? props.systemId);
+
+  useEffect(() => {
+    if (!props.entry) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Preserve full sheet content while its close transition runs.
+    setRetainedSelection({ entry: props.entry, systemId: props.systemId });
+  }, [props.entry, props.systemId]);
+
   const metadataQuery = useQuery({
     queryKey: [
       LIBRARY_QUERY_KEYS.meta,
       props.deviceKey,
-      ...(entry ? mediaRefKey(entry, props.systemId) : [null, "", ""]),
+      ...(entry ? mediaRefKey(entry, systemId) : [null, "", ""]),
     ],
     queryFn: ({ signal }) => {
       if (!entry) throw new Error("Media selection is unavailable");
-      return fetchLibraryMediaMeta(entry, props.systemId, signal);
+      return fetchLibraryMediaMeta(entry, systemId, signal);
     },
     enabled: props.isOpen && entry !== null,
     staleTime: 5 * 60 * 1000,
@@ -210,7 +227,7 @@ export function LibraryMediaDetailsModal(props: {
     try {
       const text = await resolveLibraryLaunchText(
         entry,
-        props.systemId,
+        systemId,
         controller.signal,
       );
       if (!text) throw new Error("Launch target could not be resolved");
@@ -240,7 +257,7 @@ export function LibraryMediaDetailsModal(props: {
     try {
       const text = await resolveLibraryLaunchText(
         entry,
-        props.systemId,
+        systemId,
         controller.signal,
       );
       if (!text) throw new Error("Write target could not be resolved");
@@ -278,8 +295,8 @@ export function LibraryMediaDetailsModal(props: {
     (fact) => fact.type !== "year" && fact.type !== "players",
   );
   const resolvedSystemName = resolveSystemName(
-    metadata?.title.system.id || props.systemId,
-    metadata?.title.system.name || props.systemId,
+    metadata?.title.system.id || systemId,
+    metadata?.title.system.name || systemId,
   );
   const numericPlayers = Number(players);
   const playersSummary = players
@@ -313,67 +330,75 @@ export function LibraryMediaDetailsModal(props: {
       });
     }
   };
+  const footer = entry ? (
+    <ModalActionRail
+      aria-label={t("library.mediaActions")}
+      actions={
+        <>
+          <FavoriteButton
+            entry={entry}
+            fallbackSystemId={systemId}
+            deviceKey={props.deviceKey}
+            metadataTags={metadata?.tags}
+            displayLabel={t("library.favorite")}
+            layout="responsive"
+            variant="text"
+            className="w-full whitespace-nowrap"
+          />
+          <Button
+            label={t("library.writeAction")}
+            aria-label={
+              preparingWrite ? t("library.preparingWrite") : t("library.write")
+            }
+            icon={
+              preparingWrite ? (
+                <LoadingSpinner size={20} decorative />
+              ) : (
+                <CreateIcon size="20" />
+              )
+            }
+            layout="responsive"
+            variant="text"
+            className="whitespace-nowrap"
+            disabled={!writeAvailable || preparingWrite || launching}
+            onClick={() => void write()}
+          />
+        </>
+      }
+      primaryAction={
+        <Button
+          label={launching ? t("library.launching") : t("library.launch")}
+          icon={
+            launching ? (
+              <LoadingSpinner size={20} decorative />
+            ) : (
+              <PlayIcon size={20} />
+            )
+          }
+          intent="primary"
+          disabled={!connected || launching || preparingWrite}
+          onClick={() => void launch()}
+        />
+      }
+    />
+  ) : undefined;
 
   return (
     <SlideModal
       isOpen={props.isOpen}
       close={closeModal}
       title={title}
-      fixedHeight="85vh"
+      footer={footer}
+      footerSkipLabel={t("accessibility.skipToActions")}
     >
       {entry && (
         <div className="flex flex-col gap-4 py-2">
-          <div className="flex items-center gap-2">
-            <Button
-              label={launching ? t("library.launching") : t("library.launch")}
-              icon={
-                launching ? (
-                  <LoadingSpinner size={20} decorative />
-                ) : (
-                  <PlayIcon size={20} />
-                )
-              }
-              size="lg"
-              intent="primary"
-              disabled={!connected || launching || preparingWrite}
-              onClick={() => void launch()}
-              className="min-h-12 flex-1"
-            />
-            <FavoriteButton
-              entry={entry}
-              fallbackSystemId={props.systemId}
-              deviceKey={props.deviceKey}
-              metadataTags={metadata?.tags}
-              iconOnly
-            />
-            {writeAvailable && (
-              <Button
-                icon={
-                  preparingWrite ? (
-                    <LoadingSpinner size={20} decorative />
-                  ) : (
-                    <NfcIcon size="20" />
-                  )
-                }
-                size="lg"
-                variant="outline"
-                aria-label={
-                  preparingWrite
-                    ? t("library.preparingWrite")
-                    : t("library.write")
-                }
-                disabled={preparingWrite || launching}
-                onClick={() => void write()}
-              />
-            )}
-          </div>
-
           {imageAvailable !== false && (
             <div className="flex flex-col gap-2">
               <div className="relative h-64 w-full">
                 <LibraryArtwork
                   entry={entry}
-                  systemId={props.systemId}
+                  systemId={systemId}
                   deviceKey={props.deviceKey}
                   maxSize={512}
                   priority="detail"

--- a/src/components/library/LibraryMediaOptionsModal.tsx
+++ b/src/components/library/LibraryMediaOptionsModal.tsx
@@ -30,6 +30,15 @@ export function LibraryMediaOptionsModal(props: {
       isOpen={props.isOpen}
       close={props.close}
       title={t("library.optionsTitle")}
+      footer={
+        <Button
+          label={t("library.goToTitle")}
+          variant="outline"
+          className="w-full"
+          disabled={!props.canGoToLetter}
+          onClick={props.onGoToLetter}
+        />
+      }
     >
       <div className="flex flex-col gap-5 py-3">
         <section className="flex flex-col gap-2">
@@ -70,17 +79,6 @@ export function LibraryMediaOptionsModal(props: {
             })}
           </div>
         </section>
-
-        {props.canGoToLetter && (
-          <section className="border-t border-white/25 pt-4">
-            <Button
-              label={t("library.goToTitle")}
-              variant="outline"
-              className="w-full"
-              onClick={props.onGoToLetter}
-            />
-          </section>
-        )}
       </div>
     </SlideModal>
   );

--- a/src/components/library/LibrarySystemFiltersModal.tsx
+++ b/src/components/library/LibrarySystemFiltersModal.tsx
@@ -1,11 +1,12 @@
 import { useId } from "react";
-import { Check } from "lucide-react";
+import { Check, RotateCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import type { SystemReleasePeriod, SystemSort } from "@/lib/systemFilters";
 import { handleRadioGroupKeyDown } from "@/lib/radioGroup";
 import { SlideModal } from "@/components/SlideModal";
 import { Button } from "@/components/wui/Button";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
 import { useHapticPress } from "@/hooks/useHapticPress";
 
 const SORT_OPTIONS: Array<{ value: SystemSort; labelKey: string }> = [
@@ -52,21 +53,24 @@ export function LibrarySystemFiltersModal(props: {
     props.sort !== "name-asc";
 
   const footer = (
-    <div className="border-border flex gap-3 border-t pt-3">
-      <Button
-        label={t("library.resetOptions")}
-        variant="outline"
-        className="flex-1"
-        disabled={!hasDraftOptions}
-        onClick={props.onReset}
-      />
-      <Button
-        label={t("library.showSystems", { count: props.resultCount })}
-        className="flex-1"
-        intent="primary"
-        onClick={props.onApply}
-      />
-    </div>
+    <ModalActionBar
+      secondaryAction={
+        <Button
+          label={t("library.resetOptions")}
+          icon={<RotateCcw size={20} />}
+          variant="outline"
+          disabled={!hasDraftOptions}
+          onClick={props.onReset}
+        />
+      }
+      primaryAction={
+        <Button
+          label={t("library.showSystems", { count: props.resultCount })}
+          intent="primary"
+          onClick={props.onApply}
+        />
+      }
+    />
   );
 
   return (

--- a/src/components/wui/Button.tsx
+++ b/src/components/wui/Button.tsx
@@ -2,11 +2,14 @@ import classNames from "classnames";
 import { ReactElement, useState, memo, useRef, forwardRef } from "react";
 import { useHapticPress } from "@/hooks/useHapticPress";
 
+export type ButtonLayout = "inline" | "stacked" | "responsive";
+
 interface ButtonProps {
   onClick?: () => void;
   label?: string;
   variant?: "fill" | "outline" | "text";
   size?: "default" | "sm" | "lg";
+  layout?: ButtonLayout;
   /** Semantic intent for haptic feedback: default (light), primary (medium), destructive (heavy) */
   intent?: "default" | "primary" | "destructive";
   icon?: ReactElement;
@@ -28,6 +31,7 @@ export const Button = memo(
   forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
     const variant = props.variant || "fill";
     const size = props.size || "default";
+    const layout = props.layout || "inline";
     const [isPressed, setIsPressed] = useState(false);
     const touchStartPos = useRef<{ x: number; y: number } | null>(null);
     const hasMoved = useRef(false);
@@ -55,12 +59,15 @@ export const Button = memo(
         tabIndex={props.decorative ? -1 : undefined}
         className={classNames(
           "flex",
-          "flex-row",
           "items-center",
           "justify-center",
           "font-medium",
-          "gap-2",
           "tracking-[0.1px]",
+          {
+            "flex-row gap-2": layout === "inline",
+            "flex-col gap-1": layout === "stacked",
+            "flex-col gap-1 sm:flex-row sm:gap-2": layout === "responsive",
+          },
           "cursor-pointer",
           "transition-all",
           "duration-100",
@@ -93,9 +100,10 @@ export const Button = memo(
           },
           // Label padding
           {
-            "px-4": props.label && size === "sm",
-            "px-6": props.label && size === "default",
-            "px-8": props.label && size === "lg",
+            "px-4": props.label && size === "sm" && layout === "inline",
+            "px-6": props.label && size === "default" && layout === "inline",
+            "px-8": props.label && size === "lg" && layout === "inline",
+            "px-2": props.label && layout !== "inline",
           },
           // Rounded corners
           {
@@ -169,7 +177,11 @@ export const Button = memo(
         onMouseUp={() => setIsPressed(false)}
         onMouseLeave={() => setIsPressed(false)}
       >
-        {props.icon}
+        {props.icon && (
+          <span className="flex shrink-0 items-center" aria-hidden="true">
+            {props.icon}
+          </span>
+        )}
         {props.label}
       </button>
     );

--- a/src/components/wui/ModalActionBar.tsx
+++ b/src/components/wui/ModalActionBar.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+interface ModalActionBarProps {
+  secondaryAction?: ReactNode;
+  primaryAction: ReactNode;
+}
+
+export function ModalActionBar({
+  secondaryAction,
+  primaryAction,
+}: ModalActionBarProps) {
+  if (!secondaryAction) {
+    return <div className="[&>*]:min-h-12 [&>*]:w-full">{primaryAction}</div>;
+  }
+
+  return (
+    <div className="flex gap-2">
+      <div className="min-w-0 flex-1 [&>*]:min-h-12 [&>*]:w-full">
+        {secondaryAction}
+      </div>
+      <div className="min-w-0 flex-1 [&>*]:min-h-12 [&>*]:w-full">
+        {primaryAction}
+      </div>
+    </div>
+  );
+}

--- a/src/components/wui/ModalActionBar.tsx
+++ b/src/components/wui/ModalActionBar.tsx
@@ -9,7 +9,11 @@ export function ModalActionBar({
   secondaryAction,
   primaryAction,
 }: ModalActionBarProps) {
-  if (!secondaryAction) {
+  if (
+    secondaryAction === null ||
+    secondaryAction === undefined ||
+    secondaryAction === false
+  ) {
     return <div className="[&>*]:min-h-12 [&>*]:w-full">{primaryAction}</div>;
   }
 

--- a/src/components/wui/ModalActionRail.tsx
+++ b/src/components/wui/ModalActionRail.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+interface ModalActionRailProps {
+  actions: ReactNode;
+  primaryAction: ReactNode;
+  "aria-label": string;
+}
+
+export function ModalActionRail({
+  actions,
+  primaryAction,
+  "aria-label": ariaLabel,
+}: ModalActionRailProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[minmax(0,auto)_minmax(12rem,1fr)]">
+      <div className="min-w-0 overflow-hidden">
+        <div
+          role="group"
+          aria-label={ariaLabel}
+          className="overflow-x-auto overscroll-x-contain pb-1 sm:pb-0"
+        >
+          <div className="grid min-w-full auto-cols-[minmax(5.5rem,1fr)] grid-flow-col gap-1 sm:min-w-0 [&>*]:min-h-14 [&>*]:w-full [&>*]:min-w-0 sm:[&>*]:min-h-12">
+            {actions}
+          </div>
+        </div>
+      </div>
+      <div className="min-w-0 [&>*]:min-h-12 [&>*]:w-full">{primaryAction}</div>
+    </div>
+  );
+}

--- a/src/components/wui/ModalActionRail.tsx
+++ b/src/components/wui/ModalActionRail.tsx
@@ -17,7 +17,7 @@ export function ModalActionRail({
         <div
           role="group"
           aria-label={ariaLabel}
-          className="overflow-x-auto overscroll-x-contain pb-1 sm:pb-0"
+          className="overflow-x-auto overscroll-x-contain py-1"
         >
           <div className="grid min-w-full auto-cols-[minmax(5.5rem,1fr)] grid-flow-col gap-1 sm:min-w-0 [&>*]:min-h-14 [&>*]:w-full [&>*]:min-w-0 sm:[&>*]:min-h-12">
             {actions}

--- a/src/components/wui/SettingHelp.tsx
+++ b/src/components/wui/SettingHelp.tsx
@@ -1,11 +1,6 @@
 import { useState, useMemo, type ReactNode } from "react";
 import { HelpCircleIcon } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 
 /**
  * Parses simple markdown-like formatting in text.
@@ -70,14 +65,9 @@ export function SettingHelp({
         <HelpCircleIcon size={18} />
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent onOpenChange={setOpen}>
-          <DialogHeader>
-            <DialogTitle>{title}</DialogTitle>
-          </DialogHeader>
-          <div className="text-muted-foreground">{formattedDescription}</div>
-        </DialogContent>
-      </Dialog>
+      <SlideModal isOpen={open} close={() => setOpen(false)} title={title}>
+        <div className="text-muted-foreground py-2">{formattedDescription}</div>
+      </SlideModal>
     </>
   );
 }

--- a/src/components/wui/SettingHelp.tsx
+++ b/src/components/wui/SettingHelp.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { HelpCircleIcon } from "lucide-react";
 import { SlideModal } from "@/components/SlideModal";
 
@@ -53,6 +53,7 @@ export function SettingHelp({
     () => parseFormattedText(description),
     [description],
   );
+  const close = useCallback(() => setOpen(false), []);
 
   return (
     <>
@@ -65,7 +66,7 @@ export function SettingHelp({
         <HelpCircleIcon size={18} />
       </button>
 
-      <SlideModal isOpen={open} close={() => setOpen(false)} title={title}>
+      <SlideModal isOpen={open} close={close} title={title}>
         <div className="text-muted-foreground py-2">{formattedDescription}</div>
       </SlideModal>
     </>

--- a/src/hooks/useSlideModalManager.ts
+++ b/src/hooks/useSlideModalManager.ts
@@ -1,9 +1,18 @@
 import { createContext, useContext } from "react";
 
+export interface SlideModalRegistrationOptions {
+  blocking?: boolean;
+}
+
 export interface SlideModalManager {
-  registerModal: (id: string, closeFunction: () => void) => void;
+  registerModal: (
+    id: string,
+    closeFunction: () => void,
+    options?: SlideModalRegistrationOptions,
+  ) => void;
   unregisterModal: (id: string) => void;
-  closeAllExcept: (exceptId: string) => void;
+  /** Closes existing modals, or rejects opening when another modal is blocking. */
+  closeAllExcept: (exceptId: string) => boolean;
 }
 
 export const SlideModalContext = createContext<SlideModalManager | null>(null);

--- a/src/routes/-pages/DeviceDetail.tsx
+++ b/src/routes/-pages/DeviceDetail.tsx
@@ -208,9 +208,7 @@ export function DeviceDetail() {
           if (!forgetting) setConfirmOpen(false);
         }}
         title={t("settings.deviceDetail.forgetTitle")}
-      >
-        <div className="flex flex-col gap-4 py-4">
-          <p className="text-center">{t("settings.deviceDetail.forgetBody")}</p>
+        footer={
           <div className="flex gap-2">
             <Button
               variant="outline"
@@ -230,6 +228,10 @@ export function DeviceDetail() {
               }
             />
           </div>
+        }
+      >
+        <div className="py-4">
+          <p className="text-center">{t("settings.deviceDetail.forgetBody")}</p>
         </div>
       </SlideModal>
     </PageFrame>

--- a/src/routes/-pages/Devices.tsx
+++ b/src/routes/-pages/Devices.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Pencil } from "lucide-react";
+import { ListChecks, Pencil, X } from "lucide-react";
 import { useConnection } from "@/hooks/useConnection";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useSelectDevice } from "@/hooks/useSelectDevice";
@@ -10,16 +11,22 @@ import {
   credentialStore,
 } from "@/lib/crypto/credentials";
 import {
+  deviceRegistry,
   parsedEndpointForRecord,
   useDeviceRegistry,
   type DeviceRecord,
 } from "@/lib/devices/deviceRegistry";
 import type { ParsedDeviceEndpoint } from "@/lib/devices/endpoint";
+import { invalidateLibraryImageCache } from "@/lib/libraryImageCache";
 import { logger } from "@/lib/logger";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
 import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
+import { Button } from "@/components/wui/Button";
 import { EmptyState } from "@/components/wui/EmptyState";
+import { ModalActionBar } from "@/components/wui/ModalActionBar";
+import { SlideModal } from "@/components/SlideModal";
+import { Checkbox } from "@/components/ui/checkbox";
 import { DelayedLoading } from "@/components/DelayedLoading";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { BackIcon } from "@/lib/images";
@@ -52,6 +59,7 @@ export function Devices() {
     t("settings.deviceHistory"),
   );
   const router = useRouter();
+  const queryClient = useQueryClient();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
 
@@ -69,6 +77,13 @@ export function Devices() {
 
   const { selectRecord } = useSelectDevice();
   const [pairedKeys, setPairedKeys] = useState<Set<string>>(new Set());
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectedRecordIds, setSelectedRecordIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [combineOpen, setCombineOpen] = useState(false);
+  const [combineFailed, setCombineFailed] = useState(false);
+  const [isCombining, setIsCombining] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -123,9 +138,94 @@ export function Devices() {
     (record.legacyCredentialKey !== undefined &&
       pairedKeys.has(record.legacyCredentialKey));
 
+  const toggleSelected = (recordId: string) => {
+    setSelectedRecordIds((current) => {
+      const next = new Set(current);
+      if (next.has(recordId)) {
+        next.delete(recordId);
+      } else if (next.size < 2) {
+        next.add(recordId);
+      }
+      return next;
+    });
+  };
+
   const handleSelect = (recordId: string) => {
+    if (isEditing) {
+      toggleSelected(recordId);
+      return;
+    }
     void selectRecord(recordId);
     router.navigate({ to: "/settings" });
+  };
+
+  const closeEditMode = () => {
+    if (isCombining) return;
+    setIsEditing(false);
+    setSelectedRecordIds(new Set());
+    setCombineOpen(false);
+    setCombineFailed(false);
+  };
+
+  const selectedRecords = [...selectedRecordIds]
+    .map((recordId) => records[recordId])
+    .filter((record): record is DeviceRecord => record !== undefined);
+  const combineTarget =
+    selectedRecords.find((record) => record.recordId === activeRecordId) ??
+    selectedRecords.find(hasCredentials) ??
+    selectedRecords[0];
+  const combineSource = selectedRecords.find(
+    (record) => record.recordId !== combineTarget?.recordId,
+  );
+
+  const handleConfirmCombine = async () => {
+    if (!combineTarget || !combineSource || isCombining) return;
+    setIsCombining(true);
+    setCombineFailed(false);
+    const mergedPairing =
+      hasCredentials(combineTarget) || hasCredentials(combineSource);
+    try {
+      await deviceRegistry.mergeRecords(
+        combineTarget.recordId,
+        combineSource.recordId,
+      );
+      for (const recordId of [combineTarget.recordId, combineSource.recordId]) {
+        invalidateLibraryImageCache(recordId);
+        queryClient.removeQueries({
+          predicate: (query) => query.queryKey.includes(recordId),
+        });
+      }
+      setPairedKeys((current) => {
+        const next = new Set(current);
+        next.delete(credentialKeyForRecord(combineTarget.recordId));
+        next.delete(credentialKeyForRecord(combineSource.recordId));
+        if (combineTarget.legacyCredentialKey) {
+          next.delete(combineTarget.legacyCredentialKey);
+        }
+        if (combineSource.legacyCredentialKey) {
+          next.delete(combineSource.legacyCredentialKey);
+        }
+        if (mergedPairing) {
+          next.add(credentialKeyForRecord(combineTarget.recordId));
+        }
+        return next;
+      });
+      setIsEditing(false);
+      setSelectedRecordIds(new Set());
+      setCombineOpen(false);
+      setCombineFailed(false);
+    } catch (error) {
+      logger.error("Failed to combine device records", error, {
+        category: "storage",
+        action: "combineDeviceRecords",
+        severity: "error",
+        targetRecordId: combineTarget.recordId,
+        sourceRecordId: combineSource.recordId,
+      });
+      setCombineFailed(true);
+    } finally {
+      setIsCombining(false);
+    }
   };
 
   return (
@@ -142,6 +242,27 @@ export function Devices() {
         <h1 ref={headingRef} className="text-foreground text-xl">
           {t("settings.deviceHistory")}
         </h1>
+      }
+      headerRight={
+        sortedRecords.length >= 2 ? (
+          <HeaderButton
+            onClick={() => {
+              if (isEditing) {
+                closeEditMode();
+              } else {
+                setIsEditing(true);
+              }
+            }}
+            icon={isEditing ? <X size={20} /> : <ListChecks size={20} />}
+            aria-label={t(
+              isEditing
+                ? "settings.deviceCombine.cancelEdit"
+                : "settings.deviceCombine.edit",
+            )}
+            active={isEditing}
+            disabled={isCombining}
+          />
+        ) : undefined
       }
     >
       <div className="flex flex-col gap-3 pt-2">
@@ -178,19 +299,94 @@ export function Devices() {
               isPaired={hasCredentials(record)}
               onSelect={() => handleSelect(record.recordId)}
               rightSlot={
-                <Link
-                  to="/settings/devices/$recordId"
-                  params={{ recordId: record.recordId }}
-                  aria-label={t("settings.deviceDetails")}
-                  className="bg-background border-bd-outline focus-visible:ring-offset-background flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-solid px-1.5 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:outline-none"
-                >
-                  <Pencil size={18} />
-                </Link>
+                isEditing ? (
+                  <Checkbox
+                    checked={selectedRecordIds.has(record.recordId)}
+                    onCheckedChange={() => toggleSelected(record.recordId)}
+                    aria-label={t("settings.deviceCombine.select", {
+                      device: record.name || endpoint.address,
+                    })}
+                    disabled={
+                      selectedRecordIds.size >= 2 &&
+                      !selectedRecordIds.has(record.recordId)
+                    }
+                  />
+                ) : (
+                  <Link
+                    to="/settings/devices/$recordId"
+                    params={{ recordId: record.recordId }}
+                    aria-label={t("settings.deviceDetails")}
+                    className="bg-background border-bd-outline focus-visible:ring-offset-background flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-solid px-1.5 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:outline-none"
+                  >
+                    <Pencil size={18} />
+                  </Link>
+                )
               }
             />
           ))
         )}
+        {isEditing && sortedRecords.length > 0 && (
+          <Button
+            label={t("settings.deviceCombine.action")}
+            intent="primary"
+            onClick={() => {
+              setCombineFailed(false);
+              setCombineOpen(true);
+            }}
+            disabled={selectedRecordIds.size !== 2}
+            className="mt-3 w-full"
+          />
+        )}
       </div>
+
+      <SlideModal
+        isOpen={combineOpen}
+        close={() => {
+          if (!isCombining) setCombineOpen(false);
+        }}
+        dismissible={!isCombining}
+        title={t("settings.deviceCombine.title")}
+        footer={
+          <ModalActionBar
+            secondaryAction={
+              <Button
+                variant="outline"
+                label={t("settings.deviceCombine.cancel")}
+                onClick={() => setCombineOpen(false)}
+                disabled={isCombining}
+              />
+            }
+            primaryAction={
+              <Button
+                intent="primary"
+                label={t("settings.deviceCombine.confirm")}
+                onClick={() => void handleConfirmCombine()}
+                disabled={isCombining}
+              />
+            }
+          />
+        }
+      >
+        <div className="flex flex-col gap-4 py-4">
+          <p className="text-center">
+            {t("settings.deviceCombine.body", {
+              first:
+                combineTarget?.name ??
+                parsedEndpointForRecord(combineTarget)?.address ??
+                "",
+              second:
+                combineSource?.name ??
+                parsedEndpointForRecord(combineSource)?.address ??
+                "",
+            })}
+          </p>
+          {combineFailed && (
+            <p className="text-error text-center text-sm" role="alert">
+              {t("settings.deviceCombine.failed")}
+            </p>
+          )}
+        </div>
+      </SlideModal>
     </PageFrame>
   );
 }

--- a/src/routes/-pages/Devices.tsx
+++ b/src/routes/-pages/Devices.tsx
@@ -195,14 +195,25 @@ export function Devices() {
           predicate: (query) => query.queryKey.includes(recordId),
         });
       }
+      const referencedLegacyKeys = new Set(
+        Object.values(deviceRegistry.getSnapshot().records)
+          .map((record) => record.legacyCredentialKey)
+          .filter((key): key is string => key !== undefined),
+      );
       setPairedKeys((current) => {
         const next = new Set(current);
         next.delete(credentialKeyForRecord(combineTarget.recordId));
         next.delete(credentialKeyForRecord(combineSource.recordId));
-        if (combineTarget.legacyCredentialKey) {
+        if (
+          combineTarget.legacyCredentialKey &&
+          !referencedLegacyKeys.has(combineTarget.legacyCredentialKey)
+        ) {
           next.delete(combineTarget.legacyCredentialKey);
         }
-        if (combineSource.legacyCredentialKey) {
+        if (
+          combineSource.legacyCredentialKey &&
+          !referencedLegacyKeys.has(combineSource.legacyCredentialKey)
+        ) {
           next.delete(combineSource.legacyCredentialKey);
         }
         if (mergedPairing) {

--- a/src/routes/-pages/Devices.tsx
+++ b/src/routes/-pages/Devices.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { ListChecks, Pencil, X } from "lucide-react";
+import { Pencil } from "lucide-react";
 import { useConnection } from "@/hooks/useConnection";
 import { usePageHeadingFocus } from "@/hooks/usePageHeadingFocus";
 import { useSelectDevice } from "@/hooks/useSelectDevice";
@@ -11,21 +10,16 @@ import {
   credentialStore,
 } from "@/lib/crypto/credentials";
 import {
-  deviceRegistry,
   parsedEndpointForRecord,
   useDeviceRegistry,
   type DeviceRecord,
 } from "@/lib/devices/deviceRegistry";
 import type { ParsedDeviceEndpoint } from "@/lib/devices/endpoint";
-import { invalidateLibraryImageCache } from "@/lib/libraryImageCache";
 import { logger } from "@/lib/logger";
 import { appBackNavigationOptions } from "@/lib/tabSessionStore";
 import { PageFrame } from "@/components/PageFrame";
 import { HeaderButton } from "@/components/wui/HeaderButton";
-import { Button } from "@/components/wui/Button";
 import { EmptyState } from "@/components/wui/EmptyState";
-import { SlideModal } from "@/components/SlideModal";
-import { Checkbox } from "@/components/ui/checkbox";
 import { DelayedLoading } from "@/components/DelayedLoading";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { BackIcon } from "@/lib/images";
@@ -58,7 +52,6 @@ export function Devices() {
     t("settings.deviceHistory"),
   );
   const router = useRouter();
-  const queryClient = useQueryClient();
   const goBack = () =>
     void router.navigate(appBackNavigationOptions("/settings"));
 
@@ -76,13 +69,6 @@ export function Devices() {
 
   const { selectRecord } = useSelectDevice();
   const [pairedKeys, setPairedKeys] = useState<Set<string>>(new Set());
-  const [isEditing, setIsEditing] = useState(false);
-  const [selectedRecordIds, setSelectedRecordIds] = useState<Set<string>>(
-    new Set(),
-  );
-  const [combineOpen, setCombineOpen] = useState(false);
-  const [combineFailed, setCombineFailed] = useState(false);
-  const [isCombining, setIsCombining] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -137,94 +123,9 @@ export function Devices() {
     (record.legacyCredentialKey !== undefined &&
       pairedKeys.has(record.legacyCredentialKey));
 
-  const toggleSelected = (recordId: string) => {
-    setSelectedRecordIds((current) => {
-      const next = new Set(current);
-      if (next.has(recordId)) {
-        next.delete(recordId);
-      } else if (next.size < 2) {
-        next.add(recordId);
-      }
-      return next;
-    });
-  };
-
   const handleSelect = (recordId: string) => {
-    if (isEditing) {
-      toggleSelected(recordId);
-      return;
-    }
     void selectRecord(recordId);
     router.navigate({ to: "/settings" });
-  };
-
-  const closeEditMode = () => {
-    if (isCombining) return;
-    setIsEditing(false);
-    setSelectedRecordIds(new Set());
-    setCombineOpen(false);
-    setCombineFailed(false);
-  };
-
-  const selectedRecords = [...selectedRecordIds]
-    .map((recordId) => records[recordId])
-    .filter((record): record is DeviceRecord => record !== undefined);
-  const combineTarget =
-    selectedRecords.find((record) => record.recordId === activeRecordId) ??
-    selectedRecords.find(hasCredentials) ??
-    selectedRecords[0];
-  const combineSource = selectedRecords.find(
-    (record) => record.recordId !== combineTarget?.recordId,
-  );
-
-  const handleConfirmCombine = async () => {
-    if (!combineTarget || !combineSource || isCombining) return;
-    setIsCombining(true);
-    setCombineFailed(false);
-    const mergedPairing =
-      hasCredentials(combineTarget) || hasCredentials(combineSource);
-    try {
-      await deviceRegistry.mergeRecords(
-        combineTarget.recordId,
-        combineSource.recordId,
-      );
-      for (const recordId of [combineTarget.recordId, combineSource.recordId]) {
-        invalidateLibraryImageCache(recordId);
-        queryClient.removeQueries({
-          predicate: (query) => query.queryKey.includes(recordId),
-        });
-      }
-      setPairedKeys((current) => {
-        const next = new Set(current);
-        next.delete(credentialKeyForRecord(combineTarget.recordId));
-        next.delete(credentialKeyForRecord(combineSource.recordId));
-        if (combineTarget.legacyCredentialKey) {
-          next.delete(combineTarget.legacyCredentialKey);
-        }
-        if (combineSource.legacyCredentialKey) {
-          next.delete(combineSource.legacyCredentialKey);
-        }
-        if (mergedPairing) {
-          next.add(credentialKeyForRecord(combineTarget.recordId));
-        }
-        return next;
-      });
-      setIsEditing(false);
-      setSelectedRecordIds(new Set());
-      setCombineOpen(false);
-      setCombineFailed(false);
-    } catch (error) {
-      logger.error("Failed to combine device records", error, {
-        category: "storage",
-        action: "combineDeviceRecords",
-        severity: "error",
-        targetRecordId: combineTarget.recordId,
-        sourceRecordId: combineSource.recordId,
-      });
-      setCombineFailed(true);
-    } finally {
-      setIsCombining(false);
-    }
   };
 
   return (
@@ -241,27 +142,6 @@ export function Devices() {
         <h1 ref={headingRef} className="text-foreground text-xl">
           {t("settings.deviceHistory")}
         </h1>
-      }
-      headerRight={
-        sortedRecords.length >= 2 ? (
-          <HeaderButton
-            onClick={() => {
-              if (isEditing) {
-                closeEditMode();
-              } else {
-                setIsEditing(true);
-              }
-            }}
-            icon={isEditing ? <X size={20} /> : <ListChecks size={20} />}
-            aria-label={t(
-              isEditing
-                ? "settings.deviceCombine.cancelEdit"
-                : "settings.deviceCombine.edit",
-            )}
-            active={isEditing}
-            disabled={isCombining}
-          />
-        ) : undefined
       }
     >
       <div className="flex flex-col gap-3 pt-2">
@@ -298,89 +178,19 @@ export function Devices() {
               isPaired={hasCredentials(record)}
               onSelect={() => handleSelect(record.recordId)}
               rightSlot={
-                isEditing ? (
-                  <Checkbox
-                    checked={selectedRecordIds.has(record.recordId)}
-                    onCheckedChange={() => toggleSelected(record.recordId)}
-                    aria-label={t("settings.deviceCombine.select", {
-                      device: record.name || endpoint.address,
-                    })}
-                    disabled={
-                      selectedRecordIds.size >= 2 &&
-                      !selectedRecordIds.has(record.recordId)
-                    }
-                  />
-                ) : (
-                  <Link
-                    to="/settings/devices/$recordId"
-                    params={{ recordId: record.recordId }}
-                    aria-label={t("settings.deviceDetails")}
-                    className="bg-background border-bd-outline focus-visible:ring-offset-background flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-solid px-1.5 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:outline-none"
-                  >
-                    <Pencil size={18} />
-                  </Link>
-                )
+                <Link
+                  to="/settings/devices/$recordId"
+                  params={{ recordId: record.recordId }}
+                  aria-label={t("settings.deviceDetails")}
+                  className="bg-background border-bd-outline focus-visible:ring-offset-background flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-solid px-1.5 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                  <Pencil size={18} />
+                </Link>
               }
             />
           ))
         )}
-        {isEditing && sortedRecords.length > 0 && (
-          <Button
-            label={t("settings.deviceCombine.action")}
-            intent="primary"
-            onClick={() => {
-              setCombineFailed(false);
-              setCombineOpen(true);
-            }}
-            disabled={selectedRecordIds.size !== 2}
-            className="mt-3 w-full"
-          />
-        )}
       </div>
-
-      <SlideModal
-        isOpen={combineOpen}
-        close={() => {
-          if (!isCombining) setCombineOpen(false);
-        }}
-        title={t("settings.deviceCombine.title")}
-      >
-        <div className="flex flex-col gap-4 py-4">
-          <p className="text-center">
-            {t("settings.deviceCombine.body", {
-              first:
-                combineTarget?.name ??
-                parsedEndpointForRecord(combineTarget)?.address ??
-                "",
-              second:
-                combineSource?.name ??
-                parsedEndpointForRecord(combineSource)?.address ??
-                "",
-            })}
-          </p>
-          {combineFailed && (
-            <p className="text-error text-center text-sm" role="alert">
-              {t("settings.deviceCombine.failed")}
-            </p>
-          )}
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              label={t("settings.deviceCombine.cancel")}
-              onClick={() => setCombineOpen(false)}
-              disabled={isCombining}
-              className="flex-1"
-            />
-            <Button
-              intent="primary"
-              label={t("settings.deviceCombine.confirm")}
-              onClick={() => void handleConfirmCombine()}
-              disabled={isCombining}
-              className="flex-1"
-            />
-          </div>
-        </div>
-      </SlideModal>
     </PageFrame>
   );
 }

--- a/src/routes/-pages/Index.tsx
+++ b/src/routes/-pages/Index.tsx
@@ -74,7 +74,7 @@ export function Index() {
       setWriteIntent(false);
     }
   };
-  const { PurchaseModal, proPurchaseModalOpen, setProPurchaseModalOpen } =
+  const { purchaseModal, proPurchaseModalOpen, setProPurchaseModalOpen } =
     useProPurchase();
 
   const connected = useStatusStore((state) => state.connected);
@@ -362,7 +362,7 @@ export function Index() {
         isOpen={remoteKeyboardOpen}
         close={() => setRemoteKeyboardOpen(false)}
       />
-      <PurchaseModal />
+      {purchaseModal}
       <StopConfirmModal
         isOpen={stopTarget !== null}
         onClose={() => setStopTarget(null)}

--- a/src/routes/-pages/MappingEditor.tsx
+++ b/src/routes/-pages/MappingEditor.tsx
@@ -420,11 +420,7 @@ export function MappingEditor({ id }: MappingEditorProps) {
         isOpen={confirmOpen}
         close={() => setConfirmOpen(false)}
         title={t("create.mappings.editor.deleteConfirmTitle")}
-      >
-        <div className="flex flex-col gap-4 py-4">
-          <p className="text-center">
-            {t("create.mappings.editor.deleteConfirmBody")}
-          </p>
+        footer={
           <div className="flex gap-2">
             <Button
               variant="outline"
@@ -442,6 +438,12 @@ export function MappingEditor({ id }: MappingEditorProps) {
               className="border-error text-error flex-1"
             />
           </div>
+        }
+      >
+        <div className="py-4">
+          <p className="text-center">
+            {t("create.mappings.editor.deleteConfirmBody")}
+          </p>
         </div>
       </SlideModal>
     </>

--- a/src/routes/settings.advanced.tsx
+++ b/src/routes/settings.advanced.tsx
@@ -233,11 +233,7 @@ export function AdvancedSettings() {
         isOpen={showErrorReportingModal}
         close={() => setShowErrorReportingModal(false)}
         title={t("settings.advanced.errorReportingConfirmTitle")}
-      >
-        <div className="flex flex-col gap-4 p-4">
-          <p className="text-center">
-            {t("settings.advanced.errorReportingConfirmText")}
-          </p>
+        footer={
           <div className="flex flex-row justify-center gap-4">
             <Button
               label={t("nav.cancel")}
@@ -251,6 +247,12 @@ export function AdvancedSettings() {
               disabled={!canWriteCoreSettings}
             />
           </div>
+        }
+      >
+        <div className="p-4">
+          <p className="text-center">
+            {t("settings.advanced.errorReportingConfirmText")}
+          </p>
         </div>
       </SlideModal>
     </PageFrame>

--- a/src/routes/settings.index.tsx
+++ b/src/routes/settings.index.tsx
@@ -42,7 +42,7 @@ export function Settings() {
     t("settings.title"),
   );
 
-  const { PurchaseModal, setProPurchaseModalOpen, proAccess } =
+  const { purchaseModal, setProPurchaseModalOpen, proAccess } =
     useProPurchase();
 
   const connectionError = useStatusStore((state) => state.connectionError);
@@ -315,7 +315,7 @@ export function Settings() {
         </div>
       </PageFrame>
 
-      <PurchaseModal />
+      {purchaseModal}
     </>
   );
 }

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -41,12 +41,7 @@ import {
   MfaAuthentication,
   type MfaSignInResult,
 } from "@/lib/mfaAuthentication";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { SlideModal } from "@/components/SlideModal";
 import {
   getPurchasePreviewState,
   usePurchasePreviewStore,
@@ -521,6 +516,12 @@ export function OnlinePage() {
     }
   };
 
+  const closeDeleteModal = () => {
+    if (isDeleting) return;
+    setDeleteModalOpen(false);
+    setConfirmText("");
+  };
+
   const handleDeleteAccount = async () => {
     setIsDeleting(true);
     try {
@@ -984,70 +985,58 @@ export function OnlinePage() {
       </div>
 
       {/* Delete account confirmation modal */}
-      <Dialog
-        open={deleteModalOpen}
-        onOpenChange={(open) => {
-          setDeleteModalOpen(open);
-          if (!open) setConfirmText("");
-        }}
-      >
-        <DialogContent
-          onOpenChange={(open) => {
-            setDeleteModalOpen(open);
-            if (!open) setConfirmText("");
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t("online.deleteAccountConfirmTitle")}</DialogTitle>
-          </DialogHeader>
-          <div className="flex flex-col gap-4">
-            <p className="text-muted-foreground text-sm">
-              {t("online.deleteAccountConfirmMessage")}
-            </p>
-            <p className="text-muted-foreground text-sm">
-              {t("online.deleteAccountGracePeriod")}
-            </p>
-            <div>
-              <label
-                htmlFor="delete-account-confirmation"
-                className="text-sm text-white"
-              >
-                {t("online.deleteConfirmLabel")}
-              </label>
-              <input
-                id="delete-account-confirmation"
-                type="text"
-                value={confirmText}
-                onChange={(e) => setConfirmText(e.target.value)}
-                placeholder="DELETE MY ACCOUNT"
-                className="border-bd-input bg-background text-foreground mt-1 w-full rounded-md border p-3"
-              />
-            </div>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                label={t("nav.cancel")}
-                onClick={() => {
-                  setDeleteModalOpen(false);
-                  setConfirmText("");
-                }}
-                className="flex-1"
-                disabled={isDeleting}
-              />
-              <Button
-                variant="outline"
-                intent="destructive"
-                label={
-                  isDeleting ? t("spinner.deleting") : t("online.deleteAccount")
-                }
-                onClick={handleDeleteAccount}
-                className="border-error text-error flex-1"
-                disabled={isDeleting || confirmText !== "DELETE MY ACCOUNT"}
-              />
-            </div>
+      <SlideModal
+        isOpen={deleteModalOpen}
+        close={closeDeleteModal}
+        dismissible={!isDeleting}
+        title={t("online.deleteAccountConfirmTitle")}
+        footer={
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              label={t("nav.cancel")}
+              onClick={closeDeleteModal}
+              className="flex-1"
+              disabled={isDeleting}
+            />
+            <Button
+              variant="outline"
+              intent="destructive"
+              label={
+                isDeleting ? t("spinner.deleting") : t("online.deleteAccount")
+              }
+              onClick={handleDeleteAccount}
+              className="border-error text-error flex-1"
+              disabled={isDeleting || confirmText !== "DELETE MY ACCOUNT"}
+            />
           </div>
-        </DialogContent>
-      </Dialog>
+        }
+      >
+        <div className="flex flex-col gap-4 py-2">
+          <p className="text-muted-foreground text-sm">
+            {t("online.deleteAccountConfirmMessage")}
+          </p>
+          <p className="text-muted-foreground text-sm">
+            {t("online.deleteAccountGracePeriod")}
+          </p>
+          <div>
+            <label
+              htmlFor="delete-account-confirmation"
+              className="text-sm text-white"
+            >
+              {t("online.deleteConfirmLabel")}
+            </label>
+            <input
+              id="delete-account-confirmation"
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE MY ACCOUNT"
+              className="border-bd-input bg-background text-foreground mt-1 w-full rounded-md border p-3"
+            />
+          </div>
+        </div>
+      </SlideModal>
     </PageFrame>
   );
 }

--- a/src/routes/settings.readers.tsx
+++ b/src/routes/settings.readers.tsx
@@ -113,7 +113,7 @@ export function ReadersSettings() {
 
   const shakeSystem = getSystemFromZapscript();
 
-  const { PurchaseModal, setProPurchaseModalOpen } = useProPurchase();
+  const { purchaseModal, setProPurchaseModalOpen } = useProPurchase();
 
   const router = useRouter();
   const goBack = () =>
@@ -557,7 +557,7 @@ export function ReadersSettings() {
         includeAllOption={true}
       />
 
-      <PurchaseModal />
+      {purchaseModal}
     </PageFrame>
   );
 }

--- a/src/translations/de-DE.json
+++ b/src/translations/de-DE.json
@@ -44,6 +44,14 @@
       "run": "Ausführen",
       "mainNavigation": "Hauptnavigation"
     },
+    "appBadge": {
+      "title": "Kennzeichen auf dem App-Symbol",
+      "description": "Zaparoo kann die Anzahl der Nachrichten im Posteingang auf dem App-Symbol anzeigen. iOS bezeichnet dies als Mitteilungsberechtigung, Zaparoo fordert jedoch nur die Berechtigung zum Aktualisieren des Kennzeichens an. Mitteilungen und Töne werden nicht angefordert.",
+      "noThanks": "Nein, danke",
+      "continue": "Weiter",
+      "requesting": "Wird angefordert...",
+      "deniedDescription": "Kennzeichen für das App-Symbol sind in den iOS-Einstellungen blockiert. Öffne die Einstellungen, wähle Zaparoo und aktiviere dann Mitteilungen und Kennzeichen."
+    },
     "library": {
       "title": "Bibliothek",
       "collections": "Sammlungen",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "Füge Favoriten über die Mediendetails hinzu.",
       "searchFavorites": "Favoriten durchsuchen",
       "favorite": "Favorit",
+      "mediaActions": "Medienaktionen",
       "addFavorite": "Zu Favoriten hinzufügen",
       "removeFavorite": "Aus Favoriten entfernen",
       "updatingFavorite": "Favorit wird aktualisiert...",
@@ -130,6 +139,7 @@
       "launch": "Starten",
       "launchError": "Dieses Medium konnte nicht gestartet werden",
       "write": "Auf NFC-Tag schreiben",
+      "writeAction": "Schreiben",
       "preparingWrite": "NFC-Schreibvorgang wird vorbereitet...",
       "writeError": "Dieses Medium konnte nicht zum Schreiben vorbereitet werden",
       "optionsTitle": "Bibliotheksoptionen",
@@ -169,6 +179,7 @@
       "notSupportedSub": "Du kannst in dieser App keine NFC-Lese- oder Schreibfunktionen verwenden",
       "nfcDisabledLabel": "NFC-Zugriff deaktiviert",
       "nfcDisabledSub": "Aktiviere bitte den NFC-Zugriff in den Geräteeinstellungen, um NFC lesen und schreiben zu können",
+      "openNfcSettings": "NFC-Einstellungen öffnen",
       "holdTag": "Tag an das Telefon halten",
       "holdTagReader": "Tag an das Lesegerät halten",
       "scanning": "Wird gescannt",
@@ -207,6 +218,7 @@
     },
     "accessibility": {
       "skipToContent": "Zum Hauptinhalt springen",
+      "skipToActions": "Zu den Aktionen springen",
       "logo": "Zaparoo-Logo"
     },
     "tokenStaging": {
@@ -309,6 +321,7 @@
         "writeLabel": "Auf Tag schreiben",
         "copyLabel": "Kopieren",
         "playLabel": "Vorschau",
+        "mediaActions": "Medienaktionen",
         "selectSystem": "System auswählen",
         "selectTags": "Tags auswählen",
         "loading": "Wird geladen...",
@@ -488,6 +501,7 @@
           "deletedSuccess": "Zuordnung gelöscht",
           "saveFailed": "Zuordnung konnte nicht gespeichert werden",
           "deleteFailed": "Zuordnung konnte nicht gelöscht werden",
+          "cameraPermissionDenied": "Der Kamerazugriff ist deaktiviert. Aktiviere ihn in den Systemeinstellungen.",
           "notFound": "Zuordnung nicht gefunden"
         }
       }
@@ -662,9 +676,10 @@
     },
     "requirements": {
       "title": "Einrichtung abschließen",
-      "tosLabel": "Ich stimme Folgendem zu:",
+      "legalLabel": "Ich akzeptiere die Nutzungsbedingungen und die Datenschutzerklärung",
+      "legalPrefix": "Ich akzeptiere die",
+      "legalAnd": "und die",
       "tosLink": "Nutzungsbedingungen",
-      "privacyLabel": "Ich stimme Folgendem zu:",
       "privacyLink": "Datenschutzerklärung",
       "ageLabel": "Ich bin mindestens 13 Jahre alt",
       "sendVerificationEmail": "Bestätigungs-E-Mail senden",
@@ -679,6 +694,7 @@
       "emailVerified": "E-Mail-Adresse bestätigt",
       "saved": "Gespeichert",
       "save": "Speichern",
+      "continue": "Zustimmen und fortfahren",
       "logout": "Abmelden"
     },
     "settings": {
@@ -696,6 +712,7 @@
       "updateDb.status.ready": "Datenbank ist bereit",
       "updateDb.status.optimizing": "Datenbank wird optimiert (einsatzbereit)",
       "updateDb.status.paused": "Pausiert",
+      "updateDb.status.throttled": "Läuft mit reduzierter Geschwindigkeit",
       "updateDb.status.reconnecting": "Verbindung wird wiederhergestellt...",
       "updateDb.status.mediaCount": "Datenbank bereit: {{formattedCount}} Medientitel",
       "updateDb.status.noConnection": "Nicht verbunden",
@@ -719,6 +736,7 @@
       "scrapeMedia": "Medienmetadaten abrufen",
       "scrapeMedia.cancel": "Abbrechen",
       "scrapeMedia.starting": "Wird gestartet...",
+      "scrapeMedia.startError": "Medien-Scraping konnte nicht gestartet werden",
       "scrapeMedia.scraperPlaceholder": "Scraper auswählen",
       "scrapeMedia.allSystems": "Alle Systeme",
       "scrapeMedia.selectSystemsTitle": "Zu scrapende Systeme auswählen",
@@ -727,6 +745,7 @@
       "scrapeMedia.preparing": "Scraping wird vorbereitet",
       "scrapeMedia.activeTitle": "Medien werden gescrapt",
       "scrapeMedia.activeDescription": "Metadaten für das aktuelle System werden gescrapt",
+      "scrapeMedia.viewDetails": "Details anzeigen",
       "scrapeMedia.lastScrapeTitle": "Letztes Scraping",
       "scrapeMedia.currentSystem": "Aktuelles System",
       "scrapeMedia.systemProgressCount": "{{current}} / {{total}} Systeme",
@@ -742,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "Die Mediendatenbank wird aktualisiert. Scraping ist bis zum Abschluss nicht verfügbar.",
       "scrapeMedia.stats": "{{matched}} zugeordnet, {{skipped}} übersprungen",
       "scrapeMedia.done": "Scraping abgeschlossen: {{matched}} zugeordnet, {{skipped}} übersprungen",
+      "scrapeMedia.failed": "Scraping fehlgeschlagen",
+      "scrapeMedia.cancelled": "Scraping abgebrochen",
       "scrapeMedia.status.noConnection": "Nicht verbunden",
       "scrapeMedia.status.paused": "Pausiert",
+      "scrapeMedia.status.throttled": "Läuft mit reduzierter Geschwindigkeit",
       "scrapeMedia.status.reconnecting": "Verbindung wird wiederhergestellt...",
       "scrapeMedia.status.totalScraped": "{{formattedCount}} Mediendatensätze gescrapt",
       "scrapeMedia.force": "Bereits gescrapte Medien erneut scrapen",
@@ -773,6 +795,8 @@
         "searching": "Geräte werden gesucht...",
         "stillSearching": "Suche läuft weiter...",
         "noDevices": "Keine Geräte gefunden",
+        "addresses_one": "IP-Adresse: {{addresses}}",
+        "addresses_other": "IP-Adressen: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "Verbindung zum Gerät konnte nicht hergestellt werden",
@@ -783,6 +807,8 @@
       },
       "enterDeviceAddress": "Geräteadresse eingeben",
       "deviceHistoryEmpty": "Noch keine gespeicherten Geräte.",
+      "deviceHistoryError": "Gespeicherte Geräte konnten nicht geladen werden.",
+      "deviceHistoryLoading": "Gespeicherte Geräte werden geladen...",
       "deviceDetails": "Gerätedetails",
       "activeDevice": "Aktives Gerät",
       "deviceDetail": {
@@ -798,7 +824,19 @@
         "forgetTitle": "Dieses Gerät vergessen?",
         "forgetBody": "Dadurch wird es aus deinen gespeicherten Geräten entfernt und die Kopplungsdaten werden gelöscht.",
         "forgetCancel": "Abbrechen",
-        "forgetConfirm": "Gerät vergessen"
+        "forgetConfirm": "Gerät vergessen",
+        "forgetFailed": "Das Gerät konnte nicht vergessen werden. Versuche es erneut."
+      },
+      "deviceCombine": {
+        "edit": "Geräte zusammenführen",
+        "cancelEdit": "Auswahl abbrechen",
+        "select": "{{device}} auswählen",
+        "action": "Ausgewählte zusammenführen",
+        "title": "Geräte zusammenführen?",
+        "body": "{{first}} und {{second}} zusammenführen? Gespeicherte Adressen und Kopplungsdaten bleiben erhalten.",
+        "cancel": "Abbrechen",
+        "confirm": "Zusammenführen",
+        "failed": "Geräte konnten nicht zusammengeführt werden. Es wurde nichts entfernt."
       },
       "about": {
         "title": "Über",
@@ -857,6 +895,8 @@
         "debugLoggingHelp": "Aktiviert ausführlichere Protokolldateien auf dem verbundenen Gerät. Dies kann bei der Fehlerbehebung hilfreich sein.",
         "showFilenames": "Dateinamen für Medien anzeigen",
         "showFilenamesHelp": "Zeige in den Suchergebnissen der App den vollständigen Dateinamen eines Mediums statt der bereinigten Version an. Dies kann hilfreich sein, wenn deine Dateinamen viele benutzerdefinierte Tags enthalten.",
+        "appIconBadges": "Kennzeichen auf dem App-Symbol",
+        "appIconBadgesHelp": "Zeige die Anzahl der ungelesenen Posteingangsnachrichten auf dem App-Symbol an. iOS fragt möglicherweise nach der Mitteilungsberechtigung, da Kennzeichen über die Mitteilungseinstellungen verwaltet werden.",
         "purchasePreview": "Kaufvorschau",
         "purchasePreviewLive": "Live-Status",
         "purchasePreviewFree": "Kostenloses Konto",

--- a/src/translations/en-GB.json
+++ b/src/translations/en-GB.json
@@ -44,6 +44,14 @@
       "run": "Run",
       "mainNavigation": "Main navigation"
     },
+    "appBadge": {
+      "title": "App icon badges",
+      "description": "Zaparoo can show the number of inbox messages on its app icon. iOS describes this as notification permission, but Zaparoo only requests permission to update the badge. It does not request notification alerts or sounds.",
+      "noThanks": "No thanks",
+      "continue": "Continue",
+      "requesting": "Requesting...",
+      "deniedDescription": "App icon badges are blocked in iOS Settings. Open Settings, select Zaparoo, then enable Notifications and Badges."
+    },
     "library": {
       "title": "Library",
       "collections": "Collections",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "Add favourites from media details.",
       "searchFavorites": "Search favourites",
       "favorite": "Favourite",
+      "mediaActions": "Media actions",
       "addFavorite": "Add to Favourites",
       "removeFavorite": "Remove from Favourites",
       "updatingFavorite": "Updating favourite...",
@@ -130,6 +139,7 @@
       "launch": "Launch",
       "launchError": "Could not launch this media",
       "write": "Write to NFC tag",
+      "writeAction": "Write",
       "preparingWrite": "Preparing NFC write...",
       "writeError": "Could not prepare this media for writing",
       "optionsTitle": "Library options",
@@ -169,6 +179,7 @@
       "notSupportedSub": "You will not be able to use any NFC reading or writing features in this app",
       "nfcDisabledLabel": "NFC access disabled",
       "nfcDisabledSub": "Please enable NFC access in your device settings for NFC reading and writing features",
+      "openNfcSettings": "Open NFC settings",
       "holdTag": "Hold tag to phone",
       "holdTagReader": "Hold tag to reader",
       "scanning": "Scanning",
@@ -207,6 +218,7 @@
     },
     "accessibility": {
       "skipToContent": "Skip to main content",
+      "skipToActions": "Skip to actions",
       "logo": "Zaparoo logo"
     },
     "tokenStaging": {
@@ -309,6 +321,7 @@
         "writeLabel": "Write to tag",
         "copyLabel": "Copy",
         "playLabel": "Preview",
+        "mediaActions": "Media actions",
         "selectSystem": "Select System",
         "selectTags": "Select Tags",
         "loading": "Loading...",
@@ -488,6 +501,7 @@
           "deletedSuccess": "Mapping deleted",
           "saveFailed": "Failed to save mapping",
           "deleteFailed": "Failed to delete mapping",
+          "cameraPermissionDenied": "Camera access is disabled. Enable it in system settings.",
           "notFound": "Mapping not found"
         }
       }
@@ -662,9 +676,10 @@
     },
     "requirements": {
       "title": "Complete Setup",
-      "tosLabel": "I agree to the",
+      "legalLabel": "I agree to the Terms of Service and Privacy Policy",
+      "legalPrefix": "I agree to the",
+      "legalAnd": "and",
       "tosLink": "Terms of Service",
-      "privacyLabel": "I agree to the",
       "privacyLink": "Privacy Policy",
       "ageLabel": "I'm 13 years or older",
       "sendVerificationEmail": "Send Verification Email",
@@ -679,6 +694,7 @@
       "emailVerified": "Email verified",
       "saved": "Saved",
       "save": "Save",
+      "continue": "Agree & continue",
       "logout": "Log Out"
     },
     "settings": {
@@ -696,6 +712,7 @@
       "updateDb.status.ready": "Database is ready",
       "updateDb.status.optimizing": "Optimising database (ready to use)",
       "updateDb.status.paused": "Paused",
+      "updateDb.status.throttled": "Running at reduced speed",
       "updateDb.status.reconnecting": "Reconnecting...",
       "updateDb.status.mediaCount": "Database ready: {{formattedCount}} media titles",
       "updateDb.status.noConnection": "Not connected",
@@ -719,6 +736,7 @@
       "scrapeMedia": "Scrape media metadata",
       "scrapeMedia.cancel": "Cancel",
       "scrapeMedia.starting": "Starting...",
+      "scrapeMedia.startError": "Failed to start media scrape",
       "scrapeMedia.scraperPlaceholder": "Select a scraper",
       "scrapeMedia.allSystems": "All systems",
       "scrapeMedia.selectSystemsTitle": "Select systems to scrape",
@@ -727,6 +745,7 @@
       "scrapeMedia.preparing": "Preparing scrape",
       "scrapeMedia.activeTitle": "Scraping media",
       "scrapeMedia.activeDescription": "Scraping metadata for the current system",
+      "scrapeMedia.viewDetails": "View details",
       "scrapeMedia.lastScrapeTitle": "Last scrape",
       "scrapeMedia.currentSystem": "Current system",
       "scrapeMedia.systemProgressCount": "{{current}} / {{total}} systems",
@@ -742,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "Media database update is running. Scraping is unavailable until it finishes.",
       "scrapeMedia.stats": "{{matched}} matched, {{skipped}} skipped",
       "scrapeMedia.done": "Scrape complete: {{matched}} matched, {{skipped}} skipped",
+      "scrapeMedia.failed": "Scrape failed",
+      "scrapeMedia.cancelled": "Scrape cancelled",
       "scrapeMedia.status.noConnection": "Not connected",
       "scrapeMedia.status.paused": "Paused",
+      "scrapeMedia.status.throttled": "Running at reduced speed",
       "scrapeMedia.status.reconnecting": "Reconnecting...",
       "scrapeMedia.status.totalScraped": "{{formattedCount}} media records scraped",
       "scrapeMedia.force": "Re-scrape already scraped media",
@@ -773,6 +795,8 @@
         "searching": "Searching for devices...",
         "stillSearching": "Still searching...",
         "noDevices": "No devices found",
+        "addresses_one": "IP address: {{addresses}}",
+        "addresses_other": "IP addresses: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "Unable to connect to device",
@@ -783,6 +807,8 @@
       },
       "enterDeviceAddress": "Enter a device address",
       "deviceHistoryEmpty": "No saved devices yet.",
+      "deviceHistoryError": "Saved devices could not be loaded.",
+      "deviceHistoryLoading": "Loading saved devices...",
       "deviceDetails": "Device details",
       "activeDevice": "Active device",
       "deviceDetail": {
@@ -798,7 +824,19 @@
         "forgetTitle": "Forget this device?",
         "forgetBody": "This will remove it from your saved devices and erase the pairing credentials.",
         "forgetCancel": "Cancel",
-        "forgetConfirm": "Forget device"
+        "forgetConfirm": "Forget device",
+        "forgetFailed": "Device could not be forgotten. Try again."
+      },
+      "deviceCombine": {
+        "edit": "Combine devices",
+        "cancelEdit": "Cancel selection",
+        "select": "Select {{device}}",
+        "action": "Combine selected",
+        "title": "Combine devices?",
+        "body": "Combine {{first}} and {{second}}? Saved addresses and pairing will be kept.",
+        "cancel": "Cancel",
+        "confirm": "Combine",
+        "failed": "Devices could not be combined. Nothing was removed."
       },
       "about": {
         "title": "About",
@@ -857,6 +895,8 @@
         "debugLoggingHelp": "Enables more verbose log files on the connected device. Can be useful for troubleshooting issues.",
         "showFilenames": "Show filenames for media",
         "showFilenamesHelp": "For in-app search results, display media's full filename in the list instead of the cleaned up version. Can be useful if you use a lot of custom tags in your filenames.",
+        "appIconBadges": "App icon badges",
+        "appIconBadgesHelp": "Show the unread inbox count on the app icon. iOS may ask for notification permission because badges are managed through notification settings.",
         "purchasePreview": "Purchase preview",
         "purchasePreviewLive": "Live state",
         "purchasePreviewFree": "Free account",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -65,6 +65,7 @@
       "noFavoritesHint": "Add favorites from media details.",
       "searchFavorites": "Search favorites",
       "favorite": "Favorite",
+      "mediaActions": "Media actions",
       "addFavorite": "Add to Favorites",
       "removeFavorite": "Remove from Favorites",
       "updatingFavorite": "Updating favorite...",
@@ -138,6 +139,7 @@
       "launch": "Launch",
       "launchError": "Could not launch this media",
       "write": "Write to NFC tag",
+      "writeAction": "Write",
       "preparingWrite": "Preparing NFC write...",
       "writeError": "Could not prepare this media for writing",
       "optionsTitle": "Library options",
@@ -215,6 +217,7 @@
     },
     "accessibility": {
       "skipToContent": "Skip to main content",
+      "skipToActions": "Skip to actions",
       "logo": "Zaparoo logo"
     },
     "tokenStaging": {
@@ -317,6 +320,7 @@
         "writeLabel": "Write to tag",
         "copyLabel": "Copy",
         "playLabel": "Preview",
+        "mediaActions": "Media actions",
         "selectSystem": "Select System",
         "selectTags": "Select Tags",
         "loading": "Loading...",
@@ -819,17 +823,6 @@
         "forgetCancel": "Cancel",
         "forgetConfirm": "Forget device",
         "forgetFailed": "Device could not be forgotten. Try again."
-      },
-      "deviceCombine": {
-        "edit": "Combine devices",
-        "cancelEdit": "Cancel selection",
-        "select": "Select {{device}}",
-        "action": "Combine selected",
-        "title": "Combine devices?",
-        "body": "Combine {{first}} and {{second}}? Saved addresses and pairing will be kept.",
-        "cancel": "Cancel",
-        "confirm": "Combine",
-        "failed": "Devices could not be combined. Nothing was removed."
       },
       "about": {
         "title": "About",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -676,11 +676,12 @@
     },
     "requirements": {
       "title": "Complete Setup",
-      "tosLabel": "I agree to the",
+      "legalLabel": "I agree to the Terms of Service and Privacy Policy",
+      "legalPrefix": "I agree to the",
+      "legalAnd": "and",
       "tosLink": "Terms of Service",
-      "privacyLabel": "I agree to the",
       "privacyLink": "Privacy Policy",
-      "ageLabel": "I'm 13 years or older",
+      "ageLabel": "I am 13 years of age or older",
       "sendVerificationEmail": "Send Verification Email",
       "emailSent": "Verification email sent",
       "emailSentMessage": "Check your inbox and click the link, then tap below.",
@@ -693,6 +694,7 @@
       "emailVerified": "Email verified",
       "saved": "Saved",
       "save": "Save",
+      "continue": "Agree & continue",
       "logout": "Log Out"
     },
     "settings": {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -179,6 +179,7 @@
       "notSupportedSub": "You will not be able to use any NFC reading or writing features in this app",
       "nfcDisabledLabel": "NFC access disabled",
       "nfcDisabledSub": "Please enable NFC access in your device settings for NFC reading and writing features",
+      "openNfcSettings": "Open NFC settings",
       "holdTag": "Hold tag to phone",
       "holdTagReader": "Hold tag to reader",
       "scanning": "Scanning",
@@ -823,6 +824,17 @@
         "forgetCancel": "Cancel",
         "forgetConfirm": "Forget device",
         "forgetFailed": "Device could not be forgotten. Try again."
+      },
+      "deviceCombine": {
+        "edit": "Combine devices",
+        "cancelEdit": "Cancel selection",
+        "select": "Select {{device}}",
+        "action": "Combine selected",
+        "title": "Combine devices?",
+        "body": "Combine {{first}} and {{second}}? Saved addresses and pairing will be kept.",
+        "cancel": "Cancel",
+        "confirm": "Combine",
+        "failed": "Devices could not be combined. Nothing was removed."
       },
       "about": {
         "title": "About",

--- a/src/translations/es-ES.json
+++ b/src/translations/es-ES.json
@@ -44,6 +44,14 @@
       "run": "Ejecutar",
       "mainNavigation": "Navegación principal"
     },
+    "appBadge": {
+      "title": "Globos en el icono de la App",
+      "description": "Zaparoo puede mostrar el número de mensajes de la bandeja de entrada en el icono de la App. iOS lo describe como un permiso de notificaciones, pero Zaparoo solo solicita permiso para actualizar el globo. No solicita alertas ni sonidos de notificación.",
+      "noThanks": "No, gracias",
+      "continue": "Continuar",
+      "requesting": "Solicitando...",
+      "deniedDescription": "Los globos del icono de la App están bloqueados en los Ajustes de iOS. Abre Ajustes, selecciona Zaparoo y activa Notificaciones y Globos."
+    },
     "library": {
       "title": "Biblioteca",
       "collections": "Colecciones",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "Añade favoritos desde los detalles del contenido multimedia.",
       "searchFavorites": "Buscar favoritos",
       "favorite": "Favorito",
+      "mediaActions": "Acciones multimedia",
       "addFavorite": "Añadir a favoritos",
       "removeFavorite": "Eliminar de favoritos",
       "updatingFavorite": "Actualizando favorito...",
@@ -130,6 +139,7 @@
       "launch": "Iniciar",
       "launchError": "No se pudo iniciar este contenido multimedia",
       "write": "Escribir en etiqueta NFC",
+      "writeAction": "Escribir",
       "preparingWrite": "Preparando escritura NFC...",
       "writeError": "No se pudo preparar este contenido multimedia para escribirlo",
       "optionsTitle": "Opciones de la biblioteca",
@@ -169,6 +179,7 @@
       "notSupportedSub": "No podrás usar ninguna función de lectura o escritura NFC en esta aplicación",
       "nfcDisabledLabel": "Acceso NFC deshabilitado",
       "nfcDisabledSub": "Habilita el acceso NFC en los ajustes de tu dispositivo para usar las funciones de lectura y escritura NFC",
+      "openNfcSettings": "Abrir ajustes de NFC",
       "holdTag": "Mantén la etiqueta junto al teléfono",
       "holdTagReader": "Mantén la etiqueta junto al lector",
       "scanning": "Escaneando",
@@ -207,6 +218,7 @@
     },
     "accessibility": {
       "skipToContent": "Saltar al contenido principal",
+      "skipToActions": "Saltar a las acciones",
       "logo": "Logotipo de Zaparoo"
     },
     "tokenStaging": {
@@ -309,6 +321,7 @@
         "writeLabel": "Escribir en la etiqueta",
         "copyLabel": "Copiar",
         "playLabel": "Vista previa",
+        "mediaActions": "Acciones multimedia",
         "selectSystem": "Seleccionar sistema",
         "selectTags": "Seleccionar etiquetas",
         "loading": "Cargando...",
@@ -488,6 +501,7 @@
           "deletedSuccess": "Asignación eliminada",
           "saveFailed": "Error al guardar la asignación",
           "deleteFailed": "Error al eliminar la asignación",
+          "cameraPermissionDenied": "El acceso a la cámara está deshabilitado. Habilítalo en los ajustes del sistema.",
           "notFound": "Asignación no encontrada"
         }
       }
@@ -662,9 +676,10 @@
     },
     "requirements": {
       "title": "Completar configuración",
-      "tosLabel": "Acepto los",
+      "legalLabel": "Acepto los Términos del servicio y la Política de privacidad",
+      "legalPrefix": "Acepto los",
+      "legalAnd": "y la",
       "tosLink": "Términos del servicio",
-      "privacyLabel": "Acepto la",
       "privacyLink": "Política de privacidad",
       "ageLabel": "Tengo 13 años o más",
       "sendVerificationEmail": "Enviar correo de verificación",
@@ -679,6 +694,7 @@
       "emailVerified": "Correo electrónico verificado",
       "saved": "Guardado",
       "save": "Guardar",
+      "continue": "Aceptar y continuar",
       "logout": "Cerrar sesión"
     },
     "settings": {
@@ -696,6 +712,7 @@
       "updateDb.status.ready": "La base de datos está lista",
       "updateDb.status.optimizing": "Optimizando la base de datos (lista para usar)",
       "updateDb.status.paused": "En pausa",
+      "updateDb.status.throttled": "Ejecutándose a velocidad reducida",
       "updateDb.status.reconnecting": "Reconectando...",
       "updateDb.status.mediaCount": "Base de datos lista: {{formattedCount}} títulos multimedia",
       "updateDb.status.noConnection": "Sin conexión",
@@ -719,6 +736,7 @@
       "scrapeMedia": "Obtener metadatos multimedia",
       "scrapeMedia.cancel": "Cancelar",
       "scrapeMedia.starting": "Iniciando...",
+      "scrapeMedia.startError": "Error al iniciar la obtención de metadatos multimedia",
       "scrapeMedia.scraperPlaceholder": "Seleccionar proveedor de metadatos",
       "scrapeMedia.allSystems": "Todos los sistemas",
       "scrapeMedia.selectSystemsTitle": "Seleccionar sistemas para obtener metadatos",
@@ -727,6 +745,7 @@
       "scrapeMedia.preparing": "Preparando obtención de metadatos",
       "scrapeMedia.activeTitle": "Obteniendo metadatos multimedia",
       "scrapeMedia.activeDescription": "Obteniendo metadatos del sistema actual",
+      "scrapeMedia.viewDetails": "Ver detalles",
       "scrapeMedia.lastScrapeTitle": "Última obtención",
       "scrapeMedia.currentSystem": "Sistema actual",
       "scrapeMedia.systemProgressCount": "{{current}} / {{total}} sistemas",
@@ -742,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "La base de datos multimedia se está actualizando. No se pueden obtener metadatos hasta que termine.",
       "scrapeMedia.stats": "{{matched}} coincidencias, {{skipped}} omitidos",
       "scrapeMedia.done": "Obtención completada: {{matched}} coincidencias, {{skipped}} omitidos",
+      "scrapeMedia.failed": "Error en la obtención de metadatos",
+      "scrapeMedia.cancelled": "Obtención de metadatos cancelada",
       "scrapeMedia.status.noConnection": "Sin conexión",
       "scrapeMedia.status.paused": "En pausa",
+      "scrapeMedia.status.throttled": "Ejecutándose a velocidad reducida",
       "scrapeMedia.status.reconnecting": "Reconectando...",
       "scrapeMedia.status.totalScraped": "{{formattedCount}} registros multimedia obtenidos",
       "scrapeMedia.force": "Volver a obtener metadatos del contenido multimedia ya procesado",
@@ -773,6 +795,8 @@
         "searching": "Buscando dispositivos...",
         "stillSearching": "Buscando todavía...",
         "noDevices": "No se encontraron dispositivos",
+        "addresses_one": "Dirección IP: {{addresses}}",
+        "addresses_other": "Direcciones IP: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "No se puede conectar al dispositivo",
@@ -783,6 +807,8 @@
       },
       "enterDeviceAddress": "Introduce una dirección de dispositivo",
       "deviceHistoryEmpty": "Aún no hay dispositivos guardados.",
+      "deviceHistoryError": "No se pudieron cargar los dispositivos guardados.",
+      "deviceHistoryLoading": "Cargando dispositivos guardados...",
       "deviceDetails": "Detalles del dispositivo",
       "activeDevice": "Dispositivo activo",
       "deviceDetail": {
@@ -798,7 +824,19 @@
         "forgetTitle": "¿Olvidar este dispositivo?",
         "forgetBody": "Esto lo eliminará de tus dispositivos guardados y borrará las credenciales de emparejamiento.",
         "forgetCancel": "Cancelar",
-        "forgetConfirm": "Olvidar dispositivo"
+        "forgetConfirm": "Olvidar dispositivo",
+        "forgetFailed": "No se pudo olvidar el dispositivo. Inténtalo de nuevo."
+      },
+      "deviceCombine": {
+        "edit": "Combinar dispositivos",
+        "cancelEdit": "Cancelar selección",
+        "select": "Seleccionar {{device}}",
+        "action": "Combinar seleccionados",
+        "title": "¿Combinar dispositivos?",
+        "body": "¿Combinar {{first}} y {{second}}? Se conservarán las direcciones guardadas y el emparejamiento.",
+        "cancel": "Cancelar",
+        "confirm": "Combinar",
+        "failed": "No se pudieron combinar los dispositivos. No se eliminó nada."
       },
       "about": {
         "title": "Acerca de",
@@ -857,6 +895,8 @@
         "debugLoggingHelp": "Genera archivos de registro más detallados en el dispositivo conectado. Puede resultar útil para solucionar problemas.",
         "showFilenames": "Mostrar nombres de archivo del contenido multimedia",
         "showFilenamesHelp": "En los resultados de búsqueda de la aplicación, muestra el nombre de archivo completo del contenido multimedia en la lista en lugar de la versión simplificada. Puede resultar útil si utilizas muchas etiquetas personalizadas en los nombres de archivo.",
+        "appIconBadges": "Globos en el icono de la App",
+        "appIconBadgesHelp": "Muestra el número de mensajes no leídos de la bandeja de entrada en el icono de la App. iOS puede solicitar permiso de notificaciones porque los globos se gestionan mediante los ajustes de notificaciones.",
         "purchasePreview": "Vista previa de compra",
         "purchasePreviewLive": "Estado real",
         "purchasePreviewFree": "Cuenta gratuita",

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -44,6 +44,14 @@
       "run": "Exécuter",
       "mainNavigation": "Navigation principale"
     },
+    "appBadge": {
+      "title": "Badges de l’icône de l’application",
+      "description": "Zaparoo peut afficher le nombre de messages de la boîte de réception sur l’icône de l’application. iOS présente cela comme une autorisation de notification, mais Zaparoo demande uniquement l’autorisation de mettre à jour le badge. L’application ne demande ni alertes ni sons de notification.",
+      "noThanks": "Non merci",
+      "continue": "Continuer",
+      "requesting": "Demande en cours...",
+      "deniedDescription": "Les badges de l’icône de l’application sont bloqués dans les réglages iOS. Ouvrez Réglages, sélectionnez Zaparoo, puis activez Notifications et Pastilles."
+    },
     "library": {
       "title": "Bibliothèque",
       "collections": "Collections",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "Ajoutez des favoris depuis les détails du média.",
       "searchFavorites": "Rechercher dans les favoris",
       "favorite": "Favori",
+      "mediaActions": "Actions du média",
       "addFavorite": "Ajouter aux favoris",
       "removeFavorite": "Retirer des favoris",
       "updatingFavorite": "Mise à jour du favori...",
@@ -130,6 +139,7 @@
       "launch": "Lancer",
       "launchError": "Impossible de lancer ce média",
       "write": "Écrire sur un tag NFC",
+      "writeAction": "Écrire",
       "preparingWrite": "Préparation de l’écriture NFC...",
       "writeError": "Impossible de préparer ce média pour l’écriture",
       "optionsTitle": "Options de la bibliothèque",
@@ -169,6 +179,7 @@
       "notSupportedSub": "Les fonctions de lecture et d’écriture NFC ne seront pas disponibles dans cette application",
       "nfcDisabledLabel": "Accès NFC désactivé",
       "nfcDisabledSub": "Activez l’accès NFC dans les réglages de votre appareil pour utiliser les fonctions de lecture et d’écriture NFC",
+      "openNfcSettings": "Ouvrir les réglages NFC",
       "holdTag": "Maintenez le tag contre le téléphone",
       "holdTagReader": "Maintenez le tag contre le lecteur",
       "scanning": "Scan en cours",
@@ -207,6 +218,7 @@
     },
     "accessibility": {
       "skipToContent": "Aller au contenu principal",
+      "skipToActions": "Aller aux actions",
       "logo": "Logo Zaparoo"
     },
     "tokenStaging": {
@@ -309,6 +321,7 @@
         "writeLabel": "Écrire sur le tag",
         "copyLabel": "Copier",
         "playLabel": "Aperçu",
+        "mediaActions": "Actions du média",
         "selectSystem": "Sélectionner un système",
         "selectTags": "Sélectionner des tags",
         "loading": "Chargement...",
@@ -488,6 +501,7 @@
           "deletedSuccess": "Mappage supprimé",
           "saveFailed": "Échec de l’enregistrement du mappage",
           "deleteFailed": "Échec de la suppression du mappage",
+          "cameraPermissionDenied": "L’accès à l’appareil photo est désactivé. Activez-le dans les réglages système.",
           "notFound": "Mappage introuvable"
         }
       }
@@ -662,9 +676,10 @@
     },
     "requirements": {
       "title": "Terminer la configuration",
-      "tosLabel": "J’accepte les",
+      "legalLabel": "J’accepte les Conditions d’utilisation et la Politique de confidentialité",
+      "legalPrefix": "J’accepte les",
+      "legalAnd": "et la",
       "tosLink": "Conditions d’utilisation",
-      "privacyLabel": "J’accepte la",
       "privacyLink": "Politique de confidentialité",
       "ageLabel": "J’ai au moins 13 ans",
       "sendVerificationEmail": "Envoyer l’e-mail de vérification",
@@ -679,6 +694,7 @@
       "emailVerified": "E-mail vérifié",
       "saved": "Enregistré",
       "save": "Enregistrer",
+      "continue": "Accepter et continuer",
       "logout": "Se déconnecter"
     },
     "settings": {
@@ -696,6 +712,7 @@
       "updateDb.status.ready": "La base de données est prête",
       "updateDb.status.optimizing": "Optimisation de la base de données (prête à l’emploi)",
       "updateDb.status.paused": "En pause",
+      "updateDb.status.throttled": "Fonctionnement à vitesse réduite",
       "updateDb.status.reconnecting": "Reconnexion...",
       "updateDb.status.mediaCount": "Base de données prête : {{formattedCount}} titres multimédias",
       "updateDb.status.noConnection": "Non connecté",
@@ -719,6 +736,7 @@
       "scrapeMedia": "Récupérer les métadonnées des médias",
       "scrapeMedia.cancel": "Annuler",
       "scrapeMedia.starting": "Démarrage...",
+      "scrapeMedia.startError": "Échec du démarrage de la récupération des métadonnées",
       "scrapeMedia.scraperPlaceholder": "Sélectionner une source de métadonnées",
       "scrapeMedia.allSystems": "Tous les systèmes",
       "scrapeMedia.selectSystemsTitle": "Sélectionner les systèmes à traiter",
@@ -727,6 +745,7 @@
       "scrapeMedia.preparing": "Préparation de la récupération",
       "scrapeMedia.activeTitle": "Récupération des métadonnées",
       "scrapeMedia.activeDescription": "Récupération des métadonnées du système actuel",
+      "scrapeMedia.viewDetails": "Afficher les détails",
       "scrapeMedia.lastScrapeTitle": "Dernière récupération",
       "scrapeMedia.currentSystem": "Système actuel",
       "scrapeMedia.systemProgressCount": "Systèmes : {{current}} / {{total}}",
@@ -742,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "La mise à jour de la base de données de médias est en cours. La récupération des métadonnées est indisponible jusqu’à la fin de l’opération.",
       "scrapeMedia.stats": "Correspondances : {{matched}}, éléments ignorés : {{skipped}}",
       "scrapeMedia.done": "Récupération terminée. Correspondances : {{matched}}, éléments ignorés : {{skipped}}",
+      "scrapeMedia.failed": "Échec de la récupération des métadonnées",
+      "scrapeMedia.cancelled": "Récupération des métadonnées annulée",
       "scrapeMedia.status.noConnection": "Non connecté",
       "scrapeMedia.status.paused": "En pause",
+      "scrapeMedia.status.throttled": "Fonctionnement à vitesse réduite",
       "scrapeMedia.status.reconnecting": "Reconnexion...",
       "scrapeMedia.status.totalScraped": "Enregistrements multimédias récupérés : {{formattedCount}}",
       "scrapeMedia.force": "Récupérer à nouveau les métadonnées déjà obtenues",
@@ -773,6 +795,8 @@
         "searching": "Recherche d’appareils...",
         "stillSearching": "Recherche toujours en cours...",
         "noDevices": "Aucun appareil trouvé",
+        "addresses_one": "Adresse IP : {{addresses}}",
+        "addresses_other": "Adresses IP : {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "Impossible de se connecter à l’appareil",
@@ -783,6 +807,8 @@
       },
       "enterDeviceAddress": "Saisissez une adresse d’appareil",
       "deviceHistoryEmpty": "Aucun appareil enregistré.",
+      "deviceHistoryError": "Impossible de charger les appareils enregistrés.",
+      "deviceHistoryLoading": "Chargement des appareils enregistrés...",
       "deviceDetails": "Détails de l’appareil",
       "activeDevice": "Appareil actif",
       "deviceDetail": {
@@ -798,7 +824,19 @@
         "forgetTitle": "Oublier cet appareil ?",
         "forgetBody": "Cette action le supprimera de vos appareils enregistrés et effacera les identifiants d’association.",
         "forgetCancel": "Annuler",
-        "forgetConfirm": "Oublier l’appareil"
+        "forgetConfirm": "Oublier l’appareil",
+        "forgetFailed": "Impossible d’oublier l’appareil. Réessayez."
+      },
+      "deviceCombine": {
+        "edit": "Combiner des appareils",
+        "cancelEdit": "Annuler la sélection",
+        "select": "Sélectionner {{device}}",
+        "action": "Combiner la sélection",
+        "title": "Combiner les appareils ?",
+        "body": "Combiner {{first}} et {{second}} ? Les adresses enregistrées et l’association seront conservées.",
+        "cancel": "Annuler",
+        "confirm": "Combiner",
+        "failed": "Impossible de combiner les appareils. Aucun élément n’a été supprimé."
       },
       "about": {
         "title": "À propos",
@@ -857,6 +895,8 @@
         "debugLoggingHelp": "Active des fichiers journaux plus détaillés sur l’appareil connecté. Peut faciliter le diagnostic des problèmes.",
         "showFilenames": "Afficher les noms de fichiers des médias",
         "showFilenamesHelp": "Dans les résultats de recherche de l’application, affiche le nom de fichier complet du média au lieu de sa version simplifiée. Utile si les noms de vos fichiers contiennent de nombreux tags personnalisés.",
+        "appIconBadges": "Badges de l’icône de l’application",
+        "appIconBadgesHelp": "Afficher le nombre de messages non lus de la boîte de réception sur l’icône de l’application. iOS peut demander l’autorisation d’envoyer des notifications, car les badges sont gérés dans les réglages des notifications.",
         "purchasePreview": "Aperçu des achats",
         "purchasePreviewLive": "État réel",
         "purchasePreviewFree": "Compte gratuit",

--- a/src/translations/ja-JP.json
+++ b/src/translations/ja-JP.json
@@ -44,6 +44,14 @@
       "run": "実行",
       "mainNavigation": "メインナビゲーション"
     },
+    "appBadge": {
+      "title": "アプリアイコンのバッジ",
+      "description": "Zaparooでは、アプリアイコンに受信トレイのメッセージ件数を表示できます。iOSではこれを通知の許可として説明しますが、Zaparooが要求するのはバッジを更新するための許可のみです。通知アラートやサウンドの許可は要求しません。",
+      "noThanks": "今はしない",
+      "continue": "続ける",
+      "requesting": "許可をリクエスト中...",
+      "deniedDescription": "iOSの設定でアプリアイコンのバッジがブロックされています。設定を開いてZaparooを選択し、「通知」と「バッジ」を有効にしてください。"
+    },
     "library": {
       "title": "ライブラリ",
       "collections": "コレクション",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "メディアの詳細からお気に入りに追加できます。",
       "searchFavorites": "お気に入りを検索",
       "favorite": "お気に入り",
+      "mediaActions": "メディア操作",
       "addFavorite": "お気に入りに追加",
       "removeFavorite": "お気に入りから削除",
       "updatingFavorite": "お気に入りを更新中...",
@@ -130,6 +139,7 @@
       "launch": "起動",
       "launchError": "このメディアを起動できませんでした",
       "write": "NFCタグに書き込む",
+      "writeAction": "書き込む",
       "preparingWrite": "NFC書き込みを準備中...",
       "writeError": "このメディアの書き込みを準備できませんでした",
       "optionsTitle": "ライブラリオプション",
@@ -169,6 +179,7 @@
       "notSupportedSub": "このアプリでは、NFCの読み取りや書き込み機能を使用できません",
       "nfcDisabledLabel": "NFCアクセスが無効になっています",
       "nfcDisabledSub": "NFCの読み取りおよび書き込み機能を使用するには、デバイスの設定でNFCアクセスを有効にしてください",
+      "openNfcSettings": "NFC設定を開く",
       "holdTag": "タグをスマートフォンにかざしてください",
       "holdTagReader": "タグをリーダーにかざしてください",
       "scanning": "スキャン中",
@@ -207,6 +218,7 @@
     },
     "accessibility": {
       "skipToContent": "メインコンテンツへスキップ",
+      "skipToActions": "操作へスキップ",
       "logo": "Zaparooのロゴ"
     },
     "tokenStaging": {
@@ -309,6 +321,7 @@
         "writeLabel": "タグに書き込む",
         "copyLabel": "コピー",
         "playLabel": "プレビュー",
+        "mediaActions": "メディア操作",
         "selectSystem": "システムを選択",
         "selectTags": "タグを選択",
         "loading": "読み込み中...",
@@ -488,6 +501,7 @@
           "deletedSuccess": "マッピングを削除しました",
           "saveFailed": "マッピングの保存に失敗しました",
           "deleteFailed": "マッピングの削除に失敗しました",
+          "cameraPermissionDenied": "カメラへのアクセスが無効になっています。システム設定で有効にしてください。",
           "notFound": "マッピングが見つかりません"
         }
       }
@@ -662,9 +676,10 @@
     },
     "requirements": {
       "title": "セットアップを完了",
-      "tosLabel": "以下に同意します",
+      "legalLabel": "利用規約およびプライバシーポリシーに同意します",
+      "legalPrefix": "以下に同意します：",
+      "legalAnd": "および",
       "tosLink": "利用規約",
-      "privacyLabel": "以下に同意します",
       "privacyLink": "プライバシーポリシー",
       "ageLabel": "13歳以上です",
       "sendVerificationEmail": "確認メールを送信",
@@ -679,6 +694,7 @@
       "emailVerified": "メールアドレスを確認しました",
       "saved": "保存しました",
       "save": "保存",
+      "continue": "同意して続ける",
       "logout": "サインアウト"
     },
     "settings": {
@@ -696,6 +712,7 @@
       "updateDb.status.ready": "データベースの準備完了",
       "updateDb.status.optimizing": "データベースを最適化中（使用可能）",
       "updateDb.status.paused": "一時停止中",
+      "updateDb.status.throttled": "低速で実行中",
       "updateDb.status.reconnecting": "再接続中...",
       "updateDb.status.mediaCount": "データベース準備完了: メディアタイトル{{formattedCount}}件",
       "updateDb.status.noConnection": "未接続",
@@ -719,6 +736,7 @@
       "scrapeMedia": "メディアのメタデータをスクレイピング",
       "scrapeMedia.cancel": "キャンセル",
       "scrapeMedia.starting": "開始中...",
+      "scrapeMedia.startError": "メディアのスクレイピングを開始できませんでした",
       "scrapeMedia.scraperPlaceholder": "スクレイパーを選択",
       "scrapeMedia.allSystems": "すべてのシステム",
       "scrapeMedia.selectSystemsTitle": "スクレイピングするシステムを選択",
@@ -727,6 +745,7 @@
       "scrapeMedia.preparing": "スクレイピングを準備中",
       "scrapeMedia.activeTitle": "メディアをスクレイピング中",
       "scrapeMedia.activeDescription": "現在のシステムのメタデータをスクレイピングしています",
+      "scrapeMedia.viewDetails": "詳細を表示",
       "scrapeMedia.lastScrapeTitle": "前回のスクレイピング",
       "scrapeMedia.currentSystem": "現在のシステム",
       "scrapeMedia.systemProgressCount": "{{current}} / {{total}}システム",
@@ -742,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "メディアデータベースを更新中です。完了するまでスクレイピングできません。",
       "scrapeMedia.stats": "一致{{matched}}件、スキップ{{skipped}}件",
       "scrapeMedia.done": "スクレイピング完了: 一致{{matched}}件、スキップ{{skipped}}件",
+      "scrapeMedia.failed": "スクレイピングに失敗しました",
+      "scrapeMedia.cancelled": "スクレイピングをキャンセルしました",
       "scrapeMedia.status.noConnection": "未接続",
       "scrapeMedia.status.paused": "一時停止中",
+      "scrapeMedia.status.throttled": "低速で実行中",
       "scrapeMedia.status.reconnecting": "再接続中...",
       "scrapeMedia.status.totalScraped": "メディアレコード{{formattedCount}}件を取得しました",
       "scrapeMedia.force": "取得済みのメディアも再スクレイピング",
@@ -773,6 +795,8 @@
         "searching": "デバイスを検索中...",
         "stillSearching": "引き続き検索中...",
         "noDevices": "デバイスが見つかりません",
+        "addresses_one": "IPアドレス: {{addresses}}",
+        "addresses_other": "IPアドレス: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "デバイスに接続できません",
@@ -783,6 +807,8 @@
       },
       "enterDeviceAddress": "デバイスアドレスを入力",
       "deviceHistoryEmpty": "保存済みのデバイスはまだありません。",
+      "deviceHistoryError": "保存済みのデバイスを読み込めませんでした。",
+      "deviceHistoryLoading": "保存済みのデバイスを読み込み中...",
       "deviceDetails": "デバイスの詳細",
       "activeDevice": "使用中のデバイス",
       "deviceDetail": {
@@ -798,7 +824,19 @@
         "forgetTitle": "このデバイスを削除しますか？",
         "forgetBody": "保存済みデバイスから削除し、ペアリング認証情報も消去します。",
         "forgetCancel": "キャンセル",
-        "forgetConfirm": "デバイスを削除"
+        "forgetConfirm": "デバイスを削除",
+        "forgetFailed": "デバイスを削除できませんでした。再試行してください。"
+      },
+      "deviceCombine": {
+        "edit": "デバイスを統合",
+        "cancelEdit": "選択をキャンセル",
+        "select": "{{device}}を選択",
+        "action": "選択したデバイスを統合",
+        "title": "デバイスを統合しますか？",
+        "body": "{{first}}と{{second}}を統合しますか？保存済みのアドレスとペアリング情報は保持されます。",
+        "cancel": "キャンセル",
+        "confirm": "統合",
+        "failed": "デバイスを統合できませんでした。何も削除されていません。"
       },
       "about": {
         "title": "このアプリについて",
@@ -857,6 +895,8 @@
         "debugLoggingHelp": "接続中のデバイスで、より詳細なログファイルを有効にします。問題のトラブルシューティングに役立つ場合があります。",
         "showFilenames": "メディアのファイル名を表示",
         "showFilenamesHelp": "アプリ内の検索結果で、整形された名前ではなくメディアの完全なファイル名を一覧に表示します。ファイル名に多数のカスタムタグを使用している場合に便利です。",
+        "appIconBadges": "アプリアイコンのバッジ",
+        "appIconBadgesHelp": "未読の受信トレイ件数をアプリアイコンに表示します。バッジは通知設定で管理されるため、iOSから通知の許可を求められる場合があります。",
         "purchasePreview": "購入状態のプレビュー",
         "purchasePreviewLive": "現在の状態",
         "purchasePreviewFree": "無料アカウント",

--- a/src/translations/ko-KR.json
+++ b/src/translations/ko-KR.json
@@ -44,6 +44,14 @@
       "run": "실행",
       "mainNavigation": "주 탐색"
     },
+    "appBadge": {
+      "title": "앱 아이콘 배지",
+      "description": "Zaparoo는 앱 아이콘에 받은편지함 메시지 수를 표시할 수 있습니다. iOS에서는 이를 알림 권한으로 설명하지만, Zaparoo는 배지를 업데이트할 권한만 요청합니다. 알림 배너나 소리에 대한 권한은 요청하지 않습니다.",
+      "noThanks": "괜찮습니다",
+      "continue": "계속",
+      "requesting": "요청하는 중...",
+      "deniedDescription": "iOS 설정에서 앱 아이콘 배지가 차단되어 있습니다. 설정을 열고 Zaparoo를 선택한 다음 알림 및 배지를 활성화하세요."
+    },
     "library": {
       "title": "라이브러리",
       "collections": "컬렉션",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "미디어 세부 정보에서 즐겨찾기를 추가하세요.",
       "searchFavorites": "즐겨찾기 검색",
       "favorite": "즐겨찾기",
+      "mediaActions": "미디어 작업",
       "addFavorite": "즐겨찾기에 추가",
       "removeFavorite": "즐겨찾기에서 제거",
       "updatingFavorite": "즐겨찾기를 업데이트하는 중...",
@@ -130,6 +139,7 @@
       "launch": "실행",
       "launchError": "이 미디어를 실행하지 못했습니다",
       "write": "NFC 태그에 쓰기",
+      "writeAction": "쓰기",
       "preparingWrite": "NFC 쓰기를 준비하는 중...",
       "writeError": "이 미디어를 쓰도록 준비하지 못했습니다",
       "optionsTitle": "라이브러리 옵션",
@@ -169,6 +179,7 @@
       "notSupportedSub": "이 앱에서 NFC 읽기 또는 쓰기 기능을 사용할 수 없습니다",
       "nfcDisabledLabel": "NFC 접근이 비활성화되었습니다",
       "nfcDisabledSub": "NFC 읽기 및 쓰기 기능을 사용하려면 기기 설정에서 NFC 접근을 활성화하세요",
+      "openNfcSettings": "NFC 설정 열기",
       "holdTag": "휴대전화에 태그를 대세요",
       "holdTagReader": "리더에 태그를 대세요",
       "scanning": "스캔 중",
@@ -206,7 +217,9 @@
       "nfcNotSupported": "이 기기는 NFC를 지원하지 않습니다"
     },
     "accessibility": {
-      "skipToContent": "기본 콘텐츠로 건너뛰기"
+      "skipToContent": "기본 콘텐츠로 건너뛰기",
+      "skipToActions": "작업으로 건너뛰기",
+      "logo": "Zaparoo 로고"
     },
     "tokenStaging": {
       "title": "대기 중인 토큰을 확인할까요?",
@@ -308,6 +321,7 @@
         "writeLabel": "태그에 쓰기",
         "copyLabel": "복사",
         "playLabel": "미리 보기",
+        "mediaActions": "미디어 작업",
         "selectSystem": "시스템 선택",
         "selectTags": "태그 선택",
         "loading": "불러오는 중...",
@@ -487,6 +501,7 @@
           "deletedSuccess": "매핑을 삭제했습니다",
           "saveFailed": "매핑을 저장하지 못했습니다",
           "deleteFailed": "매핑을 삭제하지 못했습니다",
+          "cameraPermissionDenied": "카메라 접근이 비활성화되었습니다. 시스템 설정에서 활성화하세요.",
           "notFound": "매핑을 찾을 수 없습니다"
         }
       }
@@ -661,9 +676,10 @@
     },
     "requirements": {
       "title": "설정 완료",
-      "tosLabel": "다음에 동의합니다:",
+      "legalLabel": "서비스 약관 및 개인정보 처리방침에 동의합니다",
+      "legalPrefix": "다음에 동의합니다:",
+      "legalAnd": "및",
       "tosLink": "서비스 약관",
-      "privacyLabel": "다음에 동의합니다:",
       "privacyLink": "개인정보 처리방침",
       "ageLabel": "만 13세 이상입니다",
       "sendVerificationEmail": "인증 이메일 보내기",
@@ -678,6 +694,7 @@
       "emailVerified": "이메일 인증됨",
       "saved": "저장됨",
       "save": "저장",
+      "continue": "동의하고 계속",
       "logout": "로그아웃"
     },
     "settings": {
@@ -695,6 +712,7 @@
       "updateDb.status.ready": "데이터베이스 준비 완료",
       "updateDb.status.optimizing": "데이터베이스 최적화 중(사용 가능)",
       "updateDb.status.paused": "일시 정지됨",
+      "updateDb.status.throttled": "속도를 낮춰 실행 중",
       "updateDb.status.reconnecting": "다시 연결하는 중...",
       "updateDb.status.mediaCount": "데이터베이스 준비 완료: 미디어 제목 {{formattedCount}}개",
       "updateDb.status.noConnection": "연결되지 않음",
@@ -718,6 +736,7 @@
       "scrapeMedia": "미디어 메타데이터 스크레이핑",
       "scrapeMedia.cancel": "취소",
       "scrapeMedia.starting": "시작하는 중...",
+      "scrapeMedia.startError": "미디어 스크레이핑을 시작하지 못했습니다",
       "scrapeMedia.scraperPlaceholder": "스크레이퍼 선택",
       "scrapeMedia.allSystems": "모든 시스템",
       "scrapeMedia.selectSystemsTitle": "스크레이핑할 시스템 선택",
@@ -726,6 +745,7 @@
       "scrapeMedia.preparing": "스크레이핑 준비 중",
       "scrapeMedia.activeTitle": "미디어 스크레이핑 중",
       "scrapeMedia.activeDescription": "현재 시스템의 메타데이터를 스크레이핑하는 중",
+      "scrapeMedia.viewDetails": "세부 정보 보기",
       "scrapeMedia.lastScrapeTitle": "마지막 스크레이핑",
       "scrapeMedia.currentSystem": "현재 시스템",
       "scrapeMedia.systemProgressCount": "시스템 {{current}} / {{total}}개",
@@ -741,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "미디어 데이터베이스 업데이트가 진행 중입니다. 완료될 때까지 스크레이핑할 수 없습니다.",
       "scrapeMedia.stats": "{{matched}}개 일치, {{skipped}}개 건너뜀",
       "scrapeMedia.done": "스크레이핑 완료: {{matched}}개 일치, {{skipped}}개 건너뜀",
+      "scrapeMedia.failed": "스크레이핑 실패",
+      "scrapeMedia.cancelled": "스크레이핑 취소됨",
       "scrapeMedia.status.noConnection": "연결되지 않음",
       "scrapeMedia.status.paused": "일시 정지됨",
+      "scrapeMedia.status.throttled": "속도를 낮춰 실행 중",
       "scrapeMedia.status.reconnecting": "다시 연결하는 중...",
       "scrapeMedia.status.totalScraped": "미디어 레코드 {{formattedCount}}개 스크레이핑됨",
       "scrapeMedia.force": "이미 스크레이핑한 미디어 다시 스크레이핑",
@@ -772,6 +795,8 @@
         "searching": "기기를 검색하는 중...",
         "stillSearching": "계속 검색하는 중...",
         "noDevices": "기기를 찾을 수 없습니다",
+        "addresses_one": "IP 주소: {{addresses}}",
+        "addresses_other": "IP 주소: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "기기에 연결할 수 없습니다",
@@ -782,6 +807,8 @@
       },
       "enterDeviceAddress": "기기 주소 입력",
       "deviceHistoryEmpty": "저장된 기기가 아직 없습니다.",
+      "deviceHistoryError": "저장된 기기를 불러오지 못했습니다.",
+      "deviceHistoryLoading": "저장된 기기를 불러오는 중...",
       "deviceDetails": "기기 세부 정보",
       "activeDevice": "활성 기기",
       "deviceDetail": {
@@ -797,7 +824,19 @@
         "forgetTitle": "이 기기를 삭제할까요?",
         "forgetBody": "저장된 기기에서 제거하고 페어링 자격 증명을 삭제합니다.",
         "forgetCancel": "취소",
-        "forgetConfirm": "기기 삭제"
+        "forgetConfirm": "기기 삭제",
+        "forgetFailed": "기기를 삭제하지 못했습니다. 다시 시도하세요."
+      },
+      "deviceCombine": {
+        "edit": "기기 통합",
+        "cancelEdit": "선택 취소",
+        "select": "{{device}} 선택",
+        "action": "선택한 기기 통합",
+        "title": "기기를 통합할까요?",
+        "body": "두 기기({{first}}, {{second}})를 통합할까요? 저장된 주소와 페어링 정보는 유지됩니다.",
+        "cancel": "취소",
+        "confirm": "통합",
+        "failed": "기기를 통합하지 못했습니다. 삭제된 항목은 없습니다."
       },
       "about": {
         "title": "정보",
@@ -856,9 +895,12 @@
         "debugLoggingHelp": "연결된 기기에 더 자세한 로그 파일을 생성합니다. 문제 해결에 유용할 수 있습니다.",
         "showFilenames": "미디어 파일명 표시",
         "showFilenamesHelp": "앱 내 검색 결과에서 정리된 이름 대신 미디어의 전체 파일명을 목록에 표시합니다. 파일명에 사용자 지정 태그가 많을 때 유용할 수 있습니다.",
+        "appIconBadges": "앱 아이콘 배지",
+        "appIconBadgesHelp": "앱 아이콘에 읽지 않은 받은편지함 메시지 수를 표시합니다. iOS에서는 배지가 알림 설정을 통해 관리되므로 알림 권한을 요청할 수 있습니다.",
         "purchasePreview": "구매 미리 보기",
         "purchasePreviewLive": "실제 상태",
         "purchasePreviewFree": "무료 계정",
+        "purchasePreviewCheckout": "Warp 결제",
         "purchasePreviewPro": "평생 Pro",
         "purchasePreviewWarp": "Warp 활성화됨",
         "purchasePreviewLoading": "불러오는 중",

--- a/src/translations/nl-NL.json
+++ b/src/translations/nl-NL.json
@@ -44,6 +44,14 @@
       "run": "Uitvoeren",
       "mainNavigation": "Hoofdnavigatie"
     },
+    "appBadge": {
+      "title": "Badges op appicoon",
+      "description": "Zaparoo kan het aantal berichten in de inbox op het appicoon tonen. iOS omschrijft dit als toestemming voor meldingen, maar Zaparoo vraagt alleen toestemming om de badge bij te werken. Er wordt geen toestemming gevraagd voor meldingswaarschuwingen of -geluiden.",
+      "noThanks": "Nee, bedankt",
+      "continue": "Doorgaan",
+      "requesting": "Aanvragen...",
+      "deniedDescription": "Badges op het appicoon zijn geblokkeerd in de iOS-instellingen. Open Instellingen, selecteer Zaparoo en schakel vervolgens Meldingen en Badges in."
+    },
     "library": {
       "title": "Bibliotheek",
       "collections": "Collecties",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "Voeg favorieten toe vanuit de mediadetails.",
       "searchFavorites": "Favorieten zoeken",
       "favorite": "Favoriet",
+      "mediaActions": "Media-acties",
       "addFavorite": "Toevoegen aan favorieten",
       "removeFavorite": "Verwijderen uit favorieten",
       "updatingFavorite": "Favoriet bijwerken...",
@@ -130,6 +139,7 @@
       "launch": "Starten",
       "launchError": "Deze media konden niet worden gestart",
       "write": "Naar NFC-tag schrijven",
+      "writeAction": "Schrijven",
       "preparingWrite": "NFC-schrijfactie voorbereiden...",
       "writeError": "Deze media konden niet worden voorbereid om te schrijven",
       "optionsTitle": "Bibliotheekopties",
@@ -169,6 +179,7 @@
       "notSupportedSub": "Je kunt de NFC-lees- en schrijffuncties in deze app niet gebruiken",
       "nfcDisabledLabel": "NFC-toegang uitgeschakeld",
       "nfcDisabledSub": "Schakel NFC-toegang in de apparaatinstellingen in om NFC te lezen en te schrijven",
+      "openNfcSettings": "NFC-instellingen openen",
       "holdTag": "Houd tag bij telefoon",
       "holdTagReader": "Houd tag bij lezer",
       "scanning": "Scannen",
@@ -206,7 +217,9 @@
       "nfcNotSupported": "NFC wordt niet ondersteund op dit apparaat"
     },
     "accessibility": {
-      "skipToContent": "Naar hoofdinhoud"
+      "skipToContent": "Naar hoofdinhoud",
+      "skipToActions": "Naar acties",
+      "logo": "Zaparoo-logo"
     },
     "tokenStaging": {
       "title": "Klaargezet token bevestigen?",
@@ -308,6 +321,7 @@
         "writeLabel": "Naar tag schrijven",
         "copyLabel": "Kopiëren",
         "playLabel": "Voorbeeld",
+        "mediaActions": "Media-acties",
         "selectSystem": "Systeem selecteren",
         "selectTags": "Tags selecteren",
         "loading": "Laden...",
@@ -487,6 +501,7 @@
           "deletedSuccess": "Mapping verwijderd",
           "saveFailed": "Mapping opslaan mislukt",
           "deleteFailed": "Mapping verwijderen mislukt",
+          "cameraPermissionDenied": "Cameratoegang is uitgeschakeld. Schakel deze in via de systeeminstellingen.",
           "notFound": "Mapping niet gevonden"
         }
       }
@@ -661,9 +676,10 @@
     },
     "requirements": {
       "title": "Installatie voltooien",
-      "tosLabel": "Ik ga akkoord met de",
+      "legalLabel": "Ik ga akkoord met de Servicevoorwaarden en het Privacybeleid",
+      "legalPrefix": "Ik ga akkoord met de",
+      "legalAnd": "en het",
       "tosLink": "Servicevoorwaarden",
-      "privacyLabel": "Ik ga akkoord met het",
       "privacyLink": "Privacybeleid",
       "ageLabel": "Ik ben 13 jaar of ouder",
       "sendVerificationEmail": "Verificatie-e-mail verzenden",
@@ -678,6 +694,7 @@
       "emailVerified": "E-mailadres geverifieerd",
       "saved": "Opgeslagen",
       "save": "Opslaan",
+      "continue": "Akkoord en doorgaan",
       "logout": "Uitloggen"
     },
     "settings": {
@@ -695,6 +712,7 @@
       "updateDb.status.ready": "Database is gereed",
       "updateDb.status.optimizing": "Database wordt geoptimaliseerd (klaar voor gebruik)",
       "updateDb.status.paused": "Gepauzeerd",
+      "updateDb.status.throttled": "Wordt op lagere snelheid uitgevoerd",
       "updateDb.status.reconnecting": "Opnieuw verbinden...",
       "updateDb.status.mediaCount": "Database gereed: {{formattedCount}} mediatitels",
       "updateDb.status.noConnection": "Niet verbonden",
@@ -718,6 +736,7 @@
       "scrapeMedia": "Mediametadata ophalen",
       "scrapeMedia.cancel": "Annuleren",
       "scrapeMedia.starting": "Starten...",
+      "scrapeMedia.startError": "Starten van mediascrape mislukt",
       "scrapeMedia.scraperPlaceholder": "Selecteer een scraper",
       "scrapeMedia.allSystems": "Alle systemen",
       "scrapeMedia.selectSystemsTitle": "Systemen selecteren om te scrapen",
@@ -726,6 +745,7 @@
       "scrapeMedia.preparing": "Scrape voorbereiden",
       "scrapeMedia.activeTitle": "Mediametadata scrapen",
       "scrapeMedia.activeDescription": "Metadata voor het huidige systeem scrapen",
+      "scrapeMedia.viewDetails": "Details bekijken",
       "scrapeMedia.lastScrapeTitle": "Laatste scrape",
       "scrapeMedia.currentSystem": "Huidig systeem",
       "scrapeMedia.systemProgressCount": "Systemen: {{current}} / {{total}}",
@@ -741,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "De mediadatabase wordt bijgewerkt. Scrapen is pas beschikbaar als dit proces klaar is.",
       "scrapeMedia.stats": "{{matched}} gekoppeld, {{skipped}} overgeslagen",
       "scrapeMedia.done": "Scrape voltooid: {{matched}} gekoppeld, {{skipped}} overgeslagen",
+      "scrapeMedia.failed": "Scrape mislukt",
+      "scrapeMedia.cancelled": "Scrape geannuleerd",
       "scrapeMedia.status.noConnection": "Niet verbonden",
       "scrapeMedia.status.paused": "Gepauzeerd",
+      "scrapeMedia.status.throttled": "Wordt op lagere snelheid uitgevoerd",
       "scrapeMedia.status.reconnecting": "Opnieuw verbinden...",
       "scrapeMedia.status.totalScraped": "{{formattedCount}} mediarecords gescrapet",
       "scrapeMedia.force": "Al gescrapete media opnieuw scrapen",
@@ -772,6 +795,8 @@
         "searching": "Apparaten zoeken...",
         "stillSearching": "Nog steeds aan het zoeken...",
         "noDevices": "Geen apparaten gevonden",
+        "addresses_one": "IP-adres: {{addresses}}",
+        "addresses_other": "IP-adressen: {{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "Kan geen verbinding maken met apparaat",
@@ -782,6 +807,8 @@
       },
       "enterDeviceAddress": "Voer een apparaatadres in",
       "deviceHistoryEmpty": "Nog geen opgeslagen apparaten.",
+      "deviceHistoryError": "Opgeslagen apparaten konden niet worden geladen.",
+      "deviceHistoryLoading": "Opgeslagen apparaten laden...",
       "deviceDetails": "Apparaatdetails",
       "activeDevice": "Actief apparaat",
       "deviceDetail": {
@@ -797,7 +824,19 @@
         "forgetTitle": "Dit apparaat vergeten?",
         "forgetBody": "Hiermee verwijder je het uit je opgeslagen apparaten en wis je de koppelingsgegevens.",
         "forgetCancel": "Annuleren",
-        "forgetConfirm": "Apparaat vergeten"
+        "forgetConfirm": "Apparaat vergeten",
+        "forgetFailed": "Apparaat kon niet worden vergeten. Probeer het opnieuw."
+      },
+      "deviceCombine": {
+        "edit": "Apparaten combineren",
+        "cancelEdit": "Selectie annuleren",
+        "select": "Selecteer {{device}}",
+        "action": "Geselecteerde apparaten combineren",
+        "title": "Apparaten combineren?",
+        "body": "{{first}} en {{second}} combineren? Opgeslagen adressen en koppeling blijven behouden.",
+        "cancel": "Annuleren",
+        "confirm": "Combineren",
+        "failed": "Apparaten konden niet worden gecombineerd. Er is niets verwijderd."
       },
       "about": {
         "title": "Over",
@@ -856,9 +895,12 @@
         "debugLoggingHelp": "Schakelt uitgebreidere logbestanden in op het verbonden apparaat. Dit kan nuttig zijn bij het oplossen van problemen.",
         "showFilenames": "Bestandsnamen voor media tonen",
         "showFilenamesHelp": "Toon in zoekresultaten in de app de volledige bestandsnaam van media in plaats van de opgeschoonde versie. Dit kan nuttig zijn als je veel aangepaste tags in je bestandsnamen gebruikt.",
+        "appIconBadges": "Badges op appicoon",
+        "appIconBadgesHelp": "Toon het aantal ongelezen inboxberichten op het appicoon. iOS kan om toestemming voor meldingen vragen, omdat badges via de meldingsinstellingen worden beheerd.",
         "purchasePreview": "Aankoopvoorbeeld",
         "purchasePreviewLive": "Livestatus",
         "purchasePreviewFree": "Gratis account",
+        "purchasePreviewCheckout": "Warp-afrekenen",
         "purchasePreviewPro": "Levenslange Pro",
         "purchasePreviewWarp": "Warp actief",
         "purchasePreviewLoading": "Laden",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -44,6 +44,14 @@
       "run": "运行",
       "mainNavigation": "主导航"
     },
+    "appBadge": {
+      "title": "应用图标角标",
+      "description": "Zaparoo 可以在应用图标上显示收件箱消息数量。iOS 将此称为通知权限，但 Zaparoo 只会请求更新角标的权限，不会请求通知提醒或声音权限。",
+      "noThanks": "不用了",
+      "continue": "继续",
+      "requesting": "正在请求...",
+      "deniedDescription": "应用图标角标已在 iOS 设置中被阻止。请打开“设置”，选择 Zaparoo，然后启用“通知”和“标记”。"
+    },
     "library": {
       "title": "媒体库",
       "collections": "合集",
@@ -57,6 +65,7 @@
       "noFavoritesHint": "可在媒体详细信息中添加收藏。",
       "searchFavorites": "搜索收藏",
       "favorite": "收藏",
+      "mediaActions": "媒体操作",
       "addFavorite": "添加到收藏",
       "removeFavorite": "从收藏中移除",
       "updatingFavorite": "正在更新收藏...",
@@ -130,6 +139,7 @@
       "launch": "启动",
       "launchError": "无法启动此媒体",
       "write": "写入 NFC 标签",
+      "writeAction": "写入",
       "preparingWrite": "正在准备 NFC 写入...",
       "writeError": "无法准备将此媒体写入标签",
       "optionsTitle": "媒体库选项",
@@ -169,6 +179,7 @@
       "notSupportedSub": "您将无法使用此应用中的任何 NFC 读取或写入功能",
       "nfcDisabledLabel": "NFC 访问权限已禁用",
       "nfcDisabledSub": "请在设备设置中启用 NFC 访问权限，以使用 NFC 读取和写入功能",
+      "openNfcSettings": "打开 NFC 设置",
       "holdTag": "将标签贴近手机",
       "holdTagReader": "将标签贴近读卡器",
       "scanning": "正在扫描",
@@ -206,7 +217,9 @@
       "nfcNotSupported": "此设备不支持 NFC"
     },
     "accessibility": {
-      "skipToContent": "跳到主要内容"
+      "skipToContent": "跳到主要内容",
+      "skipToActions": "跳到操作",
+      "logo": "Zaparoo 徽标"
     },
     "tokenStaging": {
       "title": "确认暂存的令牌？",
@@ -308,6 +321,7 @@
         "writeLabel": "写入标签",
         "copyLabel": "复制",
         "playLabel": "预览",
+        "mediaActions": "媒体操作",
         "selectSystem": "选择系统",
         "selectTags": "选择标签",
         "loading": "正在加载...",
@@ -487,6 +501,7 @@
           "deletedSuccess": "映射已删除",
           "saveFailed": "映射保存失败",
           "deleteFailed": "映射删除失败",
+          "cameraPermissionDenied": "相机访问权限已禁用。请在系统设置中启用。",
           "notFound": "未找到映射"
         }
       }
@@ -661,9 +676,10 @@
     },
     "requirements": {
       "title": "完成设置",
-      "tosLabel": "我同意",
+      "legalLabel": "我同意服务条款和隐私政策",
+      "legalPrefix": "我同意",
+      "legalAnd": "和",
       "tosLink": "服务条款",
-      "privacyLabel": "我同意",
       "privacyLink": "隐私政策",
       "ageLabel": "我已年满 13 周岁",
       "sendVerificationEmail": "发送验证邮件",
@@ -678,6 +694,7 @@
       "emailVerified": "电子邮箱已验证",
       "saved": "已保存",
       "save": "保存",
+      "continue": "同意并继续",
       "logout": "退出登录"
     },
     "settings": {
@@ -695,6 +712,7 @@
       "updateDb.status.ready": "数据库已就绪",
       "updateDb.status.optimizing": "正在优化数据库（可正常使用）",
       "updateDb.status.paused": "已暂停",
+      "updateDb.status.throttled": "正在降速运行",
       "updateDb.status.reconnecting": "正在重新连接...",
       "updateDb.status.mediaCount": "数据库已就绪：{{formattedCount}} 个媒体标题",
       "updateDb.status.noConnection": "未连接",
@@ -718,6 +736,7 @@
       "scrapeMedia": "抓取媒体元数据",
       "scrapeMedia.cancel": "取消",
       "scrapeMedia.starting": "正在启动...",
+      "scrapeMedia.startError": "无法启动媒体抓取",
       "scrapeMedia.scraperPlaceholder": "选择抓取器",
       "scrapeMedia.allSystems": "所有系统",
       "scrapeMedia.selectSystemsTitle": "选择要抓取的系统",
@@ -726,6 +745,7 @@
       "scrapeMedia.preparing": "正在准备抓取",
       "scrapeMedia.activeTitle": "正在抓取媒体",
       "scrapeMedia.activeDescription": "正在抓取当前系统的元数据",
+      "scrapeMedia.viewDetails": "查看详细信息",
       "scrapeMedia.lastScrapeTitle": "上次抓取",
       "scrapeMedia.currentSystem": "当前系统",
       "scrapeMedia.systemProgressCount": "{{current}} / {{total}} 个系统",
@@ -741,8 +761,11 @@
       "scrapeMedia.blockedByIndex": "媒体数据库正在更新。完成前无法抓取。",
       "scrapeMedia.stats": "已匹配 {{matched}} 个，已跳过 {{skipped}} 个",
       "scrapeMedia.done": "抓取完成：已匹配 {{matched}} 个，已跳过 {{skipped}} 个",
+      "scrapeMedia.failed": "抓取失败",
+      "scrapeMedia.cancelled": "抓取已取消",
       "scrapeMedia.status.noConnection": "未连接",
       "scrapeMedia.status.paused": "已暂停",
+      "scrapeMedia.status.throttled": "正在降速运行",
       "scrapeMedia.status.reconnecting": "正在重新连接...",
       "scrapeMedia.status.totalScraped": "已抓取 {{formattedCount}} 条媒体记录",
       "scrapeMedia.force": "重新抓取已抓取的媒体",
@@ -772,6 +795,8 @@
         "searching": "正在搜索设备...",
         "stillSearching": "仍在搜索...",
         "noDevices": "未找到设备",
+        "addresses_one": "IP 地址：{{addresses}}",
+        "addresses_other": "IP 地址：{{addresses}}",
         "version": "v{{version}}"
       },
       "connectionFailed": "无法连接到设备",
@@ -782,6 +807,8 @@
       },
       "enterDeviceAddress": "输入设备地址",
       "deviceHistoryEmpty": "暂无已保存的设备。",
+      "deviceHistoryError": "无法加载已保存的设备。",
+      "deviceHistoryLoading": "正在加载已保存的设备...",
       "deviceDetails": "设备详细信息",
       "activeDevice": "当前设备",
       "deviceDetail": {
@@ -797,7 +824,19 @@
         "forgetTitle": "移除此设备？",
         "forgetBody": "这将从已保存的设备中移除此设备，并清除配对凭据。",
         "forgetCancel": "取消",
-        "forgetConfirm": "移除设备"
+        "forgetConfirm": "移除设备",
+        "forgetFailed": "无法移除设备。请重试。"
+      },
+      "deviceCombine": {
+        "edit": "合并设备",
+        "cancelEdit": "取消选择",
+        "select": "选择 {{device}}",
+        "action": "合并所选设备",
+        "title": "合并设备？",
+        "body": "要合并 {{first}} 和 {{second}} 吗？已保存的地址和配对信息将会保留。",
+        "cancel": "取消",
+        "confirm": "合并",
+        "failed": "无法合并设备。未移除任何内容。"
       },
       "about": {
         "title": "关于",
@@ -856,9 +895,12 @@
         "debugLoggingHelp": "在已连接的设备上启用更详细的日志文件，有助于排查问题。",
         "showFilenames": "显示媒体文件名",
         "showFilenamesHelp": "在应用内搜索结果中显示媒体的完整文件名，而不是整理后的版本。如果文件名中使用了大量自定义标签，此选项会很有帮助。",
+        "appIconBadges": "应用图标角标",
+        "appIconBadgesHelp": "在应用图标上显示收件箱未读消息数量。由于角标通过通知设置管理，iOS 可能会请求通知权限。",
         "purchasePreview": "购买预览",
         "purchasePreviewLive": "实时状态",
         "purchasePreviewFree": "免费账户",
+        "purchasePreviewCheckout": "Warp 结账",
         "purchasePreviewPro": "终身 Pro",
         "purchasePreviewWarp": "Warp 已启用",
         "purchasePreviewLoading": "正在加载",


### PR DESCRIPTION
## Summary
- standardize SlideModal sizing, dismissal, focus, and action layout behavior
- migrate remaining dialog-style flows onto shared modal patterns and action primitives
- expand modal regression coverage and document updated design guidance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes modal behavior on `SlideModal` with mounted slide transitions, persistent footers, labeled secondary actions, skip links, and accessible help. Adds blocking-modal handling and translation-parity enforcement; updates `ProPurchase`, `WarpSubscription`, `Requirements`, and `WhatsNew` to the shared modal and restores device merging with credential preservation.

- Migration
  - Replace `PurchaseModal` with `purchaseModal` from `useProPurchase`; keep using `setProPurchaseModalOpen`.
  - Update `useSlideModalManager`: `registerModal(id, closeFn, { blocking?: boolean })`; `closeAllExcept(id)` now returns a boolean—abort opening if it returns `false`.
  - Move modal buttons into the `footer` prop and use `ModalActionRail`/`ModalActionBar` to place labeled secondary actions before the primary.
  - Adjust tests: modals remain mounted; query with `getByRole('dialog', { hidden: true })` and assert translate3d slide transforms; help opens in a modal—query help triggers by button name “Help for …”; controls that were previously hidden now remain mounted and disabled.
  - Localization: add new keys across all locales (for example, `library.mediaActions`, `create.search.writeAction`, `spinner.openNfcSettings`, `appBadge.*`); `src/__tests__/validation/translation-parity.test.ts` enforces parity.

<sup>Written for commit 7b11920e650f2b95ce3bedff42521b244223bd83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-app/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent slide-up modals with persistent footers, responsive action layouts, blocking behavior, and smoother transitions.
  * Added clearer media actions for favorites, previews, launching, copying, and NFC writing.
  * Added device-record combining with credential preservation and failure handling.
  * Simplified setup consent into a combined legal agreement with “Agree & continue.”
  * Added accessible help controls, skip links, improved focus behavior, and responsive buttons.

* **Bug Fixes**
  * Unavailable actions remain visible but disabled.
  * Improved detailed artwork loading indicators.

* **Documentation**
  * Updated modal sizing, action, footer, and responsive behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->