### PR TITLE
Prepare v1.13.0 release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "dev.wizzo.tapto"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 28
-        versionName "1.12.0"
+        versionCode 29
+        versionName "1.13.0"
         resValue "string", "capawesome_live_update_default_channel", "production-" + defaultConfig.versionCode
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,7 +98,7 @@ Required for:
    - `android/app/build.gradle` (`versionCode`, `versionName`)
    - `ios/App/App.xcodeproj/project.pbxproj` (`MARKETING_VERSION`, `CURRENT_PROJECT_VERSION`)
 3. Increment both platform build numbers on every store release. Android `versionCode` and iOS `CURRENT_PROJECT_VERSION` must match so versioned live update channels line up.
-4. Confirm `src/lib/whatsNew.ts` has announcement `releaseKeys` for the native version/build, e.g. `native:1.11.2+27`.
+4. Confirm `src/lib/whatsNew.ts` has announcement `releaseKeys` for both the native version/build and first OTA release, e.g. `native:1.11.2+27` and `live:1.11.2-ota.1`.
 5. Confirm the release guard in `src/__tests__/validation/release-config.test.ts` covers the version/channel invariants.
 6. After Capacitor upgrades, confirm GitHub Actions and Capawesome Cloud use a Node.js version supported by `@capacitor/cli`. Capacitor 8 requires Node 22+.
 7. Check About page credits in `src/routes/settings.about.tsx`:

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = App/Info.plist;
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -415,7 +415,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = App/Info.plist;
@@ -426,7 +426,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.wizzo.tapto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zaparoo-app",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zaparoo-app",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zaparoo-app",
   "private": true,
   "license": "Apache-2.0",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "packageManager": "npm@12.0.1",
   "engines": {

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -101,4 +101,10 @@ describe("whatsNew", () => {
     expect(announcement?.id).toBe("release-1.13.0");
     expect(announcement?.items).toHaveLength(5);
   });
+
+  it("should find the 1.13.0 announcement for its first live update", () => {
+    const announcement = getWhatsNewAnnouncement("live:1.13.0-ota.1");
+
+    expect(announcement?.id).toBe("release-1.13.0");
+  });
 });

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -63,8 +63,8 @@ describe("whatsNew", () => {
     vi.mocked(App.getInfo).mockResolvedValue({
       name: "Zaparoo",
       id: "dev.wizzo.tapto",
-      version: "1.12.0",
-      build: "28",
+      version: "1.13.0",
+      build: "29",
     });
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
     vi.mocked(Capacitor.isPluginAvailable).mockReturnValue(true);
@@ -76,9 +76,9 @@ describe("whatsNew", () => {
     const announcement = getWhatsNewAnnouncement(identity.releaseKey);
 
     expect(identity.releaseKey).toBe(
-      "native:1.12.0+28:bundle:bundle-2026-08-11",
+      "native:1.13.0+29:bundle:bundle-2026-08-11",
     );
-    expect(announcement?.id).toBe("release-1.12.0");
+    expect(announcement?.id).toBe("release-1.13.0");
   });
 
   it("should prefer the injected release key", async () => {
@@ -95,10 +95,10 @@ describe("whatsNew", () => {
     expect(identity.liveBundleId).toBe("bundle-2026-06-04");
   });
 
-  it("should find the first 1.12.0 announcement", () => {
-    const announcement = getWhatsNewAnnouncement("native:1.12.0+28");
+  it("should find the 1.13.0 announcement", () => {
+    const announcement = getWhatsNewAnnouncement("native:1.13.0+29");
 
-    expect(announcement?.id).toBe("release-1.12.0");
+    expect(announcement?.id).toBe("release-1.13.0");
     expect(announcement?.items).toHaveLength(5);
   });
 });

--- a/src/__tests__/validation/release-config.test.ts
+++ b/src/__tests__/validation/release-config.test.ts
@@ -107,7 +107,7 @@ describe("release configuration", () => {
     expect(releaseWorkflow).not.toContain("VITE_PURCHASE_PREVIEW");
   });
 
-  it("should have a What's New release key for the native build", () => {
+  it("should have What's New release keys for native and live-update builds", () => {
     const packageJson = readPackageJson();
     const androidGradle = readProjectFile("android/app/build.gradle");
     const androidVersionCode = requireMatch(
@@ -115,12 +115,14 @@ describe("release configuration", () => {
       /versionCode\s+(\d+)/,
       "Android versionCode",
     );
+    const nativeReleaseKey = `native:${packageJson.version}+${androidVersionCode}`;
+    const liveReleaseKey = `live:${packageJson.version}-ota.1`;
 
     expect(
-      WHATS_NEW_ANNOUNCEMENTS.some((announcement) =>
-        announcement.releaseKeys.includes(
-          `native:${packageJson.version}+${androidVersionCode}`,
-        ),
+      WHATS_NEW_ANNOUNCEMENTS.some(
+        (announcement) =>
+          announcement.releaseKeys.includes(nativeReleaseKey) &&
+          announcement.releaseKeys.includes(liveReleaseKey),
       ),
     ).toBe(true);
   });

--- a/src/__tests__/validation/release-config.test.ts
+++ b/src/__tests__/validation/release-config.test.ts
@@ -54,7 +54,7 @@ describe("release configuration", () => {
       new Set([packageJson.version]),
     );
     expect(new Set(iosBuildNumbers)).toEqual(new Set([androidVersionCode]));
-    expect(androidVersionCode).toBe(28);
+    expect(androidVersionCode).toBe(29);
   });
 
   it("should use versioned Capawesome live update channels", () => {

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -20,15 +20,15 @@ export type WhatsNewAnnouncement = {
 
 export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
   {
-    id: "release-1.12.0",
-    releaseKeys: ["native:1.12.0+28"],
-    title: "What's new in 1.12.0",
+    id: "release-1.13.0",
+    releaseKeys: ["native:1.13.0+29"],
+    title: "What's new in 1.13.0",
     items: [
       "Browse, search, favorite, launch, and write media from the new Library tab.",
-      "Subscribe to and manage Zaparoo Warp directly in the app.",
-      "Log in to Zaparoo Online accounts protected by two-factor authentication.",
-      "Replay past scans and customize ZapScript tags from search results.",
-      "Enjoy improved NFC writing, encrypted connections, accessibility, notifications, and log sharing.",
+      "Subscribe, restore, and manage Zaparoo Warp from the App.",
+      "Create and manage device profiles, roles, PINs, playtime limits, and profile cards.",
+      "Keep saved Core connections working through address changes and App restarts, with clearer connection status.",
+      "Get more reliable NFC scanning and writing, plus smoother modals, swipe-back feedback, haptics, and app icon badges.",
     ],
   },
 ];

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -21,7 +21,7 @@ export type WhatsNewAnnouncement = {
 export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
   {
     id: "release-1.13.0",
-    releaseKeys: ["native:1.13.0+29"],
+    releaseKeys: ["native:1.13.0+29", "live:1.13.0-ota.1"],
     title: "What's new in 1.13.0",
     items: [
       "Browse, search, favorite, launch, and write media from the new Library tab.",


### PR DESCRIPTION
## Summary

- bump package, Android, and iOS versions to v1.13.0 build 29
- update native release-key validation for versioned live-update channel
- refresh in-app What’s New highlights for v1.13.0

Validated with typecheck, lint, formatting check, and full test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares v1.13.0 (build 29) and fixes What’s New matching to show for both the native build and the first OTA release. Previously it matched only the native key; now it also matches the first live update so OTA users see the same highlights.

- Bump versions: Android versionCode 29/versionName 1.13.0; iOS CURRENT_PROJECT_VERSION 29/MARKETING_VERSION 1.13.0; package version 1.13.0.
- Refresh What’s New to `release-1.13.0` with release keys `native:1.13.0+29` and `live:1.13.0-ota.1`, and update unit/validation tests and deployment docs to require both.
- Validate the versioned live-update channel `production-29`.
- Rollout: create and publish `production-29` before submitting to stores.

<sup>Written for commit 77212aeb3ad4b6740fd734fe146cd95a02ddb603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-app/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the app to version **1.13.0** (build 29) across Android, iOS, and package metadata.
* **What’s New**
  * Refreshed the in-app release announcement for version 1.13.0 with updated release details and feature descriptions.
* **Tests**
  * Updated release validation and What's New checks for build 29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->