### PR TITLE
Fix setup and Online flows for 1.13.2

### DIFF
--- a/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
+++ b/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
@@ -11,12 +11,14 @@ const {
   mockSettings,
   mockSettingsUpdate,
   mockBackupStatus,
+  mockNavigate,
 } = vi.hoisted(() => ({
   mockUseDeviceLinking: vi.fn(),
   mockUseClientCapability: vi.fn(),
   mockSettings: vi.fn(),
   mockSettingsUpdate: vi.fn(),
   mockBackupStatus: vi.fn(),
+  mockNavigate: vi.fn(),
 }));
 
 const signedInUser: User = {
@@ -34,7 +36,7 @@ const signedInUser: User = {
 };
 
 vi.mock("@tanstack/react-router", () => ({
-  useRouter: () => ({ navigate: vi.fn() }),
+  useRouter: () => ({ navigate: mockNavigate }),
 }));
 
 vi.mock("@/hooks/useDeviceLinking", () => ({
@@ -122,6 +124,24 @@ describe("OnlineDeviceSetup", () => {
     );
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("online.deviceLink.help")).toBeInTheDocument();
+    expect(mockSettings).not.toHaveBeenCalled();
+    expect(mockBackupStatus).not.toHaveBeenCalled();
+  });
+
+  it("should explain disconnection and return to Settings", async () => {
+    const user = userEvent.setup();
+    render(<OnlineDeviceSetup connected={false} warpActive={false} />);
+
+    expect(
+      screen.getByText("online.deviceLink.disconnected"),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", {
+        name: "online.deviceLink.backToSettings",
+      }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/settings" });
     expect(mockSettings).not.toHaveBeenCalled();
     expect(mockBackupStatus).not.toHaveBeenCalled();
   });

--- a/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
+++ b/src/__tests__/unit/components/OnlineDeviceSetup.test.tsx
@@ -146,6 +146,31 @@ describe("OnlineDeviceSetup", () => {
     expect(mockBackupStatus).not.toHaveBeenCalled();
   });
 
+  it("should clear linked features when the Core disconnects", async () => {
+    mockUseDeviceLinking.mockReturnValue({
+      state: "linked",
+      linkDevice: vi.fn(),
+    });
+    const { rerender } = render(
+      <OnlineDeviceSetup connected warpActive={false} />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "online.features.title" }),
+    ).toBeInTheDocument();
+    expect(mockSettings).toHaveBeenCalledOnce();
+    expect(mockBackupStatus).toHaveBeenCalledOnce();
+
+    rerender(<OnlineDeviceSetup connected={false} warpActive={false} />);
+
+    expect(
+      screen.getByText("online.deviceLink.disconnected"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "online.features.title" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should offer linking without an inline description", () => {
     render(<OnlineDeviceSetup connected warpActive={false} />);
 

--- a/src/__tests__/unit/components/ProPurchase.test.tsx
+++ b/src/__tests__/unit/components/ProPurchase.test.tsx
@@ -406,8 +406,8 @@ describe("useProPurchase", () => {
       screen.getByRole("button", { name: "scan.purchaseProUnavailableAction" }),
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "settings.app.restorePurchases" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "settings.app.restorePurchases" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: "settings.app.copyBillingDiagnostics",
@@ -429,8 +429,8 @@ describe("useProPurchase", () => {
 
     expect(screen.getByText("scan.purchaseProUnavailable")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "settings.app.restorePurchases" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "settings.app.restorePurchases" }),
+    ).not.toBeInTheDocument();
   });
 
   it("should show error state and report when offerings fail to load", async () => {
@@ -468,11 +468,11 @@ describe("useProPurchase", () => {
       screen.getByRole("button", { name: "scan.purchaseProUnavailableAction" }),
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "settings.app.restorePurchases" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "settings.app.restorePurchases" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("should distinguish a store eligibility failure and expose support actions", async () => {
+  it("should distinguish a store eligibility failure and expose diagnostics", async () => {
     const user = userEvent.setup();
     const { Purchases } = await import("@revenuecat/purchases-capacitor");
     const { logger } = await import("@/lib/logger");
@@ -507,8 +507,8 @@ describe("useProPurchase", () => {
 
     expect(screen.getByText("scan.purchaseProNotAllowed")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "settings.app.restorePurchases" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "settings.app.restorePurchases" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: "settings.app.copyBillingDiagnostics",
@@ -519,7 +519,7 @@ describe("useProPurchase", () => {
     ).toBeDisabled();
   });
 
-  it("should show fetched package price with purchase and restore actions", async () => {
+  it("should show fetched package price without a duplicate restore action", async () => {
     const user = userEvent.setup();
     const { Purchases } = await import("@revenuecat/purchases-capacitor");
     vi.mocked(Purchases.getOfferings).mockResolvedValue(
@@ -540,8 +540,8 @@ describe("useProPurchase", () => {
       screen.getByRole("button", { name: "scan.purchaseProAction" }),
     ).toBeEnabled();
     expect(
-      screen.getByRole("button", { name: "settings.app.restorePurchases" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "settings.app.restorePurchases" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
         name: "settings.app.copyBillingDiagnostics",
@@ -830,7 +830,7 @@ describe("useProPurchase", () => {
     });
   });
 
-  it("should clear the store-verified Pro fallback after a clean restore finds no purchases", async () => {
+  it("should preserve store-verified Pro when RevenueCat restore finds no purchases", async () => {
     const user = userEvent.setup();
     const { usePreferencesStore } = await import("@/lib/preferencesStore");
     usePreferencesStore.setState({
@@ -847,8 +847,8 @@ describe("useProPurchase", () => {
     );
 
     await waitFor(() => {
-      expect(usePreferencesStore.getState().storeVerifiedProAccess).toBe(false);
-      expect(usePreferencesStore.getState().lifetimeProAccess).toBe(false);
+      expect(usePreferencesStore.getState().storeVerifiedProAccess).toBe(true);
+      expect(usePreferencesStore.getState().lifetimeProAccess).toBe(true);
     });
   });
 
@@ -895,6 +895,17 @@ describe("useProPurchase", () => {
         ),
       });
     });
+  });
+
+  it("should put emergency restore below billing diagnostics", () => {
+    render(<PurchaseSupportActions />);
+
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual([
+      "settings.app.copyBillingDiagnostics",
+      "settings.app.restorePurchases",
+    ]);
   });
 
   it("should show only the restore action for the restoreOnly variant", () => {

--- a/src/__tests__/unit/components/RequirementsModal.test.tsx
+++ b/src/__tests__/unit/components/RequirementsModal.test.tsx
@@ -84,6 +84,7 @@ describe("RequirementsModal", () => {
     useRequirementsStore.setState({
       isOpen: false,
       pendingRequirements: [],
+      completionRevision: 0,
     });
   });
 
@@ -349,6 +350,7 @@ describe("RequirementsModal", () => {
       accept_privacy: true,
       age_verified: true,
     });
+    expect(useRequirementsStore.getState().completionRevision).toBe(1);
   });
 
   it("should call signOut when logout is clicked", async () => {
@@ -377,6 +379,7 @@ describe("RequirementsModal", () => {
     await waitFor(() => {
       expect(FirebaseAuthentication.signOut).toHaveBeenCalled();
     });
+    expect(useRequirementsStore.getState().completionRevision).toBe(0);
   });
 
   it("should not call Purchases.logOut when RC user is already anonymous", async () => {

--- a/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
+++ b/src/__tests__/unit/components/WhatsNewInitializer.test.tsx
@@ -130,7 +130,7 @@ describe("WhatsNewInitializer", () => {
     });
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByText("What's new in test")).toBeInTheDocument();
+    expect(screen.getByText("What's new in vtest")).toBeInTheDocument();
     expect(screen.getByText("First test item")).toBeInTheDocument();
     expect(screen.getByText("Second test item")).toBeInTheDocument();
   });

--- a/src/__tests__/unit/hooks/useRequirementsModal.test.ts
+++ b/src/__tests__/unit/hooks/useRequirementsModal.test.ts
@@ -8,6 +8,7 @@ describe("useRequirementsStore", () => {
     useRequirementsStore.setState({
       isOpen: false,
       pendingRequirements: [],
+      completionRevision: 0,
     });
   });
 
@@ -60,6 +61,39 @@ describe("useRequirementsStore", () => {
     const state = useRequirementsStore.getState();
     expect(state.isOpen).toBe(false);
     expect(state.pendingRequirements).toEqual([]);
+  });
+
+  it("should mark successful completion separately from closing", () => {
+    const { trigger, complete } = useRequirementsStore.getState();
+
+    trigger([
+      {
+        type: "terms_acceptance",
+        description: "Accept terms",
+        endpoint: "/account/requirements",
+      },
+    ]);
+    complete();
+
+    const state = useRequirementsStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.pendingRequirements).toEqual([]);
+    expect(state.completionRevision).toBe(1);
+  });
+
+  it("should not mark ordinary close as successful completion", () => {
+    const { trigger, close } = useRequirementsStore.getState();
+
+    trigger([
+      {
+        type: "terms_acceptance",
+        description: "Accept terms",
+        endpoint: "/account/requirements",
+      },
+    ]);
+    close();
+
+    expect(useRequirementsStore.getState().completionRevision).toBe(0);
   });
 
   it("should replace requirements when triggered multiple times", () => {

--- a/src/__tests__/unit/hooks/useWarpSubscription.test.ts
+++ b/src/__tests__/unit/hooks/useWarpSubscription.test.ts
@@ -5,6 +5,7 @@ import type {
   PurchasesPackage,
 } from "@revenuecat/purchases-capacitor";
 import type { SubscriptionResponse } from "@/lib/models";
+import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import {
   cachePurchaseErrorDiagnostics,
   clearCachedPurchaseErrorDiagnostics,
@@ -39,6 +40,7 @@ const {
 
 let appStateCallback: ((state: { isActive: boolean }) => void) | null = null;
 let loggedInUserID = "user-123";
+let storeVerifiedProAccess = false;
 
 const monthlyPackage = {
   identifier: "$rc_monthly",
@@ -134,7 +136,10 @@ vi.mock("@/lib/preferencesStore", () => {
   };
   const usePreferencesStore = (selector: (state: unknown) => unknown) =>
     selector(state);
-  usePreferencesStore.getState = () => state;
+  usePreferencesStore.getState = () => ({
+    ...state,
+    storeVerifiedProAccess,
+  });
   return { usePreferencesStore };
 });
 
@@ -162,6 +167,12 @@ describe("useWarpSubscription", () => {
     clearCachedPurchaseErrorDiagnostics();
     appStateCallback = null;
     loggedInUserID = "user-123";
+    storeVerifiedProAccess = false;
+    useRequirementsStore.setState({
+      isOpen: false,
+      pendingRequirements: [],
+      completionRevision: 0,
+    });
     mockIsNativePlatform.mockReturnValue(true);
     mockAddAppListener.mockImplementation(
       (_event: string, callback: (state: { isActive: boolean }) => void) => {
@@ -281,7 +292,25 @@ describe("useWarpSubscription", () => {
     expect(mockRestorePurchases).toHaveBeenCalledOnce();
     expect(result.current.subscription?.is_premium).toBe(false);
     expect(result.current.activationPending).toBe(false);
-    expect(mockSetStoreVerifiedProAccess).toHaveBeenCalledWith(false);
+    expect(mockSetStoreVerifiedProAccess).not.toHaveBeenCalled();
+  });
+
+  it("should preserve store-verified Pro when Warp restore finds no entitlement", async () => {
+    storeVerifiedProAccess = true;
+    mockGetSubscriptionStatus
+      .mockResolvedValueOnce(subscription(false))
+      .mockResolvedValueOnce(subscription(false));
+    const { result } = renderHook(() => useWarpSubscription("user-123"));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let restoreResult: string | undefined;
+    await act(async () => {
+      restoreResult = await result.current.restore();
+    });
+
+    expect(restoreResult).toBe("pro_restored");
+    expect(mockSetStoreVerifiedProAccess).not.toHaveBeenCalled();
+    expect(mockSetLifetimeProAccess).toHaveBeenLastCalledWith(true);
   });
 
   it("should clear stale activation state when checkout offerings return", async () => {
@@ -386,6 +415,58 @@ describe("useWarpSubscription", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("should reload account data after requirements are completed", async () => {
+    mockGetSubscriptionStatus
+      .mockRejectedValueOnce(new Error("requirements_not_met"))
+      .mockResolvedValueOnce(subscription(true));
+
+    const { result } = renderHook(() => useWarpSubscription("user-123"));
+    await waitFor(() => expect(result.current.loadFailed).toBe(true));
+
+    act(() => useRequirementsStore.getState().complete());
+
+    await waitFor(() => {
+      expect(result.current.loadFailed).toBe(false);
+      expect(result.current.subscription?.is_premium).toBe(true);
+    });
+    expect(mockGetSubscriptionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not abort a purchase when requirements are completed", async () => {
+    mockGetSubscriptionStatus
+      .mockResolvedValueOnce(subscription(false))
+      .mockResolvedValueOnce(subscription(false))
+      .mockResolvedValueOnce(subscription(true));
+
+    let resolvePurchase!: (value: { customerInfo: CustomerInfo }) => void;
+    mockPurchasePackage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePurchase = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useWarpSubscription("user-123"));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let purchasePromise!: Promise<string>;
+    act(() => {
+      purchasePromise = result.current.purchase();
+    });
+    await waitFor(() => expect(mockPurchasePackage).toHaveBeenCalledOnce());
+
+    act(() => useRequirementsStore.getState().complete());
+    resolvePurchase({ customerInfo: customerInfo({ warp: true }) });
+
+    let purchaseResult: string | undefined;
+    await act(async () => {
+      purchaseResult = await purchasePromise;
+    });
+
+    expect(purchaseResult).toBe("active");
+    expect(mockGetSubscriptionStatus).toHaveBeenCalledTimes(3);
   });
 
   it("should refresh on foreground without replacing content with loading", async () => {

--- a/src/__tests__/unit/lib/whatsNew.test.ts
+++ b/src/__tests__/unit/lib/whatsNew.test.ts
@@ -120,6 +120,17 @@ describe("whatsNew", () => {
     );
   });
 
+  it("should reuse the 1.13.1 announcement for the 1.13.2 sleeper OTA", () => {
+    const announcement = getWhatsNewAnnouncement("live:1.13.0-ota.2");
+
+    expect(announcement?.id).toBe("release-1.13.1");
+    expect(announcement?.title).toBe("What's new in v1.13.1");
+    expect(announcement?.version).toBe("1.13.2");
+    expect(getReleaseDisplayVersion("live:1.13.0-ota.2", "1.13.0")).toBe(
+      "1.13.2",
+    );
+  });
+
   it("should preserve the native version without a mapped release key", () => {
     expect(getReleaseDisplayVersion(undefined, "1.13.0")).toBe("1.13.0");
     expect(getReleaseDisplayVersion("live:unknown", "1.13.0")).toBe("1.13.0");

--- a/src/__tests__/unit/routes/settings.advanced.test.tsx
+++ b/src/__tests__/unit/routes/settings.advanced.test.tsx
@@ -83,8 +83,8 @@ vi.mock("@capacitor/core", () => ({
   },
 }));
 
-// Mock ProPurchase — this route only needs to know the diagnostics-only
-// variant is rendered natively; purchase logic itself is tested elsewhere.
+// Mock ProPurchase — this route only needs to know full emergency purchase
+// support is rendered natively; purchase logic itself is tested elsewhere.
 vi.mock("@/components/ProPurchase", () => ({
   PurchaseSupportActions: ({ variant }: { variant?: string }) => (
     <div data-testid="purchase-support-actions" data-variant={variant}>
@@ -219,16 +219,15 @@ describe("Settings Advanced Route", () => {
       });
     });
 
-    it("should show only the billing diagnostics action natively", () => {
+    it("should show emergency billing support actions natively", () => {
       mockIsNativePlatform.mockReturnValue(true);
       mockGetPlatform.mockReturnValue("android");
 
       renderComponent();
 
-      expect(screen.getByTestId("purchase-support-actions")).toHaveAttribute(
-        "data-variant",
-        "diagnosticsOnly",
-      );
+      expect(
+        screen.getByTestId("purchase-support-actions"),
+      ).not.toHaveAttribute("data-variant");
     });
 
     it("should hide purchase support actions on web", () => {

--- a/src/__tests__/unit/routes/settings.index.test.tsx
+++ b/src/__tests__/unit/routes/settings.index.test.tsx
@@ -108,6 +108,7 @@ vi.mock("@/lib/preferencesStore", () => ({
 
 // Mock ProPurchase component
 const mockSetProPurchaseModalOpen = vi.fn();
+let mockProAccess = false;
 vi.mock("@/components/ProPurchase.tsx", () => ({
   PurchaseSupportActions: ({ variant }: { variant?: string }) => (
     <div data-testid="purchase-support-actions" data-variant={variant}>
@@ -117,7 +118,7 @@ vi.mock("@/components/ProPurchase.tsx", () => ({
   useProPurchase: () => ({
     purchaseModal: null,
     setProPurchaseModalOpen: mockSetProPurchaseModalOpen,
-    proAccess: false,
+    proAccess: mockProAccess,
   }),
 }));
 
@@ -226,6 +227,7 @@ describe("Settings Index Route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProAccess = false;
     queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -507,6 +509,32 @@ describe("Settings Index Route", () => {
         "data-variant",
         "restoreOnly",
       );
+    });
+
+    it("should hide restore action when lifetime Pro is active", async () => {
+      const { Capacitor } = await import("@capacitor/core");
+      vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+      mockProAccess = true;
+
+      renderComponent();
+
+      expect(
+        screen.queryByTestId("purchase-support-actions"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should hide restore action when Warp includes Pro", async () => {
+      const { Capacitor } = await import("@capacitor/core");
+      vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+      mockUsePreferencesStore.mockImplementation((selector) =>
+        selector({ onlinePremiumAccess: true }),
+      );
+
+      renderComponent();
+
+      expect(
+        screen.queryByTestId("purchase-support-actions"),
+      ).not.toBeInTheDocument();
     });
 
     it("should hide purchase support actions on web", async () => {

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -476,40 +476,6 @@ describe("Settings Online Route", () => {
         screen.queryByRole("button", { name: "online.changePassword" }),
       ).not.toBeInTheDocument();
     });
-
-    it("should show Google login indicator for Google users", () => {
-      mockState.loggedInUser = authenticatedUser({
-        ...mockState.loggedInUser,
-        providerData: [{ providerId: "google.com" }],
-      });
-      renderComponent();
-      expect(screen.getByText("online.loggedInWithGoogle")).toBeInTheDocument();
-    });
-
-    it("should show Apple login indicator for Apple users", () => {
-      mockState.loggedInUser = authenticatedUser({
-        ...mockState.loggedInUser,
-        providerData: [{ providerId: "apple.com" }],
-      });
-      renderComponent();
-      expect(screen.getByText("online.loggedInWithApple")).toBeInTheDocument();
-    });
-
-    it("should not infer latest login method from a linked provider", () => {
-      mockState.loggedInUser = authenticatedUser({
-        ...mockState.loggedInUser,
-        providerData: [
-          { providerId: "google.com" },
-          { providerId: "password" },
-        ],
-      });
-
-      renderComponent();
-
-      expect(
-        screen.queryByText("online.loggedInWithGoogle"),
-      ).not.toBeInTheDocument();
-    });
   });
 
   describe("mode toggle", () => {
@@ -869,53 +835,6 @@ describe("Settings Online Route", () => {
           password: "password123",
         });
       });
-    });
-
-    it("should show the email login method for a linked Google account", async () => {
-      const user = userEvent.setup();
-      const Online = getOnline();
-      const view = render(<Online />);
-      mockFirebaseAuth.getCurrentUser.mockResolvedValueOnce({
-        user: {
-          email: "test@example.com",
-          uid: "test-uid",
-          displayName: "Test User",
-          emailVerified: true,
-          providerData: [
-            { providerId: "google.com" },
-            { providerId: "password" },
-          ],
-        },
-      });
-
-      await user.type(
-        screen.getByPlaceholderText("me@example.com"),
-        "test@example.com",
-      );
-      await user.type(screen.getByLabelText("online.password"), "password123");
-      await user.click(screen.getByRole("button", { name: "online.login" }));
-
-      await waitFor(() => {
-        expect(mockSetLoggedInUser).toHaveBeenCalled();
-      });
-      mockState.loggedInUser = authenticatedUser({
-        email: "test@example.com",
-        uid: "test-uid",
-        displayName: "Test User",
-        emailVerified: true,
-        providerData: [
-          { providerId: "google.com" },
-          { providerId: "password" },
-        ],
-      });
-      view.rerender(<Online />);
-
-      expect(
-        screen.getByText("online.loggedInWithPassword"),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByText("online.loggedInWithGoogle"),
-      ).not.toBeInTheDocument();
     });
 
     it("should show error toast without logging expected login failure", async () => {

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -1064,6 +1064,25 @@ describe("Settings Online Route", () => {
       });
     });
 
+    it("should preserve the MFA challenge when sign-in has no current user", async () => {
+      mockFirebaseAuth.getCurrentUser.mockResolvedValueOnce({ user: null });
+      const user = await startMfaChallenge();
+
+      await user.type(screen.getByLabelText("online.mfaCode"), "123456");
+      await user.click(
+        screen.getByRole("button", { name: "online.mfaVerify" }),
+      );
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("online.loginFail");
+      });
+      expect(
+        screen.getByRole("heading", { name: "online.mfaTitle" }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("online.mfaCode")).toHaveValue("123456");
+      expect(mockSetLoggedInUser).not.toHaveBeenCalled();
+    });
+
     it("should keep MFA visible until account setup finishes", async () => {
       let resolveCurrentUser!: (value: {
         user: {

--- a/src/__tests__/validation/release-config.test.ts
+++ b/src/__tests__/validation/release-config.test.ts
@@ -116,17 +116,22 @@ describe("release configuration", () => {
       "Android versionCode",
     );
     const nativeReleaseKey = `native:${packageJson.version}+${androidVersionCode}`;
-    const liveReleaseKey = `live:${packageJson.version}-ota.1`;
+    const liveReleaseKeys = [
+      `live:${packageJson.version}-ota.1`,
+      `live:${packageJson.version}-ota.2`,
+    ];
 
     expect(
       WHATS_NEW_ANNOUNCEMENTS.some((announcement) =>
         announcement.releaseKeys.includes(nativeReleaseKey),
       ),
     ).toBe(true);
-    expect(
-      WHATS_NEW_ANNOUNCEMENTS.some((announcement) =>
-        announcement.releaseKeys.includes(liveReleaseKey),
-      ),
-    ).toBe(true);
+    for (const liveReleaseKey of liveReleaseKeys) {
+      expect(
+        WHATS_NEW_ANNOUNCEMENTS.some((announcement) =>
+          announcement.releaseKeys.includes(liveReleaseKey),
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/src/components/OnlineDeviceSetup.tsx
+++ b/src/components/OnlineDeviceSetup.tsx
@@ -55,8 +55,9 @@ export function OnlineDeviceSetup({
   );
   const featuresHeadingRef = useRef<HTMLHeadingElement>(null);
   const previousLinkStateRef = useRef(linkState);
-  const linked = linkState === "linked";
-  const featuresPending = linkState === "checking" || linkState === "linking";
+  const linked = connected && linkState === "linked";
+  const featuresPending =
+    connected && (linkState === "checking" || linkState === "linking");
 
   useEffect(() => {
     const becameLinked =
@@ -72,12 +73,12 @@ export function OnlineDeviceSetup({
   const settingsQuery = useQuery({
     queryKey: ["settings", "online"],
     queryFn: () => CoreAPI.settings(),
-    enabled: linked && canWriteCoreSettings,
+    enabled: connected && linked && canWriteCoreSettings,
   });
   const backupStatusQuery = useQuery({
     queryKey: ["settings", "backup", "status"],
     queryFn: () => CoreAPI.settingsBackupStatus(),
-    enabled: linked,
+    enabled: connected && linked,
     refetchInterval: (query) => {
       if (warpActive === true) return false;
       const availability = query.state.data?.remote.availability;
@@ -156,9 +157,8 @@ export function OnlineDeviceSetup({
             description={t("online.deviceLink.help")}
           />
         </div>
-        {connected ? (
-          <DeviceLinkButton enabled onStateChange={setLinkState} />
-        ) : (
+        <DeviceLinkButton enabled={connected} onStateChange={setLinkState} />
+        {!connected && (
           <div className="flex flex-col gap-3">
             <p className="text-muted-foreground text-sm">
               {t("online.deviceLink.disconnected")}

--- a/src/components/OnlineDeviceSetup.tsx
+++ b/src/components/OnlineDeviceSetup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import { DeviceLinkButton } from "@/components/DeviceLinkButton";
@@ -41,6 +42,7 @@ export function OnlineDeviceSetup({
   warpActive,
 }: OnlineDeviceSetupProps) {
   const { t, i18n } = useTranslation();
+  const router = useRouter();
   const hasSettingsWriteCapability = useClientCapability(
     ClientCapability.SettingsWrite,
   );
@@ -154,7 +156,21 @@ export function OnlineDeviceSetup({
             description={t("online.deviceLink.help")}
           />
         </div>
-        <DeviceLinkButton enabled={connected} onStateChange={setLinkState} />
+        {connected ? (
+          <DeviceLinkButton enabled onStateChange={setLinkState} />
+        ) : (
+          <div className="flex flex-col gap-3">
+            <p className="text-muted-foreground text-sm">
+              {t("online.deviceLink.disconnected")}
+            </p>
+            <Button
+              label={t("online.deviceLink.backToSettings")}
+              variant="outline"
+              onClick={() => void router.navigate({ to: "/settings" })}
+              className="w-full"
+            />
+          </div>
+        )}
       </section>
 
       {(featuresPending || linked) && (

--- a/src/components/ProPurchase.tsx
+++ b/src/components/ProPurchase.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { Capacitor } from "@capacitor/core";
 import { Clipboard } from "@capacitor/clipboard";
 import toast from "react-hot-toast";
+import { Loader2 } from "lucide-react";
 import { SlideModal } from "@/components/SlideModal";
 import { logger } from "@/lib/logger";
 import {
@@ -193,16 +194,12 @@ const ProPurchaseModal = (props: {
     })();
   };
 
-  // RevenueCat can report an already-owned iOS product as cancellation. Keep
-  // cancellation non-authoritative, but leave explicit restoration available.
   const supportActionsVariant =
-    props.offeringsStatus === "available"
-      ? "restoreOnly"
-      : props.offeringsStatus === "not_allowed" ||
-          props.offeringsStatus === "missing" ||
-          props.offeringsStatus === "error"
-        ? "full"
-        : null;
+    props.offeringsStatus === "not_allowed" ||
+    props.offeringsStatus === "missing" ||
+    props.offeringsStatus === "error"
+      ? "diagnosticsOnly"
+      : null;
 
   return (
     <SlideModal
@@ -220,6 +217,11 @@ const ProPurchaseModal = (props: {
             isPurchasing
               ? t("loading")
               : getPurchaseActionLabel(props.offeringsStatus)
+          }
+          icon={
+            isPurchasing ? (
+              <Loader2 size={20} className="animate-spin" />
+            ) : undefined
           }
           disabled={!props.purchasePackage || isPurchasing}
           onClick={handlePurchase}
@@ -379,12 +381,9 @@ export function PurchaseSupportActions({
       );
       const access = getPurchaseAccess(customerInfo);
       clearCachedPurchaseErrorDiagnostics();
-      if (!access.lifetimePro) {
-        // A clean restore that found no Pro entitlement means the store no
-        // longer backs the earlier "already owned" local fallback either.
-        usePreferencesStore.getState().setStoreVerifiedProAccess(false);
-      }
-      setLifetimeProAccess(access.lifetimePro);
+      const storeVerifiedProAccess =
+        usePreferencesStore.getState().storeVerifiedProAccess;
+      setLifetimeProAccess(access.lifetimePro || storeVerifiedProAccess);
       if (access.warp && loggedInUser) {
         setOnlinePremiumAccess(true);
       }
@@ -393,7 +392,7 @@ export function PurchaseSupportActions({
         toast(t("settings.app.restoreWarpSignIn"));
         return;
       }
-      if (access.lifetimePro || access.warp) {
+      if (access.lifetimePro || access.warp || storeVerifiedProAccess) {
         toast.success(t("settings.app.restoreSuccess"));
         return;
       }
@@ -449,9 +448,19 @@ export function PurchaseSupportActions({
 
   const showRestore = variant !== "diagnosticsOnly";
   const showDiagnostics = variant !== "restoreOnly";
+  const useOutlineButtons = variant !== "restoreOnly";
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-2">
+      {showDiagnostics && (
+        <Button
+          label={t("settings.app.copyBillingDiagnostics")}
+          variant={useOutlineButtons ? "outline" : "text"}
+          onClick={() => void handleCopyDiagnostics()}
+          disabled={isRestoring || isCopyingDiagnostics}
+          className="w-full"
+        />
+      )}
       {showRestore && (
         <Button
           label={
@@ -459,21 +468,8 @@ export function PurchaseSupportActions({
               ? t("online.warp.restoring")
               : t("settings.app.restorePurchases")
           }
-          variant="text"
+          variant={useOutlineButtons ? "outline" : "text"}
           onClick={() => void handleRestore()}
-          disabled={isRestoring || isCopyingDiagnostics}
-          className="w-full"
-        />
-      )}
-      {showDiagnostics && (
-        <Button
-          label={
-            isCopyingDiagnostics
-              ? t("loading")
-              : t("settings.app.copyBillingDiagnostics")
-          }
-          variant="text"
-          onClick={() => void handleCopyDiagnostics()}
           disabled={isRestoring || isCopyingDiagnostics}
           className="w-full"
         />

--- a/src/components/RequirementsModal.tsx
+++ b/src/components/RequirementsModal.tsx
@@ -21,7 +21,8 @@ const PRIVACY_URL = "https://zaparoo.com/privacy";
 
 export function RequirementsModal() {
   const { t, i18n } = useTranslation();
-  const { isOpen, pendingRequirements, close } = useRequirementsStore();
+  const { isOpen, pendingRequirements, close, complete } =
+    useRequirementsStore();
   const setLoggedInUser = useStatusStore((state) => state.setLoggedInUser);
 
   // Local checkbox state - NOT live updating
@@ -93,8 +94,8 @@ export function RequirementsModal() {
         // Requirements updated, but modal stays open for email verification
         setStatusMessage({ type: "success", text: t("requirements.saved") });
       } else {
-        // All requirements met, close modal
-        close();
+        // All requirements met, close modal and refresh blocked account data.
+        complete();
       }
     } catch (e) {
       logger.error("Failed to update requirements:", e, {
@@ -196,7 +197,7 @@ export function RequirementsModal() {
         });
 
         if (allPendingMet) {
-          close();
+          complete();
         } else {
           // Update local user state
           setLoggedInUser(result.user);
@@ -224,7 +225,7 @@ export function RequirementsModal() {
     } finally {
       setEmailVerifying(false);
     }
-  }, [close, pendingRequirements, setLoggedInUser, t]);
+  }, [complete, pendingRequirements, setLoggedInUser, t]);
 
   return (
     <SlideModal
@@ -277,7 +278,7 @@ export function RequirementsModal() {
               onCheckedChange={(checked) => setLegalChecked(checked === true)}
               aria-label={t("requirements.legalLabel")}
             />
-            <div className="text-sm leading-tight text-white">
+            <div className="pt-0.5 text-sm leading-tight text-white">
               <Label htmlFor="legal" className="inline leading-tight">
                 {t("requirements.legalPrefix")}
               </Label>
@@ -309,7 +310,7 @@ export function RequirementsModal() {
 
         {/* Age Verification */}
         {needsAge && (
-          <div className="flex items-start gap-3">
+          <div className="flex items-center gap-3">
             <Checkbox
               id="age"
               checked={ageChecked}

--- a/src/components/WarpSubscription.tsx
+++ b/src/components/WarpSubscription.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/wui/Button";
 import { Segmented } from "@/components/wui/Segmented";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -77,6 +78,11 @@ function WarpPurchaseModal({
             action === "purchase"
               ? t("online.warp.purchasing")
               : t("online.warp.subscribe")
+          }
+          icon={
+            action === "purchase" ? (
+              <Loader2 size={20} className="animate-spin" />
+            ) : undefined
           }
           onClick={onPurchase}
           disabled={action !== null || !purchaseEnabled}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -10,7 +10,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer grid h-6 w-6 shrink-0 place-content-center rounded border border-white/50 bg-white/10 shadow focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-white data-[state=checked]:bg-white data-[state=checked]:text-black",
+      "peer data-[state=checked]:border-bd-filled data-[state=checked]:bg-button-pattern data-[state=checked]:text-primary-foreground grid h-6 w-6 shrink-0 place-content-center rounded border border-white/50 bg-white/10 shadow focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     {...props}

--- a/src/hooks/useRequirementsModal.ts
+++ b/src/hooks/useRequirementsModal.ts
@@ -4,14 +4,23 @@ import type { PendingRequirement } from "@/lib/models";
 interface RequirementsState {
   isOpen: boolean;
   pendingRequirements: PendingRequirement[];
+  completionRevision: number;
   trigger: (requirements: PendingRequirement[]) => void;
   close: () => void;
+  complete: () => void;
 }
 
 export const useRequirementsStore = create<RequirementsState>((set) => ({
   isOpen: false,
   pendingRequirements: [],
+  completionRevision: 0,
   trigger: (requirements) =>
     set({ isOpen: true, pendingRequirements: requirements }),
   close: () => set({ isOpen: false, pendingRequirements: [] }),
+  complete: () =>
+    set((state) => ({
+      isOpen: false,
+      pendingRequirements: [],
+      completionRevision: state.completionRevision + 1,
+    })),
 }));

--- a/src/hooks/useWarpSubscription.ts
+++ b/src/hooks/useWarpSubscription.ts
@@ -5,6 +5,7 @@ import { Browser } from "@capacitor/browser";
 import { Purchases } from "@revenuecat/purchases-capacitor";
 import type { SubscriptionResponse } from "@/lib/models";
 import { getSubscriptionStatus } from "@/lib/onlineApi";
+import { useRequirementsStore } from "@/hooks/useRequirementsModal";
 import { usePreferencesStore } from "@/lib/preferencesStore";
 import { useStatusStore } from "@/lib/store";
 import {
@@ -109,6 +110,12 @@ export function useWarpSubscription(appUserID: string) {
   );
   const setOnlinePremiumAccess = usePreferencesStore(
     (state) => state.setOnlinePremiumAccess,
+  );
+  const requirementsCompletionRevision = useRequirementsStore(
+    (state) => state.completionRevision,
+  );
+  const previousRequirementsCompletionRevisionRef = useRef(
+    requirementsCompletionRevision,
   );
   const isCurrentIdentity = useCallback(
     () => useStatusStore.getState().loggedInUser?.uid === appUserID,
@@ -268,6 +275,35 @@ export function useWarpSubscription(appUserID: string) {
       if (appStateHandle) void appStateHandle.remove();
     };
   }, [loadAccount]);
+
+  useEffect(() => {
+    const previousRevision = previousRequirementsCompletionRevisionRef.current;
+    previousRequirementsCompletionRevisionRef.current =
+      requirementsCompletionRevision;
+
+    if (
+      requirementsCompletionRevision === previousRevision ||
+      actionRef.current
+    ) {
+      return;
+    }
+
+    accountLoadAbortRef.current?.abort();
+    const loadController = new AbortController();
+    accountLoadAbortRef.current = loadController;
+    void loadAccount(loadController.signal, true).finally(() => {
+      if (accountLoadAbortRef.current === loadController) {
+        accountLoadAbortRef.current = null;
+      }
+    });
+
+    return () => {
+      loadController.abort();
+      if (accountLoadAbortRef.current === loadController) {
+        accountLoadAbortRef.current = null;
+      }
+    };
+  }, [loadAccount, requirementsCompletionRevision]);
 
   const beginAction = useCallback((nextAction: Exclude<WarpAction, null>) => {
     if (actionRef.current) return null;
@@ -477,16 +513,14 @@ export function useWarpSubscription(appUserID: string) {
       assertCurrentAction(controller.signal);
       const access = getPurchaseAccess(result.customerInfo);
       clearCachedPurchaseErrorDiagnostics();
-      if (!access.lifetimePro) {
-        // A clean restore that found no Pro entitlement means the store no
-        // longer backs the earlier "already owned" local fallback either.
-        usePreferencesStore.getState().setStoreVerifiedProAccess(false);
-      }
-      setLifetimeProAccess(access.lifetimePro);
+      const storeVerifiedProAccess =
+        usePreferencesStore.getState().storeVerifiedProAccess;
+      setLifetimeProAccess(access.lifetimePro || storeVerifiedProAccess);
       setRevenueCatWarpActive(access.warp);
 
       logger.log("Purchase restore completed", {
         hasLifetimePro: access.lifetimePro,
+        hasStoreVerifiedPro: storeVerifiedProAccess,
         hasWarp: access.warp,
       });
 
@@ -513,7 +547,7 @@ export function useWarpSubscription(appUserID: string) {
       }
 
       setActivationPending(false);
-      if (access.lifetimePro) return "pro_restored";
+      if (access.lifetimePro || storeVerifiedProAccess) return "pro_restored";
       return "not_found";
     } catch (e) {
       if (!controller.signal.aborted) {

--- a/src/lib/whatsNew.ts
+++ b/src/lib/whatsNew.ts
@@ -24,7 +24,7 @@ export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
     id: "release-1.13.0",
     version: "1.13.0",
     releaseKeys: ["native:1.13.0+29"],
-    title: "What's new in 1.13.0",
+    title: "What's new in v1.13.0",
     items: [
       "Browse, search, favorite, launch, and write media from the new Library tab.",
       "Subscribe, restore, and manage Zaparoo Warp from the App.",
@@ -37,7 +37,18 @@ export const WHATS_NEW_ANNOUNCEMENTS: WhatsNewAnnouncement[] = [
     id: "release-1.13.1",
     version: "1.13.1",
     releaseKeys: ["live:1.13.0-ota.1"],
-    title: "What's new in 1.13.1",
+    title: "What's new in v1.13.1",
+    items: [
+      "Improved purchase and restore reliability, with clearer billing diagnostics when store access fails.",
+      "Fixed startup, media notification, and Online settings issues reported through production monitoring.",
+      "Still having trouble with purchases or restoring purchases? Email support@zaparoo.com or ask for help in the Zaparoo Discord.",
+    ],
+  },
+  {
+    id: "release-1.13.1",
+    version: "1.13.2",
+    releaseKeys: ["live:1.13.0-ota.2"],
+    title: "What's new in v1.13.1",
     items: [
       "Improved purchase and restore reliability, with clearer billing diagnostics when store access fails.",
       "Fixed startup, media notification, and Online settings issues reported through production monitoring.",

--- a/src/routes/settings.advanced.tsx
+++ b/src/routes/settings.advanced.tsx
@@ -229,9 +229,7 @@ export function AdvancedSettings() {
           </div>
         )}
 
-        {Capacitor.isNativePlatform() && (
-          <PurchaseSupportActions variant="diagnosticsOnly" />
-        )}
+        {Capacitor.isNativePlatform() && <PurchaseSupportActions />}
       </div>
 
       <SlideModal

--- a/src/routes/settings.index.tsx
+++ b/src/routes/settings.index.tsx
@@ -191,9 +191,11 @@ export function Settings() {
             </div>
           )}
 
-          {Capacitor.isNativePlatform() && (
-            <PurchaseSupportActions variant="restoreOnly" />
-          )}
+          {Capacitor.isNativePlatform() &&
+            !displayedProAccess &&
+            displayedOnlinePremiumAccess !== true && (
+              <PurchaseSupportActions variant="restoreOnly" />
+            )}
 
           <div className="flex flex-col gap-1">
             <Link

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -95,27 +95,6 @@ function getExpectedSignupEmailAuthErrorToken(error: unknown): string | null {
   );
 }
 
-/**
- * Get the primary auth provider from user data
- * Returns 'google', 'apple', 'password', or null
- */
-type AuthProvider = "google" | "apple" | "password";
-
-function getSoleLinkedAuthProvider(
-  providerData: { providerId: string }[] | undefined,
-): AuthProvider | null {
-  const providers = new Set<AuthProvider>();
-  for (const provider of providerData ?? []) {
-    if (provider.providerId === "google.com") providers.add("google");
-    if (provider.providerId === "apple.com") providers.add("apple");
-    if (provider.providerId === "password") providers.add("password");
-  }
-
-  return providers.size === 1
-    ? (providers.values().next().value ?? null)
-    : null;
-}
-
 function hasPasswordProvider(
   providerData: { providerId: string }[] | undefined,
 ): boolean {
@@ -138,10 +117,6 @@ export function OnlinePage() {
   const [onlinePassword, setOnlinePassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [mfaPending, setMfaPending] = useState(false);
-  const [pendingAuthProvider, setPendingAuthProvider] =
-    useState<AuthProvider | null>(null);
-  const [sessionAuthProvider, setSessionAuthProvider] =
-    useState<AuthProvider | null>(null);
   const [mfaCode, setMfaCode] = useState("");
   const [mfaError, setMfaError] = useState<string | null>(null);
   const [isMfaVerifying, setIsMfaVerifying] = useState(false);
@@ -224,19 +199,15 @@ export function OnlinePage() {
     return true;
   };
 
-  const handleFirstFactorResult = async (
-    result: MfaSignInResult,
-    provider: AuthProvider,
-  ) => {
+  const handleFirstFactorResult = async (result: MfaSignInResult) => {
     if (result.mfaRequired) {
-      setPendingAuthProvider(provider);
       setMfaPending(true);
       setMfaCode("");
       setMfaError(null);
       return;
     }
 
-    if (await completeSignIn()) setSessionAuthProvider(provider);
+    await completeSignIn();
   };
 
   const handleEmailAuth = async () => {
@@ -279,7 +250,6 @@ export function OnlinePage() {
           }
 
           setLoggedInUser(result.user);
-          setSessionAuthProvider("password");
         } else {
           toast.error(t("online.signUpFail"));
         }
@@ -313,7 +283,7 @@ export function OnlinePage() {
         });
         setOnlinePassword("");
 
-        await handleFirstFactorResult(result, "password");
+        await handleFirstFactorResult(result);
       } catch (e) {
         const error = e as Error;
         if (!isExpectedEmailAuthError(e)) {
@@ -341,7 +311,6 @@ export function OnlinePage() {
       });
     }
     setMfaPending(false);
-    setPendingAuthProvider(null);
     setMfaCode("");
     setMfaError(null);
   };
@@ -358,12 +327,8 @@ export function OnlinePage() {
     setMfaError(null);
     try {
       await MfaAuthentication.resolveTotpSignIn({ code: mfaCode });
-      const signedIn = await completeSignIn();
-      if (signedIn && pendingAuthProvider) {
-        setSessionAuthProvider(pendingAuthProvider);
-      }
+      await completeSignIn();
       setMfaPending(false);
-      setPendingAuthProvider(null);
       setMfaCode("");
     } catch (e) {
       const searchStrings = collectErrorSearchStrings(e);
@@ -394,7 +359,7 @@ export function OnlinePage() {
     setIsLoading(true);
     try {
       const result = await MfaAuthentication.signInWithGoogle();
-      await handleFirstFactorResult(result, "google");
+      await handleFirstFactorResult(result);
     } catch (e) {
       const error = e as Error;
       // Check if user cancelled the login - don't show error toast
@@ -422,7 +387,7 @@ export function OnlinePage() {
     setIsLoading(true);
     try {
       const result = await MfaAuthentication.signInWithApple();
-      await handleFirstFactorResult(result, "apple");
+      await handleFirstFactorResult(result);
     } catch (e) {
       const error = e as Error;
       // Check if user cancelled the login - don't show error toast
@@ -491,7 +456,6 @@ export function OnlinePage() {
     FirebaseAuthentication.signOut()
       .then(() => {
         setLoggedInUser(null);
-        setSessionAuthProvider(null);
         setOnlineEmail("");
         setOnlinePassword("");
       })
@@ -610,37 +574,6 @@ export function OnlinePage() {
               <span className="text-muted-foreground text-sm">
                 {loggedInUser.email}
               </span>
-
-              {/* Auth provider indicator */}
-              {(() => {
-                const provider =
-                  sessionAuthProvider ??
-                  getSoleLinkedAuthProvider(loggedInUser.providerData);
-                if (provider === "google") {
-                  return (
-                    <span className="text-muted-foreground mt-1 flex items-center gap-1.5 text-xs">
-                      <GoogleIcon size="14" />
-                      {t("online.loggedInWithGoogle")}
-                    </span>
-                  );
-                }
-                if (provider === "apple") {
-                  return (
-                    <span className="text-muted-foreground mt-1 flex items-center gap-1.5 text-xs">
-                      <AppleIcon size="14" />
-                      {t("online.loggedInWithApple")}
-                    </span>
-                  );
-                }
-                if (provider === "password") {
-                  return (
-                    <span className="text-muted-foreground mt-1 text-xs">
-                      {t("online.loggedInWithPassword")}
-                    </span>
-                  );
-                }
-                return null;
-              })()}
             </div>
 
             <OnlineDeviceSetup
@@ -848,7 +781,7 @@ export function OnlinePage() {
 
             {/* Age confirmation - only in sign up mode */}
             {isSignUpMode && (
-              <div className="flex items-start gap-3">
+              <div className="flex items-center gap-3">
                 <Checkbox
                   id="age-confirm"
                   checked={ageConfirmed}

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -327,7 +327,8 @@ export function OnlinePage() {
     setMfaError(null);
     try {
       await MfaAuthentication.resolveTotpSignIn({ code: mfaCode });
-      await completeSignIn();
+      const signedIn = await completeSignIn();
+      if (!signedIn) return;
       setMfaPending(false);
       setMfaCode("");
     } catch (e) {

--- a/src/test-utils/factories.ts
+++ b/src/test-utils/factories.ts
@@ -53,7 +53,7 @@ export const buildWhatsNewAnnouncement = (
   id: "release-1.0.1",
   version: "1.0.1",
   releaseKeys: ["native:1.0.1+2"],
-  title: "What's new in test",
+  title: "What's new in vtest",
   items: ["First test item", "Second test item"],
   ...overrides,
 });

--- a/src/translations/de-DE.json
+++ b/src/translations/de-DE.json
@@ -581,6 +581,8 @@
         "title": "Verbundenes Gerät",
         "description": "Durch die Verknüpfung wird dieses Gerät deinem Konto hinzugefügt und kann Online-Funktionen verwenden. Die Synchronisierung des Spielverlaufs ist kostenlos. Spielverlauf und Sicherungen werden erst hochgeladen, wenn du sie aktivierst.",
         "help": "Durch die Verknüpfung wird dieses Gerät deinem Konto hinzugefügt und kann Online-Funktionen verwenden. Die Verknüpfung allein lädt nichts hoch. Die Synchronisierung des Spielverlaufs und die Cloud-Sicherung müssen separat aktiviert werden.",
+        "disconnected": "Verbinde dich mit einem Core-Gerät, bevor du es mit Zaparoo Online verknüpfst.",
+        "backToSettings": "Zurück zu Einstellungen",
         "link": "Gerät verknüpfen",
         "signIn": "Anmelden, um dieses Gerät zu verknüpfen",
         "checking": "Geräteverknüpfung wird geprüft...",
@@ -700,7 +702,7 @@
       "emailVerified": "E-Mail-Adresse bestätigt",
       "saved": "Gespeichert",
       "save": "Speichern",
-      "continue": "Zustimmen und fortfahren",
+      "continue": "Weiter",
       "logout": "Abmelden"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "Verbundenes Lesegerät zum Schreiben bevorzugen",
         "restorePurchases": "Käufe wiederherstellen",
         "restoreSuccess": "Käufe wurden wiederhergestellt",
-        "restoreNotFound": "Keine Käufe zum Wiederherstellen gefunden",
+        "restoreNotFound": "Keine Käufe gefunden. Wenn dein Store meldet, dass du Pro bereits besitzt, tippe auf Pro freischalten, um den Besitz zu bestätigen.",
         "restoreFail": "Käufe konnten nicht wiederhergestellt werden",
         "restoreWarpSignIn": "Warp wurde gefunden. Melde dich bei Zaparoo Online an, um die Wiederherstellung abzuschließen.",
         "copyBillingDiagnostics": "Abrechnungsdiagnose kopieren",

--- a/src/translations/en-GB.json
+++ b/src/translations/en-GB.json
@@ -581,6 +581,8 @@
         "title": "Connected device",
         "description": "Linking adds this device to your account so it can use Online features. Play history sync is free. Linking does not upload play history or backups until you turn them on.",
         "help": "Linking adds this device to your account so it can use Online features. Linking alone does not upload anything. Play history sync and cloud backup must be enabled separately.",
+        "disconnected": "Connect to a Core device before linking it to Zaparoo Online.",
+        "backToSettings": "Back to Settings",
         "link": "Link device",
         "signIn": "Sign in to link this device",
         "checking": "Checking device link...",
@@ -700,7 +702,7 @@
       "emailVerified": "Email verified",
       "saved": "Saved",
       "save": "Save",
-      "continue": "Agree & continue",
+      "continue": "Continue",
       "logout": "Log Out"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "Prefer connected reader for writing",
         "restorePurchases": "Restore purchases",
         "restoreSuccess": "Purchases have been restored",
-        "restoreNotFound": "No purchases found to restore",
+        "restoreNotFound": "No purchases found. If your store says you already own Pro, tap Unlock Pro to verify ownership.",
         "restoreFail": "Failed to restore purchases",
         "restoreWarpSignIn": "Warp was found. Sign in to Zaparoo Online to finish restoring access.",
         "copyBillingDiagnostics": "Copy billing diagnostics",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -581,6 +581,8 @@
         "title": "Connected device",
         "description": "Linking adds this device to your account so it can use Online features. Play history sync is free. Linking does not upload play history or backups until you turn them on.",
         "help": "Linking adds this device to your account so it can use Online features. Linking alone does not upload anything. Play history sync and cloud backup must be enabled separately.",
+        "disconnected": "Connect to a Core device before linking it to Zaparoo Online.",
+        "backToSettings": "Back to Settings",
         "link": "Link device",
         "signIn": "Sign in to link this device",
         "checking": "Checking device link...",
@@ -700,7 +702,7 @@
       "emailVerified": "Email verified",
       "saved": "Saved",
       "save": "Save",
-      "continue": "Agree & continue",
+      "continue": "Continue",
       "logout": "Log Out"
     },
     "settings": {
@@ -1022,7 +1024,7 @@
         "preferRemoteWriter": "Prefer connected reader for writing",
         "restorePurchases": "Restore purchases",
         "restoreSuccess": "Purchases have been restored",
-        "restoreNotFound": "No purchases found to restore",
+        "restoreNotFound": "No purchases found. If your store says you already own Pro, tap Unlock Pro to verify ownership.",
         "restoreFail": "Failed to restore purchases",
         "restoreWarpSignIn": "Warp was found. Sign in to Zaparoo Online to finish restoring access.",
         "copyBillingDiagnostics": "Copy billing diagnostics",

--- a/src/translations/es-ES.json
+++ b/src/translations/es-ES.json
@@ -581,6 +581,8 @@
         "title": "Dispositivo conectado",
         "description": "Al vincular este dispositivo, se añade a tu cuenta para que pueda usar las funciones Online. La sincronización del historial de juego es gratuita. La vinculación no sube el historial de juego ni copias de seguridad hasta que actives esas funciones.",
         "help": "Al vincular este dispositivo, se añade a tu cuenta para que pueda usar las funciones Online. La vinculación por sí sola no sube nada. La sincronización del historial de juego y las copias de seguridad en la nube deben habilitarse por separado.",
+        "disconnected": "Conéctate a un dispositivo Core antes de vincularlo con Zaparoo Online.",
+        "backToSettings": "Volver a Ajustes",
         "link": "Vincular dispositivo",
         "signIn": "Inicia sesión para vincular este dispositivo",
         "checking": "Comprobando vinculación del dispositivo...",
@@ -700,7 +702,7 @@
       "emailVerified": "Correo electrónico verificado",
       "saved": "Guardado",
       "save": "Guardar",
-      "continue": "Aceptar y continuar",
+      "continue": "Continuar",
       "logout": "Cerrar sesión"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "Preferir un lector conectado para escribir",
         "restorePurchases": "Restaurar compras",
         "restoreSuccess": "Las compras se han restaurado",
-        "restoreNotFound": "No se encontraron compras para restaurar",
+        "restoreNotFound": "No se encontraron compras. Si tu tienda indica que ya tienes Pro, toca Desbloquear Pro para verificar la compra.",
         "restoreFail": "Fallo al restaurar las compras",
         "restoreWarpSignIn": "Se encontró Warp. Inicia sesión en Zaparoo Online para terminar de restaurar el acceso.",
         "copyBillingDiagnostics": "Copiar diagnóstico de facturación",

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -581,6 +581,8 @@
         "title": "Appareil connecté",
         "description": "L’association ajoute cet appareil à votre compte pour lui permettre d’utiliser les fonctions Online. La synchronisation de l’historique de jeu est gratuite. L’association ne téléverse ni l’historique de jeu ni les sauvegardes tant que vous ne les activez pas.",
         "help": "L’association ajoute cet appareil à votre compte pour lui permettre d’utiliser les fonctions Online. L’association seule ne téléverse rien. La synchronisation de l’historique de jeu et la sauvegarde cloud doivent être activées séparément.",
+        "disconnected": "Connectez-vous à un appareil Core avant de l’associer à Zaparoo Online.",
+        "backToSettings": "Retour aux paramètres",
         "link": "Associer l’appareil",
         "signIn": "Se connecter pour associer cet appareil",
         "checking": "Vérification de l’association de l’appareil...",
@@ -700,7 +702,7 @@
       "emailVerified": "E-mail vérifié",
       "saved": "Enregistré",
       "save": "Enregistrer",
-      "continue": "Accepter et continuer",
+      "continue": "Continuer",
       "logout": "Se déconnecter"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "Préférer le lecteur connecté pour l’écriture",
         "restorePurchases": "Restaurer les achats",
         "restoreSuccess": "Achats restaurés",
-        "restoreNotFound": "Aucun achat à restaurer",
+        "restoreNotFound": "Aucun achat trouvé. Si votre boutique indique que vous possédez déjà Pro, touchez Débloquer Pro pour vérifier l’achat.",
         "restoreFail": "Échec de la restauration des achats",
         "restoreWarpSignIn": "Warp a été trouvé. Connectez-vous à Zaparoo Online pour terminer la restauration de l’accès.",
         "copyBillingDiagnostics": "Copier le diagnostic de facturation",

--- a/src/translations/ja-JP.json
+++ b/src/translations/ja-JP.json
@@ -581,6 +581,8 @@
         "title": "接続中のデバイス",
         "description": "リンクすると、このデバイスがアカウントに追加され、Online機能を使用できます。プレイ履歴の同期は無料です。有効にするまで、リンクによってプレイ履歴やバックアップがアップロードされることはありません。",
         "help": "リンクすると、このデバイスがアカウントに追加され、Online機能を使用できます。リンクだけでは何もアップロードされません。プレイ履歴の同期とクラウドバックアップは個別に有効にする必要があります。",
+        "disconnected": "Zaparoo Online にリンクする前に Core デバイスへ接続してください。",
+        "backToSettings": "設定に戻る",
         "link": "デバイスをリンク",
         "signIn": "サインインしてこのデバイスをリンク",
         "checking": "デバイスのリンクを確認中...",
@@ -700,7 +702,7 @@
       "emailVerified": "メールアドレスを確認しました",
       "saved": "保存しました",
       "save": "保存",
-      "continue": "同意して続ける",
+      "continue": "続ける",
       "logout": "サインアウト"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "書き込みに接続中のリーダーを優先",
         "restorePurchases": "購入を復元",
         "restoreSuccess": "購入を復元しました",
-        "restoreNotFound": "復元できる購入が見つかりません",
+        "restoreNotFound": "購入が見つかりません。ストアで Pro を購入済みと表示される場合は、「Pro を解除」をタップして所有権を確認してください。",
         "restoreFail": "購入の復元に失敗しました",
         "restoreWarpSignIn": "Warpが見つかりました。Zaparoo Onlineにサインインしてアクセスの復元を完了してください。",
         "copyBillingDiagnostics": "請求診断をコピー",

--- a/src/translations/ko-KR.json
+++ b/src/translations/ko-KR.json
@@ -581,6 +581,8 @@
         "title": "연결된 기기",
         "description": "연결하면 이 기기가 계정에 추가되어 Online 기능을 사용할 수 있습니다. 플레이 기록 동기화는 무료입니다. 기능을 켜기 전에는 연결만으로 플레이 기록이나 백업이 업로드되지 않습니다.",
         "help": "연결하면 이 기기가 계정에 추가되어 Online 기능을 사용할 수 있습니다. 연결만으로는 아무것도 업로드되지 않습니다. 플레이 기록 동기화와 클라우드 백업은 별도로 활성화해야 합니다.",
+        "disconnected": "Zaparoo Online에 연결하기 전에 Core 기기에 연결하세요.",
+        "backToSettings": "설정으로 돌아가기",
         "link": "기기 연결",
         "signIn": "이 기기를 연결하려면 로그인",
         "checking": "기기 연결을 확인하는 중...",
@@ -700,7 +702,7 @@
       "emailVerified": "이메일 인증됨",
       "saved": "저장됨",
       "save": "저장",
-      "continue": "동의하고 계속",
+      "continue": "계속",
       "logout": "로그아웃"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "쓸 때 연결된 리더 우선 사용",
         "restorePurchases": "구매 복원",
         "restoreSuccess": "구매를 복원했습니다",
-        "restoreNotFound": "복원할 구매를 찾을 수 없습니다",
+        "restoreNotFound": "구매 항목을 찾을 수 없습니다. 스토어에 Pro를 이미 소유한 것으로 표시되면 Pro 잠금 해제를 눌러 소유권을 확인하세요.",
         "restoreFail": "구매를 복원하지 못했습니다",
         "restoreWarpSignIn": "Warp를 찾았습니다. Zaparoo Online에 로그인하여 액세스 복원을 완료하세요.",
         "copyBillingDiagnostics": "결제 진단 복사",

--- a/src/translations/nl-NL.json
+++ b/src/translations/nl-NL.json
@@ -581,6 +581,8 @@
         "title": "Verbonden apparaat",
         "description": "Door dit apparaat te koppelen, voeg je het toe aan je account zodat het Online-functies kan gebruiken. Synchronisatie van speelgeschiedenis is gratis. Speelgeschiedenis en back-ups worden pas geüpload nadat je ze hebt ingeschakeld.",
         "help": "Door dit apparaat te koppelen, voeg je het toe aan je account zodat het Online-functies kan gebruiken. Alleen koppelen uploadt niets. Synchronisatie van speelgeschiedenis en cloudback-ups moeten afzonderlijk worden ingeschakeld.",
+        "disconnected": "Maak verbinding met een Core-apparaat voordat je het aan Zaparoo Online koppelt.",
+        "backToSettings": "Terug naar Instellingen",
         "link": "Apparaat koppelen",
         "signIn": "Log in om dit apparaat te koppelen",
         "checking": "Apparaatkoppeling controleren...",
@@ -700,7 +702,7 @@
       "emailVerified": "E-mailadres geverifieerd",
       "saved": "Opgeslagen",
       "save": "Opslaan",
-      "continue": "Akkoord en doorgaan",
+      "continue": "Doorgaan",
       "logout": "Uitloggen"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "Voorkeur voor verbonden lezer bij schrijven",
         "restorePurchases": "Aankopen herstellen",
         "restoreSuccess": "Aankopen zijn hersteld",
-        "restoreNotFound": "Geen aankopen gevonden om te herstellen",
+        "restoreNotFound": "Geen aankopen gevonden. Als je store aangeeft dat je Pro al bezit, tik je op Pro ontgrendelen om het bezit te verifiëren.",
         "restoreFail": "Aankopen herstellen mislukt",
         "restoreWarpSignIn": "Warp is gevonden. Meld je aan bij Zaparoo Online om het herstel van toegang te voltooien.",
         "copyBillingDiagnostics": "Factureringsdiagnose kopiëren",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -581,6 +581,8 @@
         "title": "已连接的设备",
         "description": "关联后，此设备将添加到您的账户并可使用 Online 功能。游玩历史记录同步免费。在您开启相应功能前，关联操作不会上传游玩历史记录或备份。",
         "help": "关联后，此设备将添加到您的账户并可使用 Online 功能。仅关联设备不会上传任何内容。游玩历史记录同步和云备份必须分别启用。",
+        "disconnected": "请先连接 Core 设备，再将其关联到 Zaparoo Online。",
+        "backToSettings": "返回设置",
         "link": "关联设备",
         "signIn": "登录以关联此设备",
         "checking": "正在检查设备关联...",
@@ -700,7 +702,7 @@
       "emailVerified": "电子邮箱已验证",
       "saved": "已保存",
       "save": "保存",
-      "continue": "同意并继续",
+      "continue": "继续",
       "logout": "退出登录"
     },
     "settings": {
@@ -1019,7 +1021,7 @@
         "preferRemoteWriter": "写入时优先使用已连接的读卡器",
         "restorePurchases": "恢复购买",
         "restoreSuccess": "购买已恢复",
-        "restoreNotFound": "未找到可恢复的购买项目",
+        "restoreNotFound": "未找到购买项目。如果商店显示您已拥有 Pro，请点按“解锁 Pro”以验证所有权。",
         "restoreFail": "购买恢复失败",
         "restoreWarpSignIn": "已找到 Warp。请登录 Zaparoo Online 以完成访问权限恢复。",
         "copyBillingDiagnostics": "复制账单诊断",


### PR DESCRIPTION
## Summary

- improve setup checkbox styling, localized Continue copy, and disconnected Online guidance
- refresh Warp state after requirements completion without interrupting purchases or restores
- simplify purchase, diagnostics, and Online account UI behavior
- display version 1.13.2 for the second live update while preserving the unseen 1.13.1 announcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance and a Settings shortcut for disconnected device linking.
  - Added purchase progress indicators and improved billing support actions.
  - Requirements completion now refreshes account information automatically.
  - Purchase restoration preserves verified Pro access when no store entitlement is found.
  - Added release announcements for versions 1.13.1 and 1.13.2.

- **Bug Fixes**
  - Improved purchase-support visibility based on active Pro access.
  - Simplified sign-in handling and centered age-confirmation controls.

- **Localization**
  - Updated device-linking, requirements, and purchase-restoration messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->