### PR TITLE
feat: send the sign-up source with the first requirements update

### DIFF
--- a/src/__tests__/unit/lib/onlineApi.test.ts
+++ b/src/__tests__/unit/lib/onlineApi.test.ts
@@ -298,6 +298,38 @@ describe("onlineApi", () => {
       });
     });
 
+    it("passes signup attribution through unchanged", async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          requirements: {
+            email_verified: false,
+            tos_accepted: true,
+            privacy_accepted: true,
+            age_verified: true,
+          },
+        },
+      });
+
+      const { updateRequirements } = await import("../../../lib/onlineApi");
+      await updateRequirements({
+        accept_tos: true,
+        signup_attribution: {
+          source: "zaparoo-app",
+          medium: "app",
+          content: "ios",
+        },
+      });
+
+      expect(mockPost).toHaveBeenCalledWith("/account/requirements", {
+        accept_tos: true,
+        signup_attribution: {
+          source: "zaparoo-app",
+          medium: "app",
+          content: "ios",
+        },
+      });
+    });
+
     it("should throw error when API call fails", async () => {
       const apiError = new Error("Update failed");
       mockPost.mockRejectedValue(apiError);

--- a/src/__tests__/unit/lib/signupAttribution.test.ts
+++ b/src/__tests__/unit/lib/signupAttribution.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockState } = vi.hoisted(() => ({
+  mockState: { platform: "web" as string },
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => mockState.platform,
+  },
+}));
+
+import { signupAttribution } from "@/lib/signupAttribution";
+
+describe("signupAttribution", () => {
+  beforeEach(() => {
+    mockState.platform = "web";
+  });
+
+  it("names the App and its platform, nothing else", () => {
+    mockState.platform = "ios";
+    expect(signupAttribution()).toEqual({
+      source: "zaparoo-app",
+      medium: "app",
+      content: "ios",
+    });
+  });
+
+  it("reports the web build as web", () => {
+    expect(signupAttribution()).toEqual({
+      source: "zaparoo-app",
+      medium: "app",
+      content: "web",
+    });
+  });
+
+  it("carries no identifier or free text", () => {
+    const values = Object.values(signupAttribution());
+    for (const value of values) {
+      expect(value).toMatch(/^[a-z][a-z-]*$/);
+    }
+  });
+});

--- a/src/__tests__/unit/routes/settings.online.test.tsx
+++ b/src/__tests__/unit/routes/settings.online.test.tsx
@@ -906,6 +906,11 @@ describe("Settings Online Route", () => {
           accept_tos: true,
           accept_privacy: true,
           age_verified: true,
+          signup_attribution: {
+            source: "zaparoo-app",
+            medium: "app",
+            content: mockState.platform,
+          },
         });
       });
     });
@@ -1057,6 +1062,11 @@ describe("Settings Online Route", () => {
         expect(mockUpdateRequirements).toHaveBeenCalledWith({
           accept_tos: true,
           accept_privacy: true,
+          signup_attribution: {
+            source: "zaparoo-app",
+            medium: "app",
+            content: mockState.platform,
+          },
         });
         expect(mockSetLoggedInUser).toHaveBeenCalledWith(
           expect.objectContaining({ uid: "test-uid" }),
@@ -1259,6 +1269,11 @@ describe("Settings Online Route", () => {
         expect(mockUpdateRequirements).toHaveBeenCalledWith({
           accept_tos: true,
           accept_privacy: true,
+          signup_attribution: {
+            source: "zaparoo-app",
+            medium: "app",
+            content: mockState.platform,
+          },
         });
       });
     });
@@ -1279,6 +1294,11 @@ describe("Settings Online Route", () => {
         expect(mockUpdateRequirements).toHaveBeenCalledWith({
           accept_tos: true,
           accept_privacy: true,
+          signup_attribution: {
+            source: "zaparoo-app",
+            medium: "app",
+            content: mockState.platform,
+          },
         });
       });
     });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -723,10 +723,23 @@ export interface SubscriptionResponse {
   revenuecat?: RevenueCatSubscriptionInfo | null;
 }
 
+/**
+ * Where a sign-up came from. The API records it once, within an hour of the
+ * account being created, and bounds every value to a short tag; the App
+ * sends its own name and platform, nothing about the person or device.
+ */
+export interface SignupAttribution {
+  source?: string;
+  medium?: string;
+  campaign?: string;
+  content?: string;
+}
+
 export interface UpdateRequirementsRequest {
   accept_tos?: boolean;
   accept_privacy?: boolean;
   age_verified?: boolean;
+  signup_attribution?: SignupAttribution;
 }
 
 export interface DeleteAccountResponse {

--- a/src/lib/signupAttribution.ts
+++ b/src/lib/signupAttribution.ts
@@ -1,0 +1,21 @@
+import { Capacitor } from "@capacitor/core";
+import type { SignupAttribution } from "@/lib/models";
+
+/**
+ * The sign-up origin the App reports with its requirements call after a
+ * person creates an account: the App itself, and which platform build.
+ *
+ * This is not telemetry. It carries no identifier, nothing about the device
+ * beyond the platform name, and is sent once alongside the consent update
+ * that every sign-up already makes. The API records it only for a brand-new
+ * account and ignores it afterwards, so sending it on a log-in is harmless
+ * and lets an account created through Google or Apple sign-in (which lands
+ * on the same path as a log-in) be attributed too.
+ */
+export function signupAttribution(): SignupAttribution {
+  return {
+    source: "zaparoo-app",
+    medium: "app",
+    content: Capacitor.getPlatform(),
+  };
+}

--- a/src/routes/settings.online.tsx
+++ b/src/routes/settings.online.tsx
@@ -37,6 +37,7 @@ import {
   cancelAccountDeletion,
   NotSignedInError,
 } from "@/lib/onlineApi";
+import { signupAttribution } from "@/lib/signupAttribution";
 import {
   MfaAuthentication,
   type MfaSignInResult,
@@ -183,9 +184,13 @@ export function OnlinePage() {
     }
 
     try {
+      // Attribution is recorded by the API only for a brand-new account, so
+      // sending it here covers a Google or Apple sign-up, which arrives on
+      // this same path, and is ignored for an existing account.
       await updateRequirements({
         accept_tos: true,
         accept_privacy: true,
+        signup_attribution: signupAttribution(),
       });
     } catch (e) {
       logger.error("Failed to record terms acceptance:", e, {
@@ -234,11 +239,13 @@ export function OnlinePage() {
 
         if (result.user) {
           // Auto-agree to requirements on signup (includes age verification)
+          // and record that the account was created from the App
           try {
             await updateRequirements({
               accept_tos: true,
               accept_privacy: true,
               age_verified: true,
+              signup_attribution: signupAttribution(),
             });
           } catch (e) {
             logger.error("Failed to record terms acceptance:", e, {


### PR DESCRIPTION
- The account requirements call made after a sign-up now includes `signup_attribution`, naming the App and its platform (`ios`, `android` or `web`). The API records it once for a new account and ignores it afterwards, so sending it from the shared sign-in path is harmless for an existing account.
- No identifier or device details are sent, and nothing is stored on the device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account creation and sign-in flows now include signup attribution details, such as the app source, sign-up medium, and platform.
  - Attribution is included for email signup, Google sign-in, and Apple sign-in flows.
  - This information is sent with the account requirements update and does not affect existing accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->